### PR TITLE
ERC-721 support

### DIFF
--- a/analyzer/evmabi/contracts/ERC165.sol
+++ b/analyzer/evmabi/contracts/ERC165.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// https://eips.ethereum.org/EIPS/eip-165
+pragma solidity ^0.4.20;
+
+interface ERC165 {
+    /// @notice Query if a contract implements an interface
+    /// @param interfaceID The interface identifier, as specified in ERC-165
+    /// @dev Interface identification is specified in ERC-165. This function
+    ///  uses less than 30,000 gas.
+    /// @return `true` if the contract implements `interfaceID` and
+    ///  `interfaceID` is not 0xffffffff, `false` otherwise
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}

--- a/analyzer/evmabi/contracts/ERC721.sol
+++ b/analyzer/evmabi/contracts/ERC721.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// https://eips.ethereum.org/EIPS/eip-721
+pragma solidity ^0.4.20;
+
+/// @title ERC-721 Non-Fungible Token Standard
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  Note: the ERC-165 identifier for this interface is 0x80ac58cd.
+interface ERC721 /* is ERC165 */ {
+    /// @dev This emits when ownership of any NFT changes by any mechanism.
+    ///  This event emits when NFTs are created (`from` == 0) and destroyed
+    ///  (`to` == 0). Exception: during contract creation, any number of NFTs
+    ///  may be created and assigned without emitting Transfer. At the time of
+    ///  any transfer, the approved address for that NFT (if any) is reset to none.
+    event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+
+    /// @dev This emits when the approved address for an NFT is changed or
+    ///  reaffirmed. The zero address indicates there is no approved address.
+    ///  When a Transfer event emits, this also indicates that the approved
+    ///  address for that NFT (if any) is reset to none.
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+
+    /// @dev This emits when an operator is enabled or disabled for an owner.
+    ///  The operator can manage all NFTs of the owner.
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    /// @notice Count all NFTs assigned to an owner
+    /// @dev NFTs assigned to the zero address are considered invalid, and this
+    ///  function throws for queries about the zero address.
+    /// @param _owner An address for whom to query the balance
+    /// @return The number of NFTs owned by `_owner`, possibly zero
+    function balanceOf(address _owner) external view returns (uint256);
+
+    /// @notice Find the owner of an NFT
+    /// @dev NFTs assigned to zero address are considered invalid, and queries
+    ///  about them do throw.
+    /// @param _tokenId The identifier for an NFT
+    /// @return The address of the owner of the NFT
+    function ownerOf(uint256 _tokenId) external view returns (address);
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
+    ///  checks if `_to` is a smart contract (code size > 0). If so, it calls
+    ///  `onERC721Received` on `_to` and throws if the return value is not
+    ///  `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    /// @param data Additional data with no specified format, sent in call to `_to`
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev This works identically to the other function with an extra data parameter,
+    ///  except this function just sets data to "".
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Transfer ownership of an NFT -- THE CALLER IS RESPONSIBLE
+    ///  TO CONFIRM THAT `_to` IS CAPABLE OF RECEIVING NFTS OR ELSE
+    ///  THEY MAY BE PERMANENTLY LOST
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Change or reaffirm the approved address for an NFT
+    /// @dev The zero address indicates there is no approved address.
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  operator of the current owner.
+    /// @param _approved The new approved NFT controller
+    /// @param _tokenId The NFT to approve
+    function approve(address _approved, uint256 _tokenId) external payable;
+
+    /// @notice Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @dev Emits the ApprovalForAll event. The contract MUST allow
+    ///  multiple operators per owner.
+    /// @param _operator Address to add to the set of authorized operators
+    /// @param _approved True if the operator is approved, false to revoke approval
+    function setApprovalForAll(address _operator, bool _approved) external;
+
+    /// @notice Get the approved address for a single NFT
+    /// @dev Throws if `_tokenId` is not a valid NFT.
+    /// @param _tokenId The NFT to find the approved address for
+    /// @return The approved address for this NFT, or the zero address if there is none
+    function getApproved(uint256 _tokenId) external view returns (address);
+
+    /// @notice Query if an address is an authorized operator for another address
+    /// @param _owner The address that owns the NFTs
+    /// @param _operator The address that acts on behalf of the owner
+    /// @return True if `_operator` is an approved operator for `_owner`, false otherwise
+    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+}
+
+/// @dev Note: the ERC-165 identifier for this interface is 0x150b7a02.
+interface ERC721TokenReceiver {
+    /// @notice Handle the receipt of an NFT
+    /// @dev The ERC721 smart contract calls this function on the recipient
+    ///  after a `transfer`. This function MAY throw to revert and reject the
+    ///  transfer. Return of other than the magic value MUST result in the
+    ///  transaction being reverted.
+    ///  Note: the contract address is always the message sender.
+    /// @param _operator The address which called `safeTransferFrom` function
+    /// @param _from The address which previously owned the token
+    /// @param _tokenId The NFT identifier which is being transferred
+    /// @param _data Additional data with no specified format
+    /// @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+    ///  unless throwing
+    function onERC721Received(address _operator, address _from, uint256 _tokenId, bytes _data) external returns(bytes4);
+}
+
+/// @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  Note: the ERC-165 identifier for this interface is 0x5b5e139f.
+interface ERC721Metadata /* is ERC721 */ {
+    /// @notice A descriptive name for a collection of NFTs in this contract
+    function name() external view returns (string _name);
+
+    /// @notice An abbreviated name for NFTs in this contract
+    function symbol() external view returns (string _symbol);
+
+    /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.
+    /// @dev Throws if `_tokenId` is not a valid NFT. URIs are defined in RFC
+    ///  3986. The URI may point to a JSON file that conforms to the "ERC721
+    ///  Metadata JSON Schema".
+    function tokenURI(uint256 _tokenId) external view returns (string);
+}
+
+/// @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  Note: the ERC-165 identifier for this interface is 0x780e9d63.
+interface ERC721Enumerable /* is ERC721 */ {
+    /// @notice Count NFTs tracked by this contract
+    /// @return A count of valid NFTs tracked by this contract, where each one of
+    ///  them has an assigned and queryable owner not equal to the zero address
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Enumerate valid NFTs
+    /// @dev Throws if `_index` >= `totalSupply()`.
+    /// @param _index A counter less than `totalSupply()`
+    /// @return The token identifier for the `_index`th NFT,
+    ///  (sort order not specified)
+    function tokenByIndex(uint256 _index) external view returns (uint256);
+
+    /// @notice Enumerate NFTs assigned to an owner
+    /// @dev Throws if `_index` >= `balanceOf(_owner)` or if
+    ///  `_owner` is the zero address, representing invalid NFTs.
+    /// @param _owner An address where we are interested in NFTs owned by them
+    /// @param _index A counter less than `balanceOf(_owner)`
+    /// @return The token identifier for the `_index`th NFT assigned to `_owner`,
+    ///   (sort order not specified)
+    function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256);
+}

--- a/analyzer/evmabi/contracts/artifacts/ERC165.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC165.json
@@ -1,0 +1,71 @@
+{
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"supportsInterface(bytes4)": "01ffc9a7"
+		}
+	},
+	"abi": [
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "interfaceID",
+					"type": "bytes4"
+				}
+			],
+			"name": "supportsInterface",
+			"outputs": [
+				{
+					"name": "",
+					"type": "bool"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		}
+	]
+}

--- a/analyzer/evmabi/contracts/artifacts/ERC20.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC20.json
@@ -1,275 +1,275 @@
 {
-  "deploy": {
-    "VM:-": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "main:1": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "ropsten:3": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "rinkeby:4": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "kovan:42": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "goerli:5": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    },
-    "Custom": {
-      "linkReferences": {},
-      "autoDeployLib": true
-    }
-  },
-  "data": {
-    "bytecode": {
-      "linkReferences": {},
-      "object": "",
-      "opcodes": "",
-      "sourceMap": ""
-    },
-    "deployedBytecode": {
-      "linkReferences": {},
-      "object": "",
-      "opcodes": "",
-      "sourceMap": ""
-    },
-    "gasEstimates": null,
-    "methodIdentifiers": {
-      "allowance(address,address)": "dd62ed3e",
-      "approve(address,uint256)": "095ea7b3",
-      "balanceOf(address)": "70a08231",
-      "decimals()": "313ce567",
-      "name()": "06fdde03",
-      "symbol()": "95d89b41",
-      "totalSupply()": "18160ddd",
-      "transfer(address,uint256)": "a9059cbb",
-      "transferFrom(address,address,uint256)": "23b872dd"
-    }
-  },
-  "abi": [
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "name",
-      "outputs": [
-        {
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "name": "_spender",
-          "type": "address"
-        },
-        {
-          "name": "_value",
-          "type": "uint256"
-        }
-      ],
-      "name": "approve",
-      "outputs": [
-        {
-          "name": "success",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "name": "_from",
-          "type": "address"
-        },
-        {
-          "name": "_to",
-          "type": "address"
-        },
-        {
-          "name": "_value",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferFrom",
-      "outputs": [
-        {
-          "name": "success",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "decimals",
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint8"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "name": "_owner",
-          "type": "address"
-        }
-      ],
-      "name": "balanceOf",
-      "outputs": [
-        {
-          "name": "balance",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "symbol",
-      "outputs": [
-        {
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "name": "_to",
-          "type": "address"
-        },
-        {
-          "name": "_value",
-          "type": "uint256"
-        }
-      ],
-      "name": "transfer",
-      "outputs": [
-        {
-          "name": "success",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "name": "_owner",
-          "type": "address"
-        },
-        {
-          "name": "_spender",
-          "type": "address"
-        }
-      ],
-      "name": "allowance",
-      "outputs": [
-        {
-          "name": "remaining",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "name": "_from",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "name": "_to",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "name": "_value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Transfer",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "name": "_owner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "name": "_spender",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "name": "_value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Approval",
-      "type": "event"
-    }
-  ]
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"allowance(address,address)": "dd62ed3e",
+			"approve(address,uint256)": "095ea7b3",
+			"balanceOf(address)": "70a08231",
+			"decimals()": "313ce567",
+			"name()": "06fdde03",
+			"symbol()": "95d89b41",
+			"totalSupply()": "18160ddd",
+			"transfer(address,uint256)": "a9059cbb",
+			"transferFrom(address,address,uint256)": "23b872dd"
+		}
+	},
+	"abi": [
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "name",
+			"outputs": [
+				{
+					"name": "",
+					"type": "string"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_spender",
+					"type": "address"
+				},
+				{
+					"name": "_value",
+					"type": "uint256"
+				}
+			],
+			"name": "approve",
+			"outputs": [
+				{
+					"name": "success",
+					"type": "bool"
+				}
+			],
+			"payable": false,
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "totalSupply",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"name": "_value",
+					"type": "uint256"
+				}
+			],
+			"name": "transferFrom",
+			"outputs": [
+				{
+					"name": "success",
+					"type": "bool"
+				}
+			],
+			"payable": false,
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "decimals",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint8"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_owner",
+					"type": "address"
+				}
+			],
+			"name": "balanceOf",
+			"outputs": [
+				{
+					"name": "balance",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "symbol",
+			"outputs": [
+				{
+					"name": "",
+					"type": "string"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"name": "_value",
+					"type": "uint256"
+				}
+			],
+			"name": "transfer",
+			"outputs": [
+				{
+					"name": "success",
+					"type": "bool"
+				}
+			],
+			"payable": false,
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"name": "_spender",
+					"type": "address"
+				}
+			],
+			"name": "allowance",
+			"outputs": [
+				{
+					"name": "remaining",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"indexed": false,
+					"name": "_value",
+					"type": "uint256"
+				}
+			],
+			"name": "Transfer",
+			"type": "event"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_spender",
+					"type": "address"
+				},
+				{
+					"indexed": false,
+					"name": "_value",
+					"type": "uint256"
+				}
+			],
+			"name": "Approval",
+			"type": "event"
+		}
+	]
 }

--- a/analyzer/evmabi/contracts/artifacts/ERC721.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC721.json
@@ -1,0 +1,312 @@
+{
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"approve(address,uint256)": "095ea7b3",
+			"balanceOf(address)": "70a08231",
+			"getApproved(uint256)": "081812fc",
+			"isApprovedForAll(address,address)": "e985e9c5",
+			"ownerOf(uint256)": "6352211e",
+			"safeTransferFrom(address,address,uint256)": "42842e0e",
+			"safeTransferFrom(address,address,uint256,bytes)": "b88d4fde",
+			"setApprovalForAll(address,bool)": "a22cb465",
+			"transferFrom(address,address,uint256)": "23b872dd"
+		}
+	},
+	"abi": [
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "getApproved",
+			"outputs": [
+				{
+					"name": "",
+					"type": "address"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_approved",
+					"type": "address"
+				},
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "approve",
+			"outputs": [],
+			"payable": true,
+			"stateMutability": "payable",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "transferFrom",
+			"outputs": [],
+			"payable": true,
+			"stateMutability": "payable",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "safeTransferFrom",
+			"outputs": [],
+			"payable": true,
+			"stateMutability": "payable",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "ownerOf",
+			"outputs": [
+				{
+					"name": "",
+					"type": "address"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_owner",
+					"type": "address"
+				}
+			],
+			"name": "balanceOf",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_operator",
+					"type": "address"
+				},
+				{
+					"name": "_approved",
+					"type": "bool"
+				}
+			],
+			"name": "setApprovalForAll",
+			"outputs": [],
+			"payable": false,
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				},
+				{
+					"name": "data",
+					"type": "bytes"
+				}
+			],
+			"name": "safeTransferFrom",
+			"outputs": [],
+			"payable": true,
+			"stateMutability": "payable",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"name": "_operator",
+					"type": "address"
+				}
+			],
+			"name": "isApprovedForAll",
+			"outputs": [
+				{
+					"name": "",
+					"type": "bool"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_to",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "Transfer",
+			"type": "event"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_approved",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "Approval",
+			"type": "event"
+		},
+		{
+			"anonymous": false,
+			"inputs": [
+				{
+					"indexed": true,
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"indexed": true,
+					"name": "_operator",
+					"type": "address"
+				},
+				{
+					"indexed": false,
+					"name": "_approved",
+					"type": "bool"
+				}
+			],
+			"name": "ApprovalForAll",
+			"type": "event"
+		}
+	]
+}

--- a/analyzer/evmabi/contracts/artifacts/ERC721Enumerable.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC721Enumerable.json
@@ -1,0 +1,110 @@
+{
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"tokenByIndex(uint256)": "4f6ccce7",
+			"tokenOfOwnerByIndex(address,uint256)": "2f745c59",
+			"totalSupply()": "18160ddd"
+		}
+	},
+	"abi": [
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "totalSupply",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_owner",
+					"type": "address"
+				},
+				{
+					"name": "_index",
+					"type": "uint256"
+				}
+			],
+			"name": "tokenOfOwnerByIndex",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_index",
+					"type": "uint256"
+				}
+			],
+			"name": "tokenByIndex",
+			"outputs": [
+				{
+					"name": "",
+					"type": "uint256"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		}
+	]
+}

--- a/analyzer/evmabi/contracts/artifacts/ERC721Metadata.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC721Metadata.json
@@ -1,0 +1,101 @@
+{
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"name()": "06fdde03",
+			"symbol()": "95d89b41",
+			"tokenURI(uint256)": "c87b56dd"
+		}
+	},
+	"abi": [
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "name",
+			"outputs": [
+				{
+					"name": "_name",
+					"type": "string"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [],
+			"name": "symbol",
+			"outputs": [
+				{
+					"name": "_symbol",
+					"type": "string"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				}
+			],
+			"name": "tokenURI",
+			"outputs": [
+				{
+					"name": "",
+					"type": "string"
+				}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		}
+	]
+}

--- a/analyzer/evmabi/contracts/artifacts/ERC721TokenReceiver.json
+++ b/analyzer/evmabi/contracts/artifacts/ERC721TokenReceiver.json
@@ -1,0 +1,83 @@
+{
+	"deploy": {
+		"VM:-": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"main:1": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"ropsten:3": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"rinkeby:4": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"kovan:42": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"goerli:5": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		},
+		"Custom": {
+			"linkReferences": {},
+			"autoDeployLib": true
+		}
+	},
+	"data": {
+		"bytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"deployedBytecode": {
+			"linkReferences": {},
+			"object": "",
+			"opcodes": "",
+			"sourceMap": ""
+		},
+		"gasEstimates": null,
+		"methodIdentifiers": {
+			"onERC721Received(address,address,uint256,bytes)": "150b7a02"
+		}
+	},
+	"abi": [
+		{
+			"constant": false,
+			"inputs": [
+				{
+					"name": "_operator",
+					"type": "address"
+				},
+				{
+					"name": "_from",
+					"type": "address"
+				},
+				{
+					"name": "_tokenId",
+					"type": "uint256"
+				},
+				{
+					"name": "_data",
+					"type": "bytes"
+				}
+			],
+			"name": "onERC721Received",
+			"outputs": [
+				{
+					"name": "",
+					"type": "bytes4"
+				}
+			],
+			"payable": false,
+			"stateMutability": "nonpayable",
+			"type": "function"
+		}
+	]
+}

--- a/analyzer/evmabi/evmabi.go
+++ b/analyzer/evmabi/evmabi.go
@@ -7,17 +7,16 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 )
 
-//go:embed contracts/artifacts/ERC20.json
-var artifactERC20JSON []byte
-var ERC20 *abi.ABI
-
-func init() {
-	type artifact struct {
+func mustUnmarshalABI(artifactJSON []byte) *abi.ABI {
+	var artifact struct {
 		ABI *abi.ABI
 	}
-	var artifactERC20 artifact
-	if err := json.Unmarshal(artifactERC20JSON, &artifactERC20); err != nil {
+	if err := json.Unmarshal(artifactJSON, &artifact); err != nil {
 		panic(err)
 	}
-	ERC20 = artifactERC20.ABI
+	return artifact.ABI
 }
+
+//go:embed contracts/artifacts/ERC20.json
+var artifactERC20JSON []byte
+var ERC20 = mustUnmarshalABI(artifactERC20JSON)

--- a/analyzer/evmabi/evmabi.go
+++ b/analyzer/evmabi/evmabi.go
@@ -20,3 +20,23 @@ func mustUnmarshalABI(artifactJSON []byte) *abi.ABI {
 //go:embed contracts/artifacts/ERC20.json
 var artifactERC20JSON []byte
 var ERC20 = mustUnmarshalABI(artifactERC20JSON)
+
+//go:embed contracts/artifacts/ERC165.json
+var artifactERC165JSON []byte
+var ERC165 = mustUnmarshalABI(artifactERC165JSON)
+
+//go:embed contracts/artifacts/ERC721.json
+var artifactERC721JSON []byte
+var ERC721 = mustUnmarshalABI(artifactERC721JSON)
+
+//go:embed contracts/artifacts/ERC721TokenReceiver.json
+var artifactERC721TokenReceiverJSON []byte
+var ERC721TokenReceiver = mustUnmarshalABI(artifactERC721TokenReceiverJSON)
+
+//go:embed contracts/artifacts/ERC721Metadata.json
+var artifactERC721MetadataJSON []byte
+var ERC721Metadata = mustUnmarshalABI(artifactERC721MetadataJSON)
+
+//go:embed contracts/artifacts/ERC721Enumerable.json
+var artifactERC721EnumerableJSON []byte
+var ERC721Enumerable = mustUnmarshalABI(artifactERC721EnumerableJSON)

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -182,6 +182,19 @@ func EVMDownloadNewToken(ctx context.Context, logger *log.Logger, source nodeapi
 		return nil, fmt.Errorf("detect ERC165: %w", err)
 	}
 	if supportsERC165 {
+		// Note: Per spec, every ERC-721 token has to support ERC-165.
+		supportsERC721, err1 := detectInterface(ctx, logger, source, round, tokenEthAddr, ERC721InterfaceID)
+		if err1 != nil {
+			return nil, fmt.Errorf("checking ERC721 interface: %w", err1)
+		}
+		if supportsERC721 {
+			tokenData, err2 := evmDownloadTokenERC721(ctx, logger, source, round, tokenEthAddr)
+			if err2 != nil {
+				return nil, fmt.Errorf("download token ERC-721: %w", err2)
+			}
+			return tokenData, nil
+		}
+
 		// todo: add support for other token types
 		// see https://github.com/oasisprotocol/nexus/issues/225
 	}

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -134,6 +134,14 @@ func evmCallWithABICustom(
 	return nil
 }
 
+var (
+	// https://github.com/oasisprotocol/oasis-web3-gateway/blob/v3.0.0/rpc/eth/api.go#L403-L408
+	DefaultGasPrice        = []byte{1}
+	DefaultGasLimit uint64 = 30_000_000
+	DefaultCaller          = ethCommon.Address{1}.Bytes()
+	DefaultValue           = []byte{0}
+)
+
 // evmCallWithABI: Given a runtime `source` and `round`, and given an EVM
 // smart contract (at `contractEthAddr`, with `contractABI`) deployed in that
 // runtime, invokes `method(params...)` in that smart contract. The method
@@ -149,13 +157,7 @@ func evmCallWithABI(
 	method string,
 	params ...interface{},
 ) error {
-	// https://github.com/oasisprotocol/oasis-web3-gateway/blob/v3.0.0/rpc/eth/api.go#L403-L408
-	gasPrice := []byte{1}
-	gasLimit := uint64(30_000_000)
-	caller := ethCommon.Address{1}.Bytes()
-	value := []byte{0}
-
-	return evmCallWithABICustom(ctx, source, round, gasPrice, gasLimit, caller, contractEthAddr, value, contractABI, result, method, params...)
+	return evmCallWithABICustom(ctx, source, round, DefaultGasPrice, DefaultGasLimit, DefaultCaller, contractEthAddr, DefaultValue, contractABI, result, method, params...)
 }
 
 func evmDownloadTokenERC20Mutable(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte) (*EVMTokenMutableData, error) {

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -18,6 +18,12 @@ import (
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
+// EVMTokenType is a small-ish number that we use to identify what type of
+// token each row of the tokens table is. Values aren't consecutive like in an
+// enum. Prefer to use the number of the ERC if applicable and available, e.g.
+// 20 for ERC-20.
+// "Historical reasons" style note: this has grown to include non-EVM token
+// types as well.
 type EVMTokenType int
 
 const (

--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -64,6 +64,18 @@ func TestEVMDownloadTokenERC20(t *testing.T) {
 	t.Logf("data %#v", data)
 }
 
+func TestEVMDownloadTokenERC721(t *testing.T) {
+	ctx := context.Background()
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, common.RuntimeEmerald)
+	require.NoError(t, err)
+	// AI ROSE on Emerald mainnet.
+	tokenEthAddr, err := hex.DecodeString("0f4c5A429166608f9225E094F7E66B0bF68a53B9")
+	require.NoError(t, err)
+	data, err := evmDownloadTokenERC721(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
+	require.NoError(t, err)
+	t.Logf("data %#v", data)
+}
+
 func TestEVMDownloadTokenBalanceERC20(t *testing.T) {
 	ctx := context.Background()
 	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, common.RuntimeEmerald)

--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -37,6 +37,21 @@ var (
 	}
 )
 
+func TestERC165(t *testing.T) {
+	ctx := context.Background()
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, common.RuntimeEmerald)
+	require.NoError(t, err)
+	// AI ROSE on Emerald mainnet.
+	tokenEthAddr, err := hex.DecodeString("0f4c5A429166608f9225E094F7E66B0bF68a53B9")
+	require.NoError(t, err)
+	supportsERC165, err := detectERC165(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
+	require.NoError(t, err)
+	require.True(t, supportsERC165)
+	supportsERC721, err := detectInterface(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr, ERC165InterfaceID)
+	require.NoError(t, err)
+	require.True(t, supportsERC721)
+}
+
 func TestEVMDownloadTokenERC20(t *testing.T) {
 	ctx := context.Background()
 	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, common.RuntimeEmerald)

--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	ethCommon "github.com/ethereum/go-ethereum/common"
 	runtimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
 	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/stretchr/testify/require"
@@ -87,12 +86,9 @@ func TestEVMFailDeterministicOutOfGas(t *testing.T) {
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")
 	require.NoError(t, err)
 	var name string
-	gasPrice := []byte{1}
 	// Use very low gas to cause out of gas condition.
 	gasLimit := uint64(10)
-	caller := ethCommon.Address{1}.Bytes()
-	value := []byte{0}
-	err = evmCallWithABICustom(ctx, source, runtimeClient.RoundLatest, gasPrice, gasLimit, caller, tokenEthAddr, value, evmabi.ERC20, &name, "name")
+	err = evmCallWithABICustom(ctx, source, runtimeClient.RoundLatest, DefaultGasPrice, gasLimit, DefaultCaller, tokenEthAddr, DefaultValue, evmabi.ERC20, &name, "name")
 	require.Error(t, err)
 	fmt.Printf("query that runs out of gas should fail: %+v\n", err)
 	require.True(t, errors.Is(err, EVMDeterministicError{}))

--- a/analyzer/runtime/evm/erc165.go
+++ b/analyzer/runtime/evm/erc165.go
@@ -1,0 +1,93 @@
+package evm
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+
+	"github.com/oasisprotocol/nexus/analyzer/evmabi"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
+)
+
+func InterfaceID(abi *abi.ABI) []byte {
+	id := []byte{0, 0, 0, 0}
+	for _, m := range abi.Methods {
+		id[0] ^= m.ID[0]
+		id[1] ^= m.ID[1]
+		id[2] ^= m.ID[2]
+		id[3] ^= m.ID[3]
+	}
+	return id
+}
+
+var (
+	InvalidInterfaceID             = []byte{0xff, 0xff, 0xff, 0xff}
+	ERC165InterfaceID              = InterfaceID(evmabi.ERC165)
+	ERC721InterfaceID              = InterfaceID(evmabi.ERC721)
+	ERC721TokenReceiverInterfaceID = InterfaceID(evmabi.ERC721TokenReceiver)
+	ERC721MetadataInterfaceID      = InterfaceID(evmabi.ERC721Metadata)
+	ERC721EnumerableInterfaceID    = InterfaceID(evmabi.ERC721Enumerable)
+)
+
+const ERC165GasLimit uint64 = 30_000
+
+func callERC165SupportsInterface(ctx context.Context, source nodeapi.RuntimeApiLite, round uint64, contractEthAddr []byte, interfaceID []byte) (bool, error) {
+	var result bool
+	// go-ethereum insists on array and not slice for fixed types like bytes4
+	// here.
+	var interfaceIDFixed [4]byte
+	copy(interfaceIDFixed[:], interfaceID)
+	if err := evmCallWithABICustom(ctx, source, round, DefaultGasPrice, ERC165GasLimit, DefaultCaller, contractEthAddr, DefaultValue, evmabi.ERC165, &result, "supportsInterface", interfaceIDFixed); err != nil {
+		return false, err
+	}
+	return result, nil
+}
+
+// detectInterfaceOK checks using ERC-165 and returns (result, ok, err). If a
+// nondeterministic error occurs, it returns err != nil. If a deterministic
+// error occurs, it returns ok = false, err = nil. If the check succeeds, it
+// returns ok = true, err = nil.
+func detectInterfaceOK(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, contractEthAddr []byte, interfaceID []byte) (bool, bool, error) {
+	result, err := callERC165SupportsInterface(ctx, source, round, contractEthAddr, interfaceID)
+	if err != nil {
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return false, false, err
+		}
+		logDeterministicError(logger, round, contractEthAddr, "ERC165", "supportsInterface", err,
+			"interface_id", hex.EncodeToString(interfaceID),
+		)
+		return false, false, nil
+	}
+	return result, true, nil
+}
+
+func detectERC165(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, contractEthAddr []byte) (bool, error) {
+	// https://eips.ethereum.org/EIPS/eip-165#how-to-detect-if-a-contract-implements-erc-165
+	supportsERC165, ok, err := detectInterfaceOK(ctx, logger, source, round, contractEthAddr, ERC165InterfaceID)
+	if err != nil {
+		return false, fmt.Errorf("checking ERC165: %w", err)
+	}
+	if !ok || !supportsERC165 {
+		return false, nil
+	}
+	supportsInvalid, ok, err := detectInterfaceOK(ctx, logger, source, round, contractEthAddr, InvalidInterfaceID)
+	if err != nil {
+		return false, fmt.Errorf("checking invalid interface: %w", err)
+	}
+	if !ok || supportsInvalid {
+		return false, nil
+	}
+	return true, nil
+}
+
+func detectInterface(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, contractEthAddr []byte, interfaceID []byte) (bool, error) {
+	result, ok, err := detectInterfaceOK(ctx, logger, source, round, contractEthAddr, interfaceID)
+	if err != nil {
+		return false, err
+	}
+	return ok && result, nil
+}

--- a/analyzer/runtime/evm/erc165_test.go
+++ b/analyzer/runtime/evm/erc165_test.go
@@ -1,0 +1,17 @@
+package evm
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterfaceID(t *testing.T) {
+	// Reference interface identifiers are from code comments in ERC spec sample code.
+	require.Equal(t, "01ffc9a7", hex.EncodeToString(ERC165InterfaceID))
+	require.Equal(t, "80ac58cd", hex.EncodeToString(ERC721InterfaceID))
+	require.Equal(t, "150b7a02", hex.EncodeToString(ERC721TokenReceiverInterfaceID))
+	require.Equal(t, "5b5e139f", hex.EncodeToString(ERC721MetadataInterfaceID))
+	require.Equal(t, "780e9d63", hex.EncodeToString(ERC721EnumerableInterfaceID))
+}

--- a/analyzer/runtime/evm/erc20.go
+++ b/analyzer/runtime/evm/erc20.go
@@ -1,0 +1,82 @@
+package evm
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+
+	"github.com/oasisprotocol/nexus/analyzer/evmabi"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
+)
+
+const EVMTokenTypeERC20 EVMTokenType = 20
+
+func evmDownloadTokenERC20Mutable(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte) (*EVMTokenMutableData, error) {
+	var mutable EVMTokenMutableData
+	// These mandatory methods must succeed, or we do not count this as an ERC-20 token.
+	if err := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC20, &mutable.TotalSupply, "totalSupply"); err != nil {
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return nil, fmt.Errorf("calling totalSupply: %w", err)
+		}
+		logDeterministicError(logger, round, tokenEthAddr, "ERC20", "totalSupply", err)
+		return nil, nil
+	}
+	return &mutable, nil
+}
+
+func evmDownloadTokenERC20(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte) (*EVMTokenData, error) {
+	tokenData := EVMTokenData{
+		Type: EVMTokenTypeERC20,
+	}
+	// These optional methods may fail.
+	if err := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC20, &tokenData.Name, "name"); err != nil {
+		// Propagate the error (so that token-info fetching may be retried
+		// later) only if the error is non-deterministic, e.g. network
+		// failure. Otherwise, accept that the token contract doesn't expose
+		// this info.
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return nil, fmt.Errorf("calling name: %w", err)
+		}
+		logDeterministicError(logger, round, tokenEthAddr, "ERC20", "name", err)
+	}
+	if err := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC20, &tokenData.Symbol, "symbol"); err != nil {
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return nil, fmt.Errorf("calling symbol: %w", err)
+		}
+		logDeterministicError(logger, round, tokenEthAddr, "ERC20", "symbol", err)
+	}
+	if err := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC20, &tokenData.Decimals, "decimals"); err != nil {
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return nil, fmt.Errorf("calling decimals: %w", err)
+		}
+		logDeterministicError(logger, round, tokenEthAddr, "ERC20", "decimals", err)
+	}
+	mutable, err := evmDownloadTokenERC20Mutable(ctx, logger, source, round, tokenEthAddr)
+	if err != nil {
+		return nil, err
+	}
+	if mutable == nil {
+		return nil, nil
+	}
+	tokenData.EVMTokenMutableData = mutable
+	return &tokenData, nil
+}
+
+func evmDownloadTokenBalanceERC20(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte, accountEthAddr []byte) (*EVMTokenBalanceData, error) {
+	var balanceData EVMTokenBalanceData
+	accountECAddr := ethCommon.BytesToAddress(accountEthAddr)
+	if err := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC20, &balanceData.Balance, "balanceOf", accountECAddr); err != nil {
+		if !errors.Is(err, EVMDeterministicError{}) {
+			return nil, fmt.Errorf("calling balanceOf: %w", err)
+		}
+		logDeterministicError(logger, round, tokenEthAddr, "ERC20", "balanceOf", err,
+			"account_eth_addr_hex", hex.EncodeToString(accountEthAddr),
+		)
+		return nil, nil
+	}
+	return &balanceData, nil
+}

--- a/analyzer/runtime/evm/erc721.go
+++ b/analyzer/runtime/evm/erc721.go
@@ -1,0 +1,61 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
+
+	"github.com/oasisprotocol/nexus/analyzer/evmabi"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
+)
+
+const EVMTokenTypeERC721 EVMTokenType = 721
+
+func evmDownloadTokenERC721Mutable(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte) (*EVMTokenMutableData, error) {
+	var mutable EVMTokenMutableData
+	supportsEnumerable, err := detectInterface(ctx, logger, source, round, tokenEthAddr, ERC721EnumerableInterfaceID)
+	if err != nil {
+		return nil, fmt.Errorf("checking ERC721Enumerable interface: %w", err)
+	}
+	if supportsEnumerable {
+		if err1 := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC721Enumerable, &mutable.TotalSupply, "totalSupply"); err1 != nil {
+			if !errors.Is(err, EVMDeterministicError{}) {
+				return nil, fmt.Errorf("calling totalSupply: %w", err1)
+			}
+			logDeterministicError(logger, round, tokenEthAddr, "ERC721Enumerable", "totalSupply", err1)
+		}
+	}
+	return &mutable, nil
+}
+
+func evmDownloadTokenERC721(ctx context.Context, logger *log.Logger, source nodeapi.RuntimeApiLite, round uint64, tokenEthAddr []byte) (*EVMTokenData, error) {
+	tokenData := EVMTokenData{
+		Type: EVMTokenTypeERC721,
+	}
+	supportsMetadata, err := detectInterface(ctx, logger, source, round, tokenEthAddr, ERC721MetadataInterfaceID)
+	if err != nil {
+		return nil, fmt.Errorf("checking ERC721Metadata interface: %w", err)
+	}
+	if supportsMetadata { //nolint:nestif
+		if err1 := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC721Metadata, &tokenData.Name, "name"); err1 != nil {
+			if !errors.Is(err, EVMDeterministicError{}) {
+				return nil, fmt.Errorf("calling name: %w", err)
+			}
+			logDeterministicError(logger, round, tokenEthAddr, "ERC721Metadata", "name", err1)
+		}
+		if err1 := evmCallWithABI(ctx, source, round, tokenEthAddr, evmabi.ERC721Metadata, &tokenData.Symbol, "symbol"); err1 != nil {
+			if !errors.Is(err, EVMDeterministicError{}) {
+				return nil, fmt.Errorf("calling symbol: %w", err)
+			}
+			logDeterministicError(logger, round, tokenEthAddr, "ERC721Metadata", "symbol", err1)
+		}
+	}
+	mutable, err := evmDownloadTokenERC721Mutable(ctx, logger, source, round, tokenEthAddr)
+	if err != nil {
+		return nil, err
+	}
+	tokenData.EVMTokenMutableData = mutable
+	return &tokenData, nil
+}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -457,6 +457,7 @@ const (
 			tokens.total_supply,
 			CASE -- NOTE: There are two queries that use this CASE via copy-paste; edit both if changing.
 				WHEN tokens.token_type = 20 THEN 'ERC20'
+				WHEN tokens.token_type = 721 THEN 'ERC721'
 				ELSE 'unexpected_other_type' -- Our openapi spec doesn't allow us to output this, but better this than a null value (which causes nil dereference)
 			END AS type,
 			holders.cnt AS num_holders
@@ -507,6 +508,7 @@ const (
 			tokens.token_name AS token_name,
 			CASE -- NOTE: There are two queries that use this CASE via copy-paste; edit both if changing.
 				WHEN tokens.token_type = 20 THEN 'ERC20'
+				WHEN tokens.token_type = 721 THEN 'ERC721'
 				ELSE 'unexpected_other_type' -- Our openapi spec doesn't allow us to output this, but better this than a null value (which causes nil dereference)
 			END AS token_type,
 			tokens.decimals AS token_decimals


### PR DESCRIPTION
functionality:
- token scanner can detect ERC-721 using ERC-165 supportsInterface
- block scanner can detect ERC-721 events and schedule token scanning
- schedules 'mutable' parts rescan (i.e. total supply) when tokens are minted
- registers transaction related accounts when seeing events

not included:
- approvals tracking (similar to that not being supported for ERC-20)
- tracking ownership of tokens
- holders count

tested on recent blocks on emerald, where a BlockchainCuties transfer had occurred