### PR TITLE
bugfix: initialize possibleToken fields

### DIFF
--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -37,7 +37,7 @@ const NativeRuntimeTokenAddress = "oasis1runt1menat1vet0ken000000000000000000000
 
 type EVMPossibleToken struct {
 	Mutated           bool
-	TotalSupplyChange *big.Int
+	TotalSupplyChange big.Int
 }
 
 type EVMTokenData struct {

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -808,7 +808,9 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						eventData.RelatedAddresses[approvedAddr] = true
 					}
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
-						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
+						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{
+							TotalSupplyChange: &big.Int{},
+						}
 					}
 					tokenID := &big.Int{}
 					tokenID.SetBytes(tokenIDU256)
@@ -851,7 +853,9 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						eventData.RelatedAddresses[operatorAddr] = true
 					}
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
-						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
+						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{
+							TotalSupplyChange: &big.Int{},
+						}
 					}
 					approved := approvedBool[31] != 0
 					eventData.EvmLogName = evmabi.ERC721.Events["ApprovalForAll"].Name

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -751,9 +751,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					}
 					// TODO: Reckon ownership.
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
-						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{
-							TotalSupplyChange: &big.Int{},
-						}
+						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
 					}
 					// Mark as mutated if transfer is between zero address
 					// and nonzero address (either direction) and nonzero
@@ -761,12 +759,12 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					// burn.
 					if fromZero && !toZero && tokenID.Cmp(&big.Int{}) != 0 {
 						pt := blockData.PossibleTokens[eventAddr]
-						pt.TotalSupplyChange.Add(pt.TotalSupplyChange, big.NewInt(1))
+						pt.TotalSupplyChange.Add(&pt.TotalSupplyChange, big.NewInt(1))
 						pt.Mutated = true
 					}
 					if !fromZero && toZero && tokenID.Cmp(&big.Int{}) != 0 {
 						pt := blockData.PossibleTokens[eventAddr]
-						pt.TotalSupplyChange.Sub(pt.TotalSupplyChange, big.NewInt(1))
+						pt.TotalSupplyChange.Sub(&pt.TotalSupplyChange, big.NewInt(1))
 						pt.Mutated = true
 					}
 					eventData.EvmLogName = evmabi.ERC721.Events["Transfer"].Name
@@ -808,9 +806,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						eventData.RelatedAddresses[approvedAddr] = true
 					}
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
-						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{
-							TotalSupplyChange: &big.Int{},
-						}
+						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
 					}
 					tokenID := &big.Int{}
 					tokenID.SetBytes(tokenIDU256)
@@ -853,9 +849,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						eventData.RelatedAddresses[operatorAddr] = true
 					}
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
-						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{
-							TotalSupplyChange: &big.Int{},
-						}
+						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
 					}
 					approved := approvedBool[31] != 0
 					eventData.EvmLogName = evmabi.ERC721.Events["ApprovalForAll"].Name

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -286,10 +286,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 
 	// Insert EVM token addresses.
 	for addr, possibleToken := range data.PossibleTokens {
-		totalSupply := "0"
-		if possibleToken.TotalSupplyChange != nil {
-			totalSupply = possibleToken.TotalSupplyChange.String()
-		}
+		totalSupply := possibleToken.TotalSupplyChange.String()
 		if possibleToken.Mutated {
 			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateUpsert, m.runtime, addr, totalSupply, data.Header.Round)
 		} else {
@@ -298,12 +295,12 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		// Dead reckon total_supply because it's optional for ERC721 contracts.
 		// If the evm_tokens analyzer is able to fetch the total supply from the node,
 		// it will supersede this.
-		if possibleToken.TotalSupplyChange != nil && possibleToken.TotalSupplyChange.Cmp(&big.Int{}) != 0 {
+		if possibleToken.TotalSupplyChange.Cmp(&big.Int{}) != 0 {
 			batch.Queue(
 				queries.RuntimeEVMTokenTotalSupplyChangeUpdate,
 				m.runtime,
 				addr,
-				possibleToken.TotalSupplyChange.String(),
+				totalSupply,
 			)
 		}
 	}

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -286,11 +286,11 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 
 	// Insert EVM token addresses.
 	for addr, possibleToken := range data.PossibleTokens {
-		totalSupply := possibleToken.TotalSupplyChange.String()
+		totalSupplyChange := possibleToken.TotalSupplyChange.String()
 		if possibleToken.Mutated {
-			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateUpsert, m.runtime, addr, totalSupply, data.Header.Round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateUpsert, m.runtime, addr, totalSupplyChange, data.Header.Round)
 		} else {
-			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.runtime, addr, totalSupply, data.Header.Round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.runtime, addr, totalSupplyChange, data.Header.Round)
 		}
 		// Dead reckon total_supply because it's optional for ERC721 contracts.
 		// If the evm_tokens analyzer is able to fetch the total supply from the node,
@@ -300,7 +300,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 				queries.RuntimeEVMTokenTotalSupplyChangeUpdate,
 				m.runtime,
 				addr,
-				totalSupply,
+				totalSupplyChange,
 			)
 		}
 	}


### PR DESCRIPTION
The analyzer crashed with 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x64bc9d]

goroutine 127299 [running]:
math/big.(*Int).Add(0x0, 0x1?, 0xc0000ab2f0?)
	/usr/local/go/src/math/big/int.go:116 +0x1d
github.com/oasisprotocol/nexus/analyzer/runtime.extractEvents.func4.3({0xc000644b0c, 0x14, 0x14}, {0xc000644b2c, 0x14, 0x14}, {0xc000644b40?, 0xc000602858?, 0x69fab4?})
	/code/go/analyzer/runtime/extract.go:764 +0x5e5
github.com/oasisprotocol/nexus/analyzer/runtime.VisitEVMEvent(0xc0000a5b30, 0xc000602e08)
	/code/go/analyzer/runtime/visitors.go:215 +0x7b9
github.com/oasisprotocol/nexus/analyzer/runtime.extractEvents.func4(0xc0000a5b30)
	/code/go/analyzer/runtime/extract.go:633 +0x456
github.com/oasisprotocol/nexus/analyzer/runtime.VisitSdkEvent(0x8?, 0xc000603220)
	/code/go/analyzer/runtime/visitors.go:148 +0x531
github.com/oasisprotocol/nexus/analyzer/runtime.VisitSdkEvents({0xc000456e00, 0x2, 0x0?}, 0xc000603218?)
	/code/go/analyzer/runtime/visitors.go:158 +0x68
github.com/oasisprotocol/nexus/analyzer/runtime.extractEvents(0xc00054be48?, 0xc000311900?, {0xc000456e00?, 0x2?, 0x6?})
	/code/go/analyzer/runtime/extract.go:529 +0x135
github.com/oasisprotocol/nexus/analyzer/runtime.ExtractRound({0x0, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...}, ...)
	/code/go/analyzer/runtime/extract.go:472 +0x13e7
github.com/oasisprotocol/nexus/analyzer/runtime.(*processor).ProcessBlock(0xc000526230, {0x18e98c0, 0xc000b0c1e0}, 0xc00048e700?)
	/code/go/analyzer/runtime/runtime.go:116 +0x259
github.com/oasisprotocol/nexus/analyzer/block.(*blockBasedAnalyzer).Start(0xc0005262d0, {0x18e9850, 0xc00030f7c0})
	/code/go/analyzer/block/block.go:240 +0x951
github.com/oasisprotocol/nexus/cmd/analyzer.(*Service).Start.func1({0x18e3318?, 0xc0005262d0?})
	/code/go/cmd/analyzer/analyzer.go:387 +0x71
created by github.com/oasisprotocol/nexus/cmd/analyzer.(*Service).Start
```

The root cause was that the totalSupplyChange could be nil if a previously processed ERC721Approval or ERC721ApprovalForAll event in the block initialized `possibleToken.TotalSupplyChange` to `nil`. 

Todo:
Might be better to change `possibleToken.TotalSupplyChange` to not be a pointer since we [default to 0 anyway](https://github.com/oasisprotocol/nexus/blob/803ca11501cfbf0c75917afc6ee620f4e228d9c6/analyzer/runtime/runtime.go#L289)... but big.Int uses pointer receiver methods.
```
type EVMPossibleToken struct {
	Mutated           bool
	TotalSupplyChange big.Int
}
```

Testing... wasn't able to connect to a mainnet sapphire grpc endpoint yet locally (only testnet). 