### PR TITLE
analyzer/runtime: Index (un)delegate events, txs

### DIFF
--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -28,7 +28,7 @@ type CallHandler struct {
 	UnknownMethod               func(methodName string) error // Invoked for a tx call that doesn't map to any of the above method names.
 }
 
-//nolint:nestif
+//nolint:nestif,gocyclo
 func VisitCall(call *sdkTypes.Call, result *sdkTypes.CallResult, handler *CallHandler) error {
 	// List of methods: See each of the SDK modules, example for consensus_accounts:
 	//   https://github.com/oasisprotocol/oasis-sdk/blob/client-sdk%2Fgo%2Fv0.6.0/client-sdk/go/modules/consensusaccounts/consensus_accounts.go#L16-L20

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -18,15 +18,20 @@ import (
 )
 
 type CallHandler struct {
-	AccountsTransfer          func(body *accounts.Transfer) error
-	ConsensusAccountsDeposit  func(body *consensusaccounts.Deposit) error
-	ConsensusAccountsWithdraw func(body *consensusaccounts.Withdraw) error
-	EVMCreate                 func(body *evm.Create, ok *[]byte) error
-	EVMCall                   func(body *evm.Call, ok *[]byte) error
+	AccountsTransfer            func(body *accounts.Transfer) error
+	ConsensusAccountsDeposit    func(body *consensusaccounts.Deposit) error
+	ConsensusAccountsWithdraw   func(body *consensusaccounts.Withdraw) error
+	ConsensusAccountsDelegate   func(body *consensusaccounts.Delegate) error
+	ConsensusAccountsUndelegate func(body *consensusaccounts.Undelegate) error
+	EVMCreate                   func(body *evm.Create, ok *[]byte) error
+	EVMCall                     func(body *evm.Call, ok *[]byte) error
+	UnknownMethod               func(methodName string) error // Invoked for a tx call that doesn't map to any of the above method names.
 }
 
 //nolint:nestif
 func VisitCall(call *sdkTypes.Call, result *sdkTypes.CallResult, handler *CallHandler) error {
+	// List of methods: See each of the SDK modules, example for consensus_accounts:
+	//   https://github.com/oasisprotocol/oasis-sdk/blob/client-sdk%2Fgo%2Fv0.6.0/client-sdk/go/modules/consensusaccounts/consensus_accounts.go#L16-L20
 	switch call.Method {
 	case "accounts.Transfer":
 		if handler.AccountsTransfer != nil {
@@ -56,6 +61,26 @@ func VisitCall(call *sdkTypes.Call, result *sdkTypes.CallResult, handler *CallHa
 			}
 			if err := handler.ConsensusAccountsWithdraw(&body); err != nil {
 				return fmt.Errorf("consensus accounts withdraw: %w", err)
+			}
+		}
+	case "consensus.Delegate":
+		if handler.ConsensusAccountsDelegate != nil {
+			var body consensusaccounts.Delegate
+			if err := cbor.Unmarshal(call.Body, &body); err != nil {
+				return fmt.Errorf("unmarshal consensus accounts delegate: %w", err)
+			}
+			if err := handler.ConsensusAccountsDelegate(&body); err != nil {
+				return fmt.Errorf("consensus accounts delegate: %w", err)
+			}
+		}
+	case "consensus.Undelegate":
+		if handler.ConsensusAccountsUndelegate != nil {
+			var body consensusaccounts.Undelegate
+			if err := cbor.Unmarshal(call.Body, &body); err != nil {
+				return fmt.Errorf("unmarshal consensus accounts undelegate: %w", err)
+			}
+			if err := handler.ConsensusAccountsUndelegate(&body); err != nil {
+				return fmt.Errorf("consensus accounts undelegate: %w", err)
 			}
 		}
 	case "evm.Create":
@@ -93,6 +118,10 @@ func VisitCall(call *sdkTypes.Call, result *sdkTypes.CallResult, handler *CallHa
 			if err := handler.EVMCall(&body, okP); err != nil {
 				return fmt.Errorf("evm call: %w", err)
 			}
+		}
+	default:
+		if handler.UnknownMethod != nil {
+			return handler.UnknownMethod(string(call.Method))
 		}
 	}
 	return nil

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2344,6 +2344,8 @@ components:
               - "accounts.Transfer"
               - "consensus.Deposit"
               - "consensus.Withdraw"
+              - "consensus.Delegate"
+              - "consensus.Undelegate"
               - "evm.Create"
               - "evm.Call"
             May be null if the transaction was malformed or encrypted.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2373,7 +2373,7 @@ components:
               - For `method = "consensus.Deposit"`, this is the paratime account receiving the funds.
               - For `method = "consensus.Withdraw"`, this is the consensus (!) account receiving the funds.
               - For `method = "consensus.Delegate"`, this is the consensus (!) account receiving the funds.
-              - For `method = "consensus.Undelegate"`, this is the consensus (!) account to which funds were previously delegated. Not that this corresponds with the `.from` field in the transaction body.
+              - For `method = "consensus.Undelegate"`, this is the consensus (!) account to which funds were previously delegated. Note that this corresponds with the `.from` field in the transaction body.
               - For `method = "evm.Create"`, this is the address of the newly created smart contract.
               - For `method = "evm.Call"`, this is the address of the called smart contract
           example: "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq"

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2143,6 +2143,9 @@ components:
         - accounts.mint
         - consensus_accounts.deposit
         - consensus_accounts.withdraw
+        - consensus_accounts.delegate
+        - consensus_accounts.undelegate_start
+        - consensus_accounts.undelegate_done
         - core.gas_used
         - evm.log
       example: *runtime_event_type_1

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2371,7 +2371,9 @@ components:
             if applicable. The meaning varies based on the transaction method. Some notable examples:
               - For `method = "accounts.Transfer"`, this is the paratime account receiving the funds.
               - For `method = "consensus.Deposit"`, this is the paratime account receiving the funds.
-              - For `method = "consensus.Withdraw"`, this is a consensus (!) account receiving the funds.
+              - For `method = "consensus.Withdraw"`, this is the consensus (!) account receiving the funds.
+              - For `method = "consensus.Delegate"`, this is the consensus (!) account receiving the funds.
+              - For `method = "consensus.Undelegate"`, this is the consensus (!) account to which funds were previously delegated. Not that this corresponds with the `.from` field in the transaction body.
               - For `method = "evm.Create"`, this is the address of the newly created smart contract.
               - For `method = "evm.Call"`, this is the address of the called smart contract
           example: "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq"


### PR DESCRIPTION
Adds indexing of txs that call the `consensus.Delegate` and `consensus.Undelegate` methods, and of `consensus_accounts` SDK events of type `Delegate`, `UndelegateStart`, `UndelegateDone`.

TODO: Testing. For starters, I'll run this on the last few weeks of data on testnet, which is where these txs and events first appeared.