### PR TITLE
 storage: add chain.evm_tokens token_name index

### DIFF
--- a/.changelog/466.feature.md
+++ b/.changelog/466.feature.md
@@ -1,0 +1,1 @@
+storage: add chain.evm_tokens name and symbol indices

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -333,6 +333,10 @@ CREATE TABLE chain.evm_tokens
   -- Token analyzer bumps this when it downloads info about the token.
   last_download_round UINT63
 );
+-- Added in 30_evm_tokens_name_index.up.sql.
+-- -- Add indexes for evm_tokens token names and symbols for search.
+-- CREATE INDEX ix_evm_tokens_name ON chain.evm_tokens USING GIST (token_name gist_trgm_ops);
+-- CREATE INDEX ix_evm_tokens_symbol ON chain.evm_tokens USING GIST (symbol gist_trgm_ops);
 
 CREATE TABLE analysis.evm_token_balances
 (

--- a/storage/migrations/30_evm_tokens_name_index.up.sql
+++ b/storage/migrations/30_evm_tokens_name_index.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Add indexes for evm_tokens token names and symbols for search.
+CREATE INDEX ix_evm_tokens_name ON chain.evm_tokens USING GIST (token_name gist_trgm_ops);
+CREATE INDEX ix_evm_tokens_symbol ON chain.evm_tokens USING GIST (symbol gist_trgm_ops);
+
+COMMIT;


### PR DESCRIPTION
from #460 

This speeds up searching tokens by name. For simplicity, we're not merging this for now (2024-06) until search proves problematically slow.