### PR TITLE
Andrew7234/account num txs

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -337,6 +337,12 @@ var (
     INSERT INTO chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
       VALUES ($1, $2, $3, $4)`
 
+	RuntimeAccountNumTxsUpsert = `
+    INSERT INTO chain.runtime_accounts as accounts (runtime, address, num_txs)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (runtime, address) DO UPDATE
+      SET num_txs = accounts.num_txs + $3;`
+
 	RuntimeTransactionInsert = `
     INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, fee, gas_limit, gas_used, size, timestamp, method, body, "to", amount, evm_encrypted_format, evm_encrypted_public_key, evm_encrypted_data_nonce, evm_encrypted_data_data, evm_encrypted_result_nonce, evm_encrypted_result_data, success, error_module, error_code, error_message)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)`

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -178,6 +178,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		}
 		for addr := range transactionData.RelatedAccountAddresses {
 			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.runtime, addr, data.Header.Round, transactionData.Index)
+			batch.Queue(queries.RuntimeAccountNumTxsUpsert, m.runtime, addr, 1)
 		}
 		var (
 			evmEncryptedFormat      *common.CallFormat

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -464,8 +464,8 @@ const (
 				(SELECT sum(amount) from chain.runtime_transfers where runtime = $1 AND receiver = $2::text)
 				, 0) AS total_received,
 			COALESCE (
-				(SELECT count(*) from chain.runtime_related_transactions where runtime = $1 AND account_address = $2::text)
-				, 0) AS num_txns`
+				(SELECT num_txs from chain.runtime_accounts where runtime = $1 AND address = $2::text)
+				, 0) AS num_txs`
 
 	//nolint:gosec // Linter suspects a hardcoded access token.
 	EvmTokens = `

--- a/storage/migrations/15_runtime_account_stats.up.sql
+++ b/storage/migrations/15_runtime_account_stats.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE TABLE chain.runtime_accounts
+(
+    runtime runtime NOT NULL,
+    address oasis_addr NOT NULL,
+    PRIMARY KEY (runtime, address),
+
+    num_txs UINT63 NOT NULL DEFAULT 0
+);
+
+-- Backfill chain.runtime_accounts
+INSERT INTO chain.runtime_accounts (runtime, address, num_txs)
+    SELECT runtime, account_address, COUNT(*) 
+    FROM chain.runtime_related_transactions
+    GROUP BY (runtime, account_address);
+
+-- Grant others read-only use.
+GRANT SELECT ON ALL TABLES IN SCHEMA chain TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA chain TO PUBLIC;
+
+COMMIT;


### PR DESCRIPTION
https://app.clickup.com/t/863h5r3dt

tldr: the `/{runtime}/accounts/{addr}` endpoint is slow because we recalculate the account_stats.num_txs on the fly (scanning entire `runtime_related_transactions` table) for every request. 
```
InitPlan 3 (returns $2)
     ->  Aggregate  (cost=393.60..393.61 rows=1 width=8) (actual time=2636.657..2636.658 rows=1 loops=1)
           ->  Index Only Scan using ix_runtime_related_transactions_address on runtime_related_transactions  (cost=0.57..387.13 rows=2586 width=0) (actual time=5.619..2611.100 rows=235330 loops=1)
                 Index Cond: ((runtime = 'sapphire'::runtime) AND (account_address = 'oasis1qru38k694sl27t399kgn5dptdj2atn3u6v4qvkyw'::text))
                 Heap Fetches: 3000
```

This PR creates a new `stats.runtime_accounts` table, backfills it, and populates it via a trigger. Note that the trigger function is an upsert so it should be safe with the fast-sync analyzer mode.

Testing:
- Tested locally and confirmed no outward api changes. 