### PR TITLE
add index for chain.addres_preimages.address_data

### DIFF
--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -413,7 +413,9 @@ const (
 			tokens.decimals
 		FROM chain.runtime_events as evs
 		LEFT JOIN chain.address_preimages AS preimages ON
-			DECODE(evs.body ->> 'address', 'base64')=preimages.address_data
+			DECODE(evs.body ->> 'address', 'base64')=preimages.address_data AND
+			preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			preimages.context_version = 0
 		LEFT JOIN chain.evm_tokens as tokens ON
 			(evs.runtime=tokens.runtime) AND
 			(preimages.address=tokens.token_address)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -412,6 +412,9 @@ const (
 			END AS token_type,
 			tokens.decimals
 		FROM chain.runtime_events as evs
+		-- Look up the oasis-style address derived from evs.body.address.
+		-- The derivation is just a keccak hash and we could theoretically compute it instead of looking it up,
+		-- but the implementing/importing the right hash function in postgres would take some work.
 		LEFT JOIN chain.address_preimages AS preimages ON
 			DECODE(evs.body ->> 'address', 'base64')=preimages.address_data AND
 			preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -141,10 +141,15 @@ CREATE INDEX ix_runtime_events_evm_log_params ON chain.runtime_events USING gin(
 -- we've encountered the preimage before to find out what the address was
 -- derived from.
 --
--- If you need to go the other way, from context + data to address, you'd just
--- run the derivation. Thus we don't provide an index for going that way. See
--- oasis-core/go/common/crypto/address/address.go for details. Consider
--- inserting the preimage here if you're ingesting new blockchain data though.
+-- If you need to go the other way, from context + data to address, you'd 
+-- normally just run the derivation. See oasis-core/go/common/crypto/address/address.go
+-- for details. Consider inserting the preimage here if you're ingesting new 
+-- blockchain data though.
+--
+-- However, we do provide an index going the other way because certain queries 
+-- require computing the derivation within Postgres and implementing/importing 
+-- the right hash function will take some work. 
+-- TODO: import keccak hash into postgres
 --
 -- Retain this across hard forks as long as the address derivation scheme is
 -- compatible.
@@ -162,6 +167,9 @@ CREATE TABLE chain.address_preimages
   -- Ethereum address. For a "staking" context, this is the ed25519 pubkey.
   address_data       BYTEA NOT NULL
 );
+-- Added in 10_runtime_address_preimage_idx.up.sql
+-- CREATE INDEX IF NOT EXISTS ix_address_preimages_address_data ON chain.address_preimages (address_data) 
+--     WHERE context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND context_version = 0;
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- Module evm -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -144,12 +144,12 @@ CREATE INDEX ix_runtime_events_evm_log_params ON chain.runtime_events USING gin(
 -- If you need to go the other way, from context + data to address, you'd 
 -- normally just run the derivation. See oasis-core/go/common/crypto/address/address.go
 -- for details. Consider inserting the preimage here if you're ingesting new 
--- blockchain data though.
+-- blockchain data.
 --
 -- However, we do provide an index going the other way because certain queries 
 -- require computing the derivation within Postgres and implementing/importing 
--- the right hash function will take some work. 
--- TODO: import keccak hash into postgres
+-- the right hash function will take some work.
+-- TODO: import keccak hash into postgres.
 --
 -- Retain this across hard forks as long as the address derivation scheme is
 -- compatible.

--- a/storage/migrations/10_runtime_address_preimage_idx.up.sql
+++ b/storage/migrations/10_runtime_address_preimage_idx.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Note: We use `IF NOT EXISTS` because the index has already been added manually in some places.
+CREATE INDEX IF NOT EXISTS ix_address_preimages_address_data ON chain.address_preimages (address_data) 
+    WHERE context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND 
+        context_version = 0;
+
+COMMIT;


### PR DESCRIPTION
@lukaw3d pointed out that the `/events` endpoint was slow. Root cause was the left join on `address_preimages` in order to look up token-specific information for events. 