### PR TITLE
Update parameter description to better match behavior

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -981,7 +981,7 @@ paths:
           name: name
           schema:
             type: string
-          description: A filter on the name, the name must contain this value as a substring.
+          description: A filter on the name, the name or symbol must contain this value as a substring.
       responses:
         '200':
           description: The requested tokens.


### PR DESCRIPTION
Looking at the code [here](https://github.com/oasisprotocol/nexus/commit/f29b2db3a6cc1bdb5ddc358de51e52cc34ba5855#diff-c50bc5e7bf70c6477e2cfbc66d3d6130ffcf0dd9060ba20bc63a129edb477b29R469), I think we are returning matches in the token symbol, not only in the token name. (Which is perfect.) I think the description of the parameter should reflect that.