### PR TITLE
analyzer: bugfix download erc721 mutable data

### DIFF
--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -160,7 +160,7 @@ func (m main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 		if err != nil {
 			return fmt.Errorf("downloading mutated token %s: %w", staleToken.Addr, err)
 		}
-		if mutable != nil {
+		if mutable != nil && mutable.TotalSupply != nil {
 			batch.Queue(queries.RuntimeEVMTokenUpdate,
 				m.runtime,
 				staleToken.Addr,

--- a/analyzer/runtime/evm/erc721.go
+++ b/analyzer/runtime/evm/erc721.go
@@ -27,7 +27,6 @@ func evmDownloadTokenERC721Mutable(ctx context.Context, logger *log.Logger, sour
 				return nil, fmt.Errorf("calling totalSupply: %w", err1)
 			}
 			logDeterministicError(logger, round, tokenEthAddr, "ERC721Enumerable", "totalSupply", err1)
-			return nil, nil
 		}
 	}
 	return &mutable, nil

--- a/analyzer/runtime/evm/erc721.go
+++ b/analyzer/runtime/evm/erc721.go
@@ -27,6 +27,7 @@ func evmDownloadTokenERC721Mutable(ctx context.Context, logger *log.Logger, sour
 				return nil, fmt.Errorf("calling totalSupply: %w", err1)
 			}
 			logDeterministicError(logger, round, tokenEthAddr, "ERC721Enumerable", "totalSupply", err1)
+			return nil, nil
 		}
 	}
 	return &mutable, nil


### PR DESCRIPTION
Error logs from production testnet: 

```
{"caller":"grpc.go:242","err":"reverted: no revert reason","level":"error","method":"/oasis-core.RuntimeClient/Query","module":"grpc/client","msg":"request failed","req_seq":691,"rsp":{"data":null},"ts":"2023-07-17T23:08:52.727908865Z"}
{"analyzer":"evm_tokens_sapphire","caller":"client.go:179","contract_eth_addr_hex":"3d040c42f8159bfbd87a0acc436b2ed7a54955d0","err":"runtime client evm simulate call: reverted: no revert reason","interface_id":"01ffc9a7","interface_name":"ERC165","level":"info","method":"supportsInterface","module":"analysis_service","msg":"call failed","round":1909247,"ts":"2023-07-17T23:08:52.727998191Z"}
{"args":["sapphire","oasis1qzk5pr2x8ah04lgjee3lv06fmyvqvz45egjv4ps0","<nil>"],"caller":"client.go:60","db":"oasisindexer","err":"ERROR: invalid input syntax for type numeric: \"<nil>\" (SQLSTATE 22P02)","level":"error","module":"postgres","msg":"Query","pid":531279,"sql":"\n    UPDATE chain.evm_tokens\n    SET\n      total_supply = $3\n    WHERE\n      runtime = $1 AND\n      token_address = $2","time":"18.382251ms","ts":"2023-07-17T23:08:52.766526348Z"}
{"analyzer":"evm_tokens_sapphire","caller":"evm_tokens.go:252","err":"sending batch: query 0 &{\n    UPDATE chain.evm_tokens\n    SET\n      total_supply = $3\n    WHERE\n      runtime = $1 AND\n      token_address = $2 [sapphire oasis1qzk5pr2x8ah04lgjee3lv06fmyvqvz45egjv4ps0 <nil>]}: ERROR: invalid input syntax for type numeric: \"<nil>\" (SQLSTATE 22P02)","level":"error","module":"analysis_service","msg":"error processing batch","ts":"2023-07-17T23:08:52.768619337Z"}
```

This PR adds an additional check to handle valid cases where an ERC721 token supports `isEnumerable` but the actual `totalSupply` call fails for some reason. When this happens we should still return a non-nil `mutableData` (and not kick out early in case we add more fields to `mutableData` in the future).