### PR TITLE
[api] return evm address instead of oasis addr in RuntimeEvmBalance

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1740,15 +1740,19 @@ components:
     RuntimeEvmBalance:
       description: Balance of an account for a specific runtime and EVM token.
       type: object
-      required: [balance, token_contract_addr, token_decimals, token_type]
+      required: [balance, token_contract_addr, token_contract_addr_eth, token_decimals, token_type]
       properties:
         balance:
           <<: *BigIntType
           description: Number of tokens held, in base units.
         token_contract_addr:
           type: string
-          description: The EVM address of this token's contract. Encoded as a lowercase hex string.
-          example: 'dc19a122e268128b5ee20366299fc7b5b199c8e3'
+          description: The oasis address of this token's contract.
+          example: 'oasis1qzk5pr2x8ah04lgjee3lv06fmyvqvz45egjv4ps0'
+        token_contract_addr_eth:
+          type: string
+          description: The EVM address of this token's contract.
+          example: '0xF8E3DE55D24D13607A12628E0A113B66BA578bDC'
         token_symbol:
           type: string
           description: The token ticker symbol. Not guaranteed to be unique across distinct EVM tokens.

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1393,9 +1393,11 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 
 	for runtimeEvmRows.Next() {
 		b := RuntimeEvmBalance{}
+		var addrPreimage []byte
 		if err = runtimeEvmRows.Scan(
 			&b.Balance,
 			&b.TokenContractAddr,
+			&addrPreimage,
 			&b.TokenSymbol,
 			&b.TokenName,
 			&b.TokenType,
@@ -1403,6 +1405,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 		); err != nil {
 			return nil, wrapError(err)
 		}
+		b.TokenContractAddrEth = ethCommon.BytesToAddress(addrPreimage).String()
 		a.EvmBalances = append(a.EvmBalances, b)
 	}
 

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -525,6 +525,7 @@ const (
 		SELECT
 			balances.balance AS balance,
 			balances.token_address AS token_address,
+			preimages.address_data AS token_address_eth,
 			tokens.symbol AS token_symbol,
 			tokens.token_name AS token_name,
 			CASE -- NOTE: There are three queries that use this CASE via copy-paste; edit both if changing.
@@ -534,6 +535,7 @@ const (
 			END AS token_type,
 			tokens.decimals AS token_decimals
 		FROM chain.evm_token_balances AS balances
+		JOIN chain.address_preimages AS preimages ON (preimages.address = balances.token_address AND preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND preimages.context_version = 0)
 		JOIN chain.evm_tokens         AS tokens USING (runtime, token_address)
 		WHERE runtime = $1 AND
 			balances.account_address = $2::text AND


### PR DESCRIPTION
According to the [openapi spec](https://github.com/oasisprotocol/nexus/blob/main/api/spec/v1.yaml#L1748), the token_contract_address in `RuntimeEvmBalance` should be the EVM address and not the oasis address. 

Need to confirm with explorer team that the currently returned oasis address can be replaced by the evm address. If not, we can return both the oasis and evm addresses (though the oasis address can be derived from the eth address).