### PR TITLE
Re-enable ERC-721 token type in the API specs

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2444,8 +2444,8 @@ components:
       type: string
       enum:
         - ERC20
+        - ERC721        
         # Desired support in the future, among others:
-        # - ERC721
         # - ERC1155
       description: |
         The type of a EVM token.


### PR DESCRIPTION
Support for this token type has been re-enabled by #447 and #459, but the API specification needs to be updated, too.