### PR TITLE
paratime analyzers other than block analyzer, queue length metric

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -558,6 +558,16 @@ var (
 		evm.NativeRuntimeTokenAddress,
 	)
 
+	RuntimeEVMTokenBalanceAnalysisStaleCount = `
+    SELECT COUNT(*) AS cnt
+    FROM analysis.evm_token_balances AS balance_analysis
+    WHERE
+      balance_analysis.runtime = $1 AND
+      (
+        balance_analysis.last_download_round IS NULL OR
+        balance_analysis.last_mutate_round > balance_analysis.last_download_round
+      )`
+
 	RuntimeEVMTokenBalanceAnalysisUpdate = `
     UPDATE analysis.evm_token_balances
     SET

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -412,6 +412,13 @@ var (
       code_analysis.is_contract IS NULL
     LIMIT $2`
 
+	RuntimeEVMContractCodeAnalysisStaleCount = `
+    SELECT COUNT(*) AS cnt
+    FROM analysis.evm_contract_code AS code_analysis
+    WHERE
+      code_analysis.runtime = $1::runtime AND
+      code_analysis.is_contract IS NULL`
+
 	RuntimeEVMTokenBalanceUpdate = `
     INSERT INTO chain.evm_token_balances (runtime, token_address, account_address, balance)
       VALUES ($1, $2, $3, $4)

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -448,6 +448,16 @@ var (
       )
     LIMIT $2`
 
+	RuntimeEVMTokenAnalysisStaleCount = `
+    SELECT COUNT(*) AS cnt
+    FROM analysis.evm_tokens AS token_analysis
+    WHERE
+      token_analysis.runtime = $1 AND
+      (
+        token_analysis.last_download_round IS NULL OR
+        token_analysis.last_mutate_round > token_analysis.last_download_round
+      )`
+
 	RuntimeEVMTokenAnalysisInsert = `
     INSERT INTO analysis.evm_tokens (runtime, token_address, last_mutate_round)
       VALUES ($1, $2, $3)


### PR DESCRIPTION
sample output:
```
# HELP evm_contract_code_emerald_queue_length count of stale analysis.evm_contract_code rows
# TYPE evm_contract_code_emerald_queue_length gauge
evm_contract_code_emerald_queue_length 0
# HELP evm_token_balances_emerald_queue_length count of stale analysis.evm_token_balances rows
# TYPE evm_token_balances_emerald_queue_length gauge
evm_token_balances_emerald_queue_length 0
# HELP evm_tokens_emerald_queue_length count of stale analysis.evm_tokens rows
# TYPE evm_tokens_emerald_queue_length gauge
evm_tokens_emerald_queue_length 0
```
it runs kinda fast locally so I don't have a copy with nonzero values