### PR TITLE
Andrew7234/evmtokens api

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2493,7 +2493,7 @@ components:
 
     EvmToken:
       type: object
-      required: [contract_addr, num_holders, type]
+      required: [contract_addr, eth_contract_addr, num_holders, type, verified]
       properties:
         contract_addr:
           type: string
@@ -2534,6 +2534,10 @@ components:
           description: |
             The number of addresses that have a nonzero balance of this token.
           example: 123
+        verified:
+          type: boolean
+          description: Whether the contract has been successfully verified by Sourcify.
+          example: false
 
     AccountStats:
       type: object

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1498,11 +1498,12 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 			&t.TotalSupply,
 			&t.Type,
 			&t.NumHolders,
+			&t.Verified,
 		); err2 != nil {
 			return nil, wrapError(err2)
 		}
 
-		t.EthContractAddr = common.Ptr(ethCommon.BytesToAddress(addrPreimage).String())
+		t.EthContractAddr = ethCommon.BytesToAddress(addrPreimage).String()
 		ts.EvmTokens = append(ts.EvmTokens, t)
 	}
 

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1393,9 +1393,10 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 
 	for runtimeEvmRows.Next() {
 		b := RuntimeEvmBalance{}
+		var addrPreimage []byte
 		if err = runtimeEvmRows.Scan(
 			&b.Balance,
-			&b.TokenContractAddr,
+			&addrPreimage,
 			&b.TokenSymbol,
 			&b.TokenName,
 			&b.TokenType,
@@ -1403,6 +1404,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 		); err != nil {
 			return nil, wrapError(err)
 		}
+		b.TokenContractAddr = ethCommon.BytesToAddress(addrPreimage).String()
 		a.EvmBalances = append(a.EvmBalances, b)
 	}
 

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -478,10 +478,15 @@ const (
 				WHEN tokens.token_type = 721 THEN 'ERC721'
 				ELSE 'unexpected_other_type' -- Our openapi spec doesn't allow us to output this, but better this than a null value (which causes nil dereference)
 			END AS type,
-			holders.cnt AS num_holders
+			holders.cnt AS num_holders,
+			CASE
+				WHEN contracts.verification_info_downloaded_at IS NOT NULL THEN TRUE
+				ELSE FALSE
+			END AS verified 
 		FROM chain.evm_tokens AS tokens
 		JOIN chain.address_preimages AS preimages ON (token_address = preimages.address)
 		JOIN holders USING (token_address)
+		LEFT JOIN chain.evm_contracts as contracts ON (tokens.runtime = contracts.runtime AND tokens.token_address = contracts.contract_address)
 		WHERE
 			(tokens.runtime = $1) AND
 			($2::oasis_addr IS NULL OR tokens.token_address = $2::oasis_addr) AND

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -521,7 +521,7 @@ const (
 	AccountRuntimeEvmBalances = `
 		SELECT
 			balances.balance AS balance,
-			balances.token_address AS token_address,
+			preimages.address_data AS token_address,
 			tokens.symbol AS token_symbol,
 			tokens.token_name AS token_name,
 			CASE -- NOTE: There are two queries that use this CASE via copy-paste; edit both if changing.
@@ -531,6 +531,7 @@ const (
 			END AS token_type,
 			tokens.decimals AS token_decimals
 		FROM chain.evm_token_balances AS balances
+		JOIN chain.address_preimages AS preimages ON (preimages.address = balances.token_address AND preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND preimages.context_version = 0)
 		JOIN chain.evm_tokens         AS tokens USING (runtime, token_address)
 		WHERE runtime = $1 AND
 			balances.account_address = $2::text AND


### PR DESCRIPTION
From slack: 
```When listing tokens via the /:runtime/evm_tokens, we need as part of the EvmToken object:
  - data about the underlying token contract:
    - eth address
    - verification status (we only need a boolean, not the whole data structure)```