### PR TITLE
analyzer/runtime: enable balance tracking for ERC-721

### DIFF
--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -255,6 +255,13 @@ func EVMDownloadTokenBalance(ctx context.Context, logger *log.Logger, source nod
 		}
 		return balance, nil
 
+	case EVMTokenTypeERC721:
+		balance, err := evmDownloadTokenBalanceERC721(ctx, logger, source, round, tokenEthAddr, accountEthAddr)
+		if err != nil {
+			return nil, fmt.Errorf("download token balance ERC-721: %w", err)
+		}
+		return balance, nil
+
 	// todo: add support for other token types
 	// see https://github.com/oasisprotocol/nexus/issues/225
 

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -739,6 +739,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 							return fmt.Errorf("from: %w", err2)
 						}
 						eventData.RelatedAddresses[fromAddr] = true
+						registerTokenDecrease(blockData.TokenBalanceChanges, eventAddr, fromAddr, big.NewInt(1))
 					}
 					if !toZero {
 						toAddr, err2 := registerRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, toEthAddr)
@@ -746,6 +747,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 							return fmt.Errorf("to: %w", err2)
 						}
 						eventData.RelatedAddresses[toAddr] = true
+						registerTokenIncrease(blockData.TokenBalanceChanges, eventAddr, toAddr, big.NewInt(1))
 					}
 					// TODO: Reckon ownership.
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {


### PR DESCRIPTION
the "balance" is the number of the tokens they have, i.e. exactly one moves per Transfer event. this will help us show the number of holders

tested with the same block range as #447 