### PR TITLE
analyzer/runtime/consensusaccounts: Handle new client-sdk 0.6.0 event codes

### DIFF
--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -90,6 +90,30 @@ func DecodeConsensusAccountsEvent(event *nodeapi.RuntimeEvent) ([]consensusaccou
 		for _, ev := range evs {
 			events = append(events, consensusaccounts.Event{Withdraw: ev})
 		}
+	case consensusaccounts.DelegateEventCode:
+		var evs []*consensusaccounts.DelegateEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode consensus accounts delegate event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, consensusaccounts.Event{Delegate: ev})
+		}
+	case consensusaccounts.UndelegateStartEventCode:
+		var evs []*consensusaccounts.UndelegateStartEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode consensus accounts undelegate start event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, consensusaccounts.Event{UndelegateStart: ev})
+		}
+	case consensusaccounts.UndelegateDoneEventCode:
+		var evs []*consensusaccounts.UndelegateDoneEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode consensus accounts undelegate done event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, consensusaccounts.Event{UndelegateDone: ev})
+		}
 	default:
 		return nil, fmt.Errorf("invalid consensus accounts event code: %v", event.Code)
 	}

--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -12,6 +12,15 @@ import (
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
+// The methods below largely replicate the logic in the SDK's
+// DecodeEvent() functions in various client-sdk/go/modules/<module>/<module>.go.
+//
+// The main difference is that we inject the `unmarshalSingleOrArray()` call
+// instead of a simple `cbor.Unmarshal()` call. This is because early versions
+// of the SDK CBOR-encoded a single event at a time, while later versions
+// encode an array of events. We want to support both so we can index the entire
+// history.
+
 func DecodeCoreEvent(event *nodeapi.RuntimeEvent) ([]core.Event, error) {
 	if event.Module != core.ModuleName {
 		return nil, nil

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -156,7 +156,7 @@ func VisitSdkEvent(event *nodeapi.RuntimeEvent, handler *SdkEventHandler) error 
 func VisitSdkEvents(events []nodeapi.RuntimeEvent, handler *SdkEventHandler) error {
 	for i := range events {
 		if err := VisitSdkEvent(&events[i], handler); err != nil {
-			return fmt.Errorf("event %d: %w", i, err)
+			return fmt.Errorf("event %d: %w; raw event: %+v", i, err, events[i])
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds suppport for parsing (the new event codes present in) Sapphire 0.6.0 blocks; it is a follow-up to #508 which was not possible to test at the time.
It was not enough to just import the newer type definitions (as #508 did), we also had to add some handling for the new types (as this PR does).

Testing: Indexed the offending block 2_378_823 of sapphire testnet. (Now the internal testnet node is working again, so I was able to test properly.)