### PR TITLE
Andrew7234/evm token transfers

### DIFF
--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -70,6 +70,7 @@ type StaleToken struct {
 	Addr                  string
 	LastDownloadRound     *uint64
 	TotalSupply           common.BigInt
+	NumTransfers          uint64
 	Type                  *evm.EVMTokenType
 	AddrContextIdentifier string
 	AddrContextVersion    int
@@ -91,6 +92,7 @@ func (m main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, err
 			&staleToken.Addr,
 			&staleToken.LastDownloadRound,
 			&totalSupply,
+			&staleToken.NumTransfers,
 			&staleToken.Type,
 			&staleToken.AddrContextIdentifier,
 			&staleToken.AddrContextVersion,
@@ -147,6 +149,7 @@ func (m main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			tokenData.Symbol,
 			tokenData.Decimals,
 			totalSupply,
+			staleToken.NumTransfers,
 		)
 	} else if *staleToken.Type != evm.EVMTokenTypeUnsupported {
 		mutable, err := evm.EVMDownloadMutatedToken(
@@ -161,7 +164,7 @@ func (m main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			return fmt.Errorf("downloading mutated token %s: %w", staleToken.Addr, err)
 		}
 		if mutable != nil && mutable.TotalSupply != nil {
-			batch.Queue(queries.RuntimeEVMTokenUpdate,
+			batch.Queue(queries.RuntimeEVMTokenTotalSupplyUpdate,
 				m.runtime,
 				staleToken.Addr,
 				mutable.TotalSupply.String(),

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -36,8 +36,9 @@ const (
 const NativeRuntimeTokenAddress = "oasis1runt1menat1vet0ken0000000000000000000000"
 
 type EVMPossibleToken struct {
-	Mutated           bool
-	TotalSupplyChange big.Int
+	Mutated            bool
+	TotalSupplyChange  big.Int
+	NumTransfersChange uint64
 }
 
 type EVMTokenData struct {

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -655,6 +655,8 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
 						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
 					}
+					// Mints, burns, and zero-value transfers all count as transfers.
+					blockData.PossibleTokens[eventAddr].NumTransfersChange++
 					// Mark as mutated if transfer is between zero address
 					// and nonzero address (either direction) and nonzero
 					// amount. These will change the total supply as mint/
@@ -753,6 +755,8 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					if _, ok := blockData.PossibleTokens[eventAddr]; !ok {
 						blockData.PossibleTokens[eventAddr] = &evm.EVMPossibleToken{}
 					}
+					// Mints, burns, and zero-value transfers all count as transfers.
+					blockData.PossibleTokens[eventAddr].NumTransfersChange++
 					// Mark as mutated if transfer is between zero address
 					// and nonzero address (either direction) and nonzero
 					// amount. These will change the total supply as mint/

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2537,6 +2537,11 @@ components:
         total_supply:
           <<: *BigIntType
           description: The total number of base units available.
+        num_transfers:
+          type: integer
+          format: int64
+          description: |
+            The total number of transfers of this token.
         num_holders:
           type: integer
           format: int64

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1498,6 +1498,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 			&t.Symbol,
 			&t.Decimals,
 			&t.TotalSupply,
+			&t.NumTransfers,
 			&t.Type,
 			&t.NumHolders,
 			&t.IsVerified,

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -482,6 +482,7 @@ const (
 			tokens.symbol,
 			tokens.decimals,
 			tokens.total_supply,
+			tokens.num_transfers,
 			CASE -- NOTE: There are three queries that use this CASE via copy-paste; edit both if changing.
 				WHEN tokens.token_type = 20 THEN 'ERC20'
 				WHEN tokens.token_type = 721 THEN 'ERC721'

--- a/storage/migrations/14_evm_token_transfers.up.sql
+++ b/storage/migrations/14_evm_token_transfers.up.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+ALTER TABLE chain.evm_tokens ADD COLUMN num_transfers UINT63 NOT NULL DEFAULT 0;
+ALTER TABLE analysis.evm_tokens ADD COLUMN num_transfers UINT63 NOT NULL DEFAULT 0;
+
+-- Backfill chain.evm_tokens.num_transfers
+WITH transfers AS (
+    SELECT runtime, DECODE(body ->> 'address', 'base64') AS eth_addr, COUNT(*) AS num_xfers
+        FROM chain.runtime_events
+        GROUP BY runtime, eth_addr
+)
+UPDATE chain.evm_tokens as tokens
+    SET num_transfers = transfers.num_xfers
+    FROM transfers
+    LEFT JOIN chain.address_preimages as preimages 
+    ON
+        preimages.address_data = transfers.eth_addr AND
+        preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+        preimages.context_version = 0
+    WHERE
+        tokens.runtime = transfers.runtime AND
+        tokens.token_address = preimages.address;
+
+-- Backfill analysis.evm_tokens.num_transfers for tokens that haven't been processed yet.
+-- These values will be inserted into chain.evm_tokens when the token is downloaded.
+WITH transfers AS (
+    SELECT runtime, DECODE(body ->> 'address', 'base64') AS eth_addr, COUNT(*) AS num_xfers
+        FROM chain.runtime_events
+        GROUP BY runtime, eth_addr
+)
+UPDATE analysis.evm_tokens as tokens
+    SET num_transfers = transfers.num_xfers
+    FROM transfers
+    LEFT JOIN chain.address_preimages as preimages 
+    ON
+        preimages.address_data = transfers.eth_addr AND
+        preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+        preimages.context_version = 0
+    WHERE
+        tokens.runtime = transfers.runtime AND
+        tokens.token_address = preimages.address AND
+        tokens.last_download_round IS NULL;
+
+COMMIT;


### PR DESCRIPTION
https://app.clickup.com/t/8692hqtf5

Adds support for dead-reckoning `evmToken.NumTransfers` without using triggers.

The accounting in this is almost identical to how we track `evmToken.TotalSupply`, in that we maintain two dead-reckoned sums in `analysis.evmTokens` and `chain.evmTokens` for possible and confirmed evm tokens, respectively. Once the evmTokens analyzer downloads a token, it copies the value from `analysis` to `chain`.