### PR TITLE
nodeapi: cache deterministic failure responses

### DIFF
--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -209,7 +209,7 @@ type Proposal governance.Proposal
 // Like ConsensusApiLite, but for the runtime API.
 type RuntimeApiLite interface {
 	GetEventsRaw(ctx context.Context, round uint64) ([]RuntimeEvent, error)
-	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
+	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) (*FallibleResponse, error)
 	EVMGetCode(ctx context.Context, round uint64, address []byte) ([]byte, error)
 	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
 	GetTransactionsWithResults(ctx context.Context, round uint64) ([]RuntimeTransactionWithResults, error)

--- a/storage/oasis/nodeapi/evm.go
+++ b/storage/oasis/nodeapi/evm.go
@@ -1,0 +1,34 @@
+package nodeapi
+
+import "github.com/oasisprotocol/oasis-core/go/common/errors"
+
+// FallibleResponse stores the response to a node query.
+// Currently only used by EvmSimulateCall. If we use this for
+// other node queries with different return types, consider
+// adding generics.
+type FallibleResponse struct {
+	Ok               []byte
+	DeterministicErr *DeterministicError
+}
+
+// DeterministicError mirrors known errors that may be returned by the node. This
+// struct is necessary because cbor serde requires a concrete type, not just
+// the `error` interface.
+type DeterministicError struct {
+	msg string
+}
+
+func (e DeterministicError) Error() string {
+	return e.msg
+}
+
+// TODO: can we move this to oasis-sdk/client-sdk/go/modules/evm?
+const EVMModuleName = "evm"
+
+var (
+	// Known deterministic errors that may be cached
+	// https://github.com/oasisprotocol/oasis-sdk/blob/runtime-sdk/v0.2.0/runtime-sdk/modules/evm/src/lib.rs#L123
+	ErrSdkEVMExecutionFailed = errors.New(EVMModuleName, 2, "execution failed")
+	// https://github.com/oasisprotocol/oasis-sdk/blob/runtime-sdk/v0.2.0/runtime-sdk/modules/evm/src/lib.rs#L147
+	ErrSdkEVMReverted = errors.New(EVMModuleName, 8, "reverted")
+)

--- a/storage/oasis/nodeapi/file/kvstore.go
+++ b/storage/oasis/nodeapi/file/kvstore.go
@@ -157,7 +157,7 @@ func fetchTypedValue[Value any](cache KVStore, key CacheKey, value *Value) error
 	}
 	err = cbor.Unmarshal(raw, value)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal key %s from cache into %T: %v", key.Pretty(), value, err)
+		return fmt.Errorf("failed to unmarshal the value for key %s from cache into %T: %v; raw value was %x", key.Pretty(), value, err, raw)
 	}
 
 	return nil

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -81,11 +81,11 @@ func (r *FileRuntimeApiLite) GetNativeBalance(ctx context.Context, round uint64,
 	)
 }
 
-func (r *FileRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
-	return GetSliceFromCacheOrCall(
+func (r *FileRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) (*nodeapi.FallibleResponse, error) {
+	return GetFromCacheOrCall(
 		r.db, round == roothash.RoundLatest,
 		generateCacheKey("EVMSimulateCall", r.runtime, round, gasPrice, gasLimit, caller, address, value, data),
-		func() ([]byte, error) {
+		func() (*nodeapi.FallibleResponse, error) {
 			return r.runtimeApi.EVMSimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
 		},
 	)

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -77,7 +77,7 @@ func (rc *HistoryRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint64)
 	return api.GetEventsRaw(ctx, round)
 }
 
-func (rc *HistoryRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
+func (rc *HistoryRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) (*nodeapi.FallibleResponse, error) {
 	api, err := rc.APIForRound(round)
 	if err != nil {
 		return nil, fmt.Errorf("getting api for runtime %s round %d: %w", rc.Runtime, round, err)


### PR DESCRIPTION
https://app.clickup.com/t/8692qau0v

Updates `EvmSimulateCall` to return a wrapped result that can also include a known error.

Testing: Ran the e2e_regression tests with non-block analyzers locally; no issues with running in offline mode.

random thoughts:
- Decided against using FallibleResponse for all node queries since it introduces a lot of unnecessary bloat/boilerplate.
- Think more about how/when we actually want to cache node errors. Are there any cases of `EvmSimulateCall` that might error 'deterministically' but later succeed? ---- No, since `EvmSimulateCall` is queried at a given `round`
- For evm.Code, we currently ignore any errors and retry later, which means that we don't want to cache the error (except maaybe in testing environs). --- Yes, the only errors evm.Code will return are transient ones. If a contract does not exist at a given address, evm.Code will successfully return an empty byte array, not a deterministic error type.