### PR TITLE
Adjust chain.runtime_events indexes

### DIFF
--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -97,7 +97,7 @@ CREATE TABLE chain.runtime_related_transactions
   tx_index        UINT31 NOT NULL,
   FOREIGN KEY (runtime, tx_round, tx_index) REFERENCES chain.runtime_transactions(runtime, round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX ix_runtime_related_transactions_address ON chain.runtime_related_transactions (runtime, account_address);
+CREATE INDEX ix_runtime_related_transactions_address ON chain.runtime_related_transactions (runtime, account_address); -- Removed in 13_runtime_indexes.up.sql
 CREATE INDEX ix_runtime_related_transactions_round_index ON chain.runtime_related_transactions (runtime, tx_round, tx_index);
 CREATE INDEX ix_runtime_related_transactions_address_round_index ON chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index);
 
@@ -129,10 +129,10 @@ CREATE TABLE chain.runtime_events
   evm_log_signature BYTEA CHECK (octet_length(evm_log_signature) = 32)
 );
 CREATE INDEX ix_runtime_events_round ON chain.runtime_events(runtime, round);  -- for sorting by round, when there are no filters applied
-CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events(tx_hash);
-CREATE INDEX ix_runtime_events_tx_eth_hash ON chain.runtime_events(tx_eth_hash);
-CREATE INDEX ix_runtime_events_related_accounts ON chain.runtime_events USING gin(related_accounts);
-CREATE INDEX ix_runtime_events_evm_log_signature ON chain.runtime_events(evm_log_signature);
+CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events/*USING hash */(tx_hash); -- updated in 13_runtime_indexes.up.sql
+CREATE INDEX ix_runtime_events_tx_eth_hash ON chain.runtime_events/*USING hash */(tx_eth_hash); -- updated in 13_runtime_indexes.up.sql
+CREATE INDEX ix_runtime_events_related_accounts ON chain.runtime_events USING gin(related_accounts); -- for fetching account activity for a given account
+CREATE INDEX ix_runtime_events_evm_log_signature ON chain.runtime_events(/* runtime, */evm_log_signature/*, round*/); -- for fetching a certain event type, eg Transfers; updated in 13_runtime_indexes.up.sql
 CREATE INDEX ix_runtime_events_evm_log_params ON chain.runtime_events USING gin(evm_log_params);
 
 -- Oasis addresses are derived from a derivation "context" and a piece of

--- a/storage/migrations/13_runtime_indexes.up.sql
+++ b/storage/migrations/13_runtime_indexes.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DROP INDEX chain.ix_runtime_related_transactions_address; -- This index is a prefix of an existing index and therefore unnecessary
+
+DROP INDEX chain.ix_runtime_events_tx_hash;
+DROP INDEX chain.ix_runtime_events_tx_eth_hash;
+DROP INDEX chain.ix_runtime_events_evm_log_signature;
+
+CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events USING hash (tx_hash);
+CREATE INDEX ix_runtime_events_tx_eth_hash ON chain.runtime_events USING hash (tx_eth_hash);
+CREATE INDEX ix_runtime_events_evm_log_signature ON chain.runtime_events(runtime, evm_log_signature, round);
+
+COMMIT;


### PR DESCRIPTION
@lukaw3d found that the `/events` endpoint was slow when a related account was not specified in the query (`rel=oasis12345`). The `explain analyze` of the query:

```
oasisindexer=*> explain analyze SELECT
            evs.round,
            evs.tx_index,
            evs.tx_hash,
            evs.tx_eth_hash,
            evs.timestamp,
            evs.type,
            evs.body,
            evs.evm_log_name,
            evs.evm_log_params,
            tokens.symbol,
            CASE -- NOTE: There are three queries that use this CASE via copy-paste; edit both if changing.
                WHEN tokens.token_type = 20 THEN 'ERC20'
                WHEN tokens.token_type = 721 THEN 'ERC721'
                ELSE NULL -- Our openapi spec doesn't allow us to output this, but better this than a null value (which causes nil dereference)
            END AS token_type,
            tokens.decimals
        FROM chain.runtime_events as evs
        -- Look up the oasis-style address derived from evs.body.address.
        -- The derivation is just a keccak hash and we could theoretically compute it instead of looking it up,
        -- but the implementing/importing the right hash function in postgres would take some work.
        LEFT JOIN chain.address_preimages AS preimages ON
            DECODE(evs.body ->> 'address', 'base64')=preimages.address_data AND
            preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
            preimages.context_version = 0
        LEFT JOIN chain.evm_tokens as tokens ON
            (evs.runtime=tokens.runtime) AND
            (preimages.address=tokens.token_address)
        WHERE evs.runtime='sapphire' and evs.evm_log_signature=decode('ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', 'hex') order by evs.round desc, evs.tx_index, evs.type, evs.body::text limit 1000 offset 0;

Limit  (cost=1075.95..10567.32 rows=1000 width=723) (actual time=23671.368..23673.820 rows=85 loops=1)
   ->  Nested Loop Left Join  (cost=1075.95..2688767.17 rows=283172 width=723) (actual time=23671.366..23673.808 rows=85 loops=1)
         Join Filter: ((evs.runtime = tokens.runtime) AND ((preimages.address)::text = (tokens.token_address)::text))
         ->  Gather Merge  (cost=1075.68..2680973.89 rows=283172 width=699) (actual time=23671.305..23673.486 rows=85 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Incremental Sort  (cost=75.65..2647288.79 rows=117988 width=699) (actual time=22244.970..23642.661 rows=28 loops=3)
                     Sort Key: evs.round DESC, evs.tx_index, evs.type, ((evs.body)::text)
                     Presorted Key: evs.round
                     Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 85kB  Peak Memory: 85kB
                     Worker 0:  Full-sort Groups: 2  Sort Method: quicksort  Average Memory: 89kB  Peak Memory: 89kB
                     Worker 1:  Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 67kB  Peak Memory: 67kB
                     ->  Nested Loop Left Join  (cost=0.98..2642904.24 rows=117988 width=699) (actual time=719.131..23641.814 rows=28 loops=3)
                           ->  Parallel Index Scan Backward using ix_runtime_events_round on runtime_events evs  (cost=0.56..1782310.29 rows=117988 width=652) (actual time=717.539..23635.467 rows=28 loops=3)
                                 Index Cond: (runtime = 'sapphire'::runtime)
                                 Filter: (evm_log_signature = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'::bytea)
                                 Rows Removed by Filter: 372147
                           ->  Index Scan using ix_address_preimages_address_data on address_preimages preimages  (cost=0.42..7.28 rows=1 width=69) (actual time=0.206..0.207 rows=1 loops=85)
                                 Index Cond: (address_data = decode((evs.body ->> 'address'::text), 'base64'::text))
                                 Filter: ((context_identifier = 'oasis-runtime-sdk/address: secp256k1eth'::text) AND ((context_version)::integer = 0))
         ->  Materialize  (cost=0.28..6.05 rows=1 width=66) (actual time=0.001..0.001 rows=0 loops=85)
               ->  Index Scan using evm_tokens_pkey on evm_tokens tokens  (cost=0.28..6.04 rows=1 width=66) (actual time=0.045..0.045 rows=0 loops=1)
                     Index Cond: (runtime = 'sapphire'::runtime)
 Planning Time: 4.599 ms
 Execution Time: 23674.186 ms
```

The issue is that postgres is scanning backwards by round and filtering by `evm_log_signature`, and is not using the existing index on `evm_log_signature` because of the `order by round desc`. This PR updates the index to be more useful to the query. No other queries use this index.

New timings
```
 Limit  (cost=1063.44..6580.68 rows=1000 width=686) (actual time=63.622..219.231 rows=348 loops=1)
   ->  Nested Loop Left Join  (cost=1063.44..1529621.18 rows=277051 width=686) (actual time=63.620..219.173 rows=348 loops=1)
         Join Filter: ((evs.runtime = tokens.runtime) AND ((preimages.address)::text = (tokens.token_address)::text))
         Rows Removed by Join Filter: 3757
         ->  Gather Merge  (cost=1058.94..1391053.60 rows=277051 width=663) (actual time=63.521..216.633 rows=348 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Incremental Sort  (cost=58.92..1358075.02 rows=115438 width=663) (actual time=35.149..95.806 rows=116 loops=3)
                     Sort Key: evs.round DESC, evs.tx_index, evs.type, ((evs.body)::text)
                     Presorted Key: evs.round
                     Full-sort Groups: 3  Sort Method: quicksort  Average Memory: 91kB  Peak Memory: 91kB
                     Worker 0:  Full-sort Groups: 5  Sort Method: quicksort  Average Memory: 123kB  Peak Memory: 132kB
                       Pre-sorted Groups: 9  Sort Method: quicksort  Average Memory: 54kB  Peak Memory: 277kB
                     Worker 1:  Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 27kB  Peak Memory: 27kB
                     ->  Nested Loop Left Join  (cost=1.00..1353520.19 rows=115438 width=663) (actual time=4.419..91.201 rows=116 loops=3)
                           ->  Parallel Index Scan Backward using ix_runtime_events_evm_log_signature on runtime_events evs  (cost=0.56..525875.96 rows=115438 width=616) (actual time=1.611..69.041 rows=116 loops=3)
                                 Index Cond: ((runtime = 'sapphire'::runtime) AND (evm_log_signature = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'::bytea))
                           ->  Index Scan using ix_address_preimages_address_data on address_preimages preimages  (cost=0.43..7.16 rows=1 width=68) (actual time=0.182..0.182 rows=1 loops=348)
                                 Index Cond: (address_data = decode((evs.body ->> 'address'::text), 'base64'::text))
                                 Filter: ((context_identifier = 'oasis-runtime-sdk/address: secp256k1eth'::text) AND ((context_version)::integer = 0))
         ->  Materialize  (cost=4.49..42.15 rows=28 width=65) (actual time=0.000..0.001 rows=12 loops=348)
               ->  Bitmap Heap Scan on evm_tokens tokens  (cost=4.49..42.01 rows=28 width=65) (actual time=0.041..0.073 rows=28 loops=1)
                     Recheck Cond: (runtime = 'sapphire'::runtime)
                     Heap Blocks: exact=4
                     ->  Bitmap Index Scan on evm_tokens_pkey  (cost=0.00..4.49 rows=28 width=0) (actual time=0.029..0.031 rows=28 loops=1)
                           Index Cond: (runtime = 'sapphire'::runtime)
 Planning Time: 3.607 ms
 Execution Time: 219.412 ms
(28 rows)
```

I also updated the tx_hash and eth_tx_hash indexes to better match the ones in `chain.runtime_transactions`