### PR TITLE
[db] add index to improve /status queries

### DIFF
--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -15,7 +15,7 @@ const (
 		SELECT height, processed_time
 			FROM analysis.processed_blocks
 			WHERE analyzer=$1 AND processed_time IS NOT NULL
-		ORDER BY processed_time DESC
+		ORDER BY height DESC
 		LIMIT 1`
 
 	Blocks = `


### PR DESCRIPTION
Noticed that the queries to `/v1/` and `/v1/{runtime}/status` were slow during the load tests. 

Within the staging db: 
```
oasisindexer=> explain analyze SELECT height, processed_time
                        FROM analysis.processed_blocks
                        WHERE analyzer='consensus' AND processed_time IS NOT NULL
                ORDER BY processed_time DESC
                LIMIT 1;
                                                                       QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=122859.34..122859.46 rows=1 width=16) (actual time=1532.263..1533.708 rows=1 loops=1)
   ->  Gather Merge  (cost=122859.34..389035.66 rows=2281352 width=16) (actual time=1532.261..1533.704 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=121859.32..124711.01 rows=1140676 width=16) (actual time=1510.410..1510.411 rows=1 loops=3)
               Sort Key: processed_time DESC
               Sort Method: top-N heapsort  Memory: 25kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 25kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 25kB
               ->  Parallel Seq Scan on processed_blocks  (cost=0.00..116155.94 rows=1140676 width=16) (actual time=0.031..1178.207 rows=910748 loops=3)
                     Filter: ((processed_time IS NOT NULL) AND (analyzer = 'consensus'::text))
                     Rows Removed by Filter: 1758780
 Planning Time: 0.147 ms
 Execution Time: 1533.740 ms
(14 rows)
```

Adding the index fixed the performance: 

```
oasisindexer=> explain analyze SELECT height, processed_time
                        FROM analysis.processed_blocks
                        WHERE analyzer='consensus' AND processed_time IS NOT NULL
                ORDER BY processed_time DESC
                LIMIT 1;
                                                                                     QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.56..0.70 rows=1 width=16) (actual time=0.036..0.036 rows=1 loops=1)
   ->  Index Scan Backward using ix_processed_blocks_analyzer_processed on processed_blocks  (cost=0.56..384588.48 rows=2746007 width=16) (actual time=0.035..0.035 rows=1 loops=1)
         Index Cond: (analyzer = 'consensus'::text)
 Planning Time: 0.149 ms
 Execution Time: 0.050 ms
(5 rows)
```