### PR TITLE
cmd: Log goroutines (stack traces) on SIGUSR1

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,9 +2,13 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/signal"
+	"runtime/pprof"
 	"sync"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -84,6 +88,9 @@ func rootMain(cmd *cobra.Command, args []string) {
 
 // Execute spawns the main entry point after handing the config file.
 func Execute() {
+	// Debug hook. If we receive SIGUSR1, dump all goroutines.
+	go dumpGoroutinesOnSignal(syscall.SIGUSR1)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -98,5 +105,27 @@ func init() {
 		api.Register,
 	} {
 		f(rootCmd)
+	}
+}
+
+// Starts listening for the specified signals, and logs a dump of all
+// goroutines when the process receives one of those signals.
+func dumpGoroutinesOnSignal(signals ...os.Signal) {
+	logger := log.NewDefaultLogger("toplevel")
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, signals...)
+	logger.Info("listening for signals", "signals", signals)
+	for range c {
+		b := bytes.NewBufferString("")
+		_ = pprof.Lookup("goroutine").WriteTo(b, 1)
+		logger.Warn("USER-REQUESTED DUMP: all goroutines", "goroutines_all", b.String())
+
+		b = bytes.NewBufferString("")
+		_ = pprof.Lookup("block").WriteTo(b, 1)
+		logger.Warn("USER-REQUESTED DUMP: stack traces that led to blocking on synchronization primitives", "goroutines_block", b.String())
+
+		b = bytes.NewBufferString("")
+		_ = pprof.Lookup("mutex").WriteTo(b, 1)
+		logger.Warn("USER-REQUESTED DUMP: stack traces of holders of contended mutexes", "goroutines_mutex", b.String())
 	}
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/866ahha15

This PR maxes the `nexus` binary respond to the `SIGUSR1` os signal by logging the stack traces of all goroutines.

A good way to read the stack traces is to pass the (last minute of) logs through on of:
```
| jq -r  '.goroutines_all | select(.)'
| jq -r  '.goroutines_block | select(.)'
| jq -r  '.goroutines_mutex | select(.)'
```

Motivation:
Currently, the only way to obtain the stacks of goroutines is to send a SIGQUIT, which also terminates the program. And in a way that does not safely close the KVStore , at that. When analyzers get inexplicably stuck (see e.g. https://app.clickup.com/t/866ahh8xy), the list of goroutines can be very helpful for diagnosing the live system.

Tested locally.
