### PR TITLE
statecheck/runtime: fix balance checks

### DIFF
--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -90,9 +90,8 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 		assert.Nil(t, err)
 		for denom, amount := range balances.Balances {
 			if stringifyDenomination(denom, sdkPT) == a.Symbol {
-				assert.Equal(t, amount.ToBigInt(), a.Balance)
+				assert.Equal(t, *amount.ToBigInt(), a.Balance.Int, "address: %s", a.Address)
 			}
-			assert.Equal(t, amount.ToBigInt().Int64(), a.Balance)
 		}
 		actualAccts[a.Address] = true
 	}


### PR DESCRIPTION
The balance check was broken as it was comparing different types:
```
actual  : common.BigInt(common.BigInt{Int:big.Int{neg:false, abs:big.nat{0x6cc752931729f680}}})
expected: *big.Int(7838324468163933824)
```

Additionally, there was a duplicated/wrong additional `assert` outside the `if` statement.