### PR TITLE
update total_supply to accept negative updates

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -471,7 +471,7 @@ var (
       VALUES ($1, $2, $3, $4)
     ON CONFLICT (runtime, token_address) DO NOTHING`
 
-	RuntimeEVMTokenAnalysisMutateInsert = `
+	RuntimeEVMTokenAnalysisMutateUpsert = `
     INSERT INTO analysis.evm_tokens (runtime, token_address, total_supply, last_mutate_round)
       VALUES ($1, $2, $3, $4)
     ON CONFLICT (runtime, token_address) DO

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -291,7 +291,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			totalSupply = possibleToken.TotalSupplyChange.String()
 		}
 		if possibleToken.Mutated {
-			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateInsert, m.runtime, addr, totalSupply, data.Header.Round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateUpsert, m.runtime, addr, totalSupply, data.Header.Round)
 		} else {
 			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.runtime, addr, totalSupply, data.Header.Round)
 		}

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -186,14 +186,19 @@ CREATE TABLE chain.evm_tokens
   token_name TEXT,
   symbol TEXT,
   decimals INTEGER,
-  total_supply uint_numeric
+  -- NOT an uint because a non-conforming token contract could issue a fake burn event,
+  -- causing a negative dead-reckoned total_supply.
+  total_supply uint_numeric -- changed to NUMERIC(1000,0) in 09_evm_token_total_supply.up.sql
 );
 
 CREATE TABLE chain.evm_token_analysis  -- Moved to analysis.evm_tokens in 06_analysis_schema.up.sql
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
-  total_supply uint_numeric, -- Dead reckons total_supply before token is downloaded.
+  -- Dead-reckoned total_supply before token metadata is downloaded. 
+  -- NOT an uint because a non-conforming token contract could issue a fake burn event,
+  -- causing a negative dead-reckoned total_supply.
+  total_supply uint_numeric, -- changed to NUMERIC(1000,0) in 09_evm_token_total_supply.up.sql
   PRIMARY KEY (runtime, token_address),
   -- Block analyzer bumps this when it sees the mutable fields of the token
   -- change (e.g. total supply) based on dead reckoning.

--- a/storage/migrations/09_evm_token_total_supply.up.sql
+++ b/storage/migrations/09_evm_token_total_supply.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE analysis.evm_tokens ALTER COLUMN total_supply type NUMERIC(1000,0);
+ALTER TABLE chain.evm_tokens ALTER COLUMN total_supply type NUMERIC(1000,0);
+
+COMMIT;


### PR DESCRIPTION
The testnet sapphire indexers stalled at block 2025715 due to 
`{"args":["sapphire","oasis1qqlhksazqvm5tgt9pr3csf6dzmgy9d904qpza6vy","-1",2025715],"caller":"client.go:60","db":"oasisindexer","err":"ERROR: value for domain uint_numeric violates check constraint \"uint_numeric_check\" (SQLSTATE 23514)","level":"error","module":"postgres","msg":"Query","pid":119862,"sql":"\n    INSERT INTO analysis.evm_tokens (runtime, token_address, total_supply, last_mutate_round)\n      VALUES ($1, $2, $3, $4)\n    ON CONFLICT (runtime, token_address) DO\n      UPDATE SET \n        total_supply = analysis.evm_tokens.total_supply + $3,\n        last_mutate_round = excluded.last_mutate_round","time":"1.929012ms","ts":"2023-07-28T09:55:42.734831909Z"}`

The underlying cause was that the `total_supply` column in `analysis.evm_tokens` was enforcing a non-negative constraint that was violated when applying a negative total_supply update. Note that the final `total_supply` was still nonnegative - but psql does type checking on the arguments of `insert .... on conflict do update set ...` and this caused the error. Also note that `chain.evm_tokens.total_supply` is still a `uint_numeric` with the built-in nonnegative check.

Already applied to {staging, prod} x {testnet, mainnet}. 