### PR TITLE
nodeapi: Make CommitteeKind compatbile across cobalt and damask

### DIFF
--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -190,7 +190,12 @@ type (
 
 type (
 	Validator scheduler.Validator
-	Committee scheduler.Committee
+	Committee struct {
+		Kind      CommitteeKind
+		Members   []*scheduler.CommitteeNode
+		RuntimeID coreCommon.Namespace
+		ValidFor  beacon.EpochTime
+	}
 )
 
 // .................... Governance ....................

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -394,7 +394,7 @@ func convertCommittee(c schedulerCobalt.Committee) nodeapi.Committee {
 		}
 	}
 	return nodeapi.Committee{
-		Kind:      scheduler.CommitteeKind(c.Kind), // We assume the enum is backwards-compatible.
+		Kind:      nodeapi.CommitteeKind(c.Kind), // The enum is compatible between Cobalt and Damask.
 		Members:   members,
 		RuntimeID: c.RuntimeID,
 		ValidFor:  c.ValidFor,

--- a/storage/oasis/nodeapi/compat_types.go
+++ b/storage/oasis/nodeapi/compat_types.go
@@ -1,0 +1,56 @@
+// The nodeapi package provides a low-level interface to the Oasis node API.
+// The types that it exposes are simplified versions of the types exposed by
+// oasis-core Damask: The top-level type structs are defined in api.go, and
+// the types of their fields are almost universally directly the types exposed
+// by oasis-core Damask. The reason is that as oasis-core evolves, Damask types
+// are mostly able to represent all the information from Cobalt, plus some.
+//
+// This file contains the exceptions to the above rule: It provides substitute
+// types for those Damask types that cannot express Cobalt information.
+
+package nodeapi
+
+import "fmt"
+
+// Copy-pasted from Cobalt; Damask does not support the "storage" kind.
+type CommitteeKind uint8
+
+const (
+	KindInvalid         CommitteeKind = 0
+	KindComputeExecutor CommitteeKind = 1
+	KindStorage         CommitteeKind = 2
+
+	// MaxCommitteeKind is a dummy value used for iterating all committee kinds.
+	MaxCommitteeKind = 3
+
+	KindInvalidName         = "invalid"
+	KindComputeExecutorName = "executor"
+	KindStorageName         = "storage"
+)
+
+// MarshalText encodes a CommitteeKind into text form.
+func (k CommitteeKind) MarshalText() ([]byte, error) {
+	switch k {
+	case KindInvalid:
+		return []byte(KindInvalidName), nil
+	case KindComputeExecutor:
+		return []byte(KindComputeExecutorName), nil
+	case KindStorage:
+		return []byte(KindStorageName), nil
+	default:
+		return nil, fmt.Errorf("invalid role: %d", k)
+	}
+}
+
+// UnmarshalText decodes a text slice into a CommitteeKind.
+func (k *CommitteeKind) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case KindComputeExecutorName:
+		*k = KindComputeExecutor
+	case KindStorageName:
+		*k = KindStorage
+	default:
+		return fmt.Errorf("invalid role: %s", string(text))
+	}
+	return nil
+}

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -174,7 +174,12 @@ func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64
 	}
 	committees := make([]nodeapi.Committee, len(rsp))
 	for i, c := range rsp {
-		committees[i] = nodeapi.Committee(*c)
+		committees[i] = nodeapi.Committee{
+			Kind:      nodeapi.CommitteeKind(c.Kind), // The enum is compatible between Cobalt and Damask.
+			Members:   c.Members,
+			RuntimeID: c.RuntimeID,
+			ValidFor:  c.ValidFor,
+		}
 	}
 	return committees, nil
 }


### PR DESCRIPTION
Bugfix for accessing cobalt state. I don't know how we didn't hit this problem before.


**Problem**
The CommitteeKind type (which is used inside committee updates at the consensus layer) is an enum, with **three** possible values in cobalt, but only **two** possible values in damask. Before this PR, we were using the damask type. So when trying to serialize an enum value that comes from cobalt and is valid in cobalt but not in damask, an error was raised.

**Solution**
This PR creates a new type that's independent of cobalt and damask (even though it's technically just copy-paste from cobalt), but is compatible with both. 
No data changes are needed (caches, db, etc). The new type is byte-compatible with the type we've been using. Just the serde methods are able to accept the extra enum value.

**Testing**
Not much because the change is minimal. Previously, some blocks just before damask failed to get indexed (because the CommitteeKind value gets serialized for insertion into the DB). After this PR, those blocks can be indexed.