### PR TITLE
bugfix: analyzer/consensus: votes: upsert instead of insert

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -783,7 +783,7 @@ func (m *processor) queueFinalizations(batch *storage.QueryBatch, data *storage.
 
 func (m *processor) queueVotes(batch *storage.QueryBatch, data *storage.GovernanceData) error {
 	for _, vote := range data.Votes {
-		batch.Queue(queries.ConsensusVoteInsert,
+		batch.Queue(queries.ConsensusVoteUpsert,
 			vote.ID,
 			vote.Submitter.String(),
 			vote.Vote,

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -384,9 +384,11 @@ var (
     SET invalid_votes = $2
       WHERE id = $1`
 
-	ConsensusVoteInsert = `
+	ConsensusVoteUpsert = `
     INSERT INTO chain.votes (proposal, voter, vote)
-      VALUES ($1, $2, $3)`
+      VALUES ($1, $2, $3)
+    ON CONFLICT (proposal, voter) DO UPDATE SET
+	    vote = excluded.vote;`
 
 	RuntimeBlockInsert = `
     INSERT INTO chain.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)


### PR DESCRIPTION
Previously, the analyzer halted if it encountered more than one vote ever for the same (proposal, voter) pair.

This happens in block 4637995:
```INSERT INTO chain.votes (proposal, voter, vote)
      VALUES ($1, $2, $3) [1 oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt yes]}: ERROR: duplicate key value violates unique constraint "votes_pkey"```