### PR TITLE
/{runtime}/transactions: Add heuristic field for "is tx a native token transfer?"

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2303,6 +2303,16 @@ components:
           type: object
           description: The method call body. May be null if the transaction was malformed.
           example: {"address": "t1mAPucIdVnrYBpJOcLV2nZoOFo=", "data": RBo+cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "value": ""}
+        is_likely_native_token_transfer:
+          type: boolean
+          description: |
+            Whether this transaction likely represents a native token transfer.
+            This is based on a heuristic, and can change at any time without warning and possibly without updating the documentation.
+            The current heuristic sets this to `true` for:
+             - Transactions with method "accounts.Transfer". Those are always native token transfers.
+             - Transactions with method "evm.Call" that have no `data` field in their `body`. Those tend to be transfers, but the runtimes provides no reliable visibility into whether a transfer happened.
+            Note: Other transactions with method "evm.Call", and possibly "evm.Create", may also be (or include) native token transfers. The heuristic will be `false` for those.
+          example: true
         to:
           <<: *AddressType
           description: |

--- a/tests/e2e_regression/expected/emerald_txs.body
+++ b/tests/e2e_regression/expected/emerald_txs.body
@@ -2011,6 +2011,7 @@
       "gas_used": 22142,
       "hash": "34204265b53f41a253f30651882bf1317739ac694ccfb966d2b57e54a82c8ee2",
       "index": 3,
+      "is_likely_native_token_transfer": true,
       "method": "evm.Call",
       "nonce_0": 60,
       "round": 1003586,


### PR DESCRIPTION
Resolves https://app.clickup.com/t/866ahv3h0

We cannot know if an `evm.Call` tx transfers native runtime tokens or not, but we can expose a heuristic that all clients will consume.

This PR adds an `is_likely_native_token_transfer` field to the runtime tx output, with that heuristic.