### PR TITLE
always update last_download_round for evm_tokens

### DIFF
--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -157,15 +157,23 @@ func (p *processor) ProcessItem(ctx context.Context, batch *storage.QueryBatch, 
 		if err != nil {
 			return fmt.Errorf("downloading mutated token %s: %w", staleToken.Addr, err)
 		}
+		// We may be unable to download the totalSupply because
+		// of a deterministic error or because the contract may
+		// not provide the data.
 		if mutable != nil && mutable.TotalSupply != nil {
 			batch.Queue(queries.RuntimeEVMTokenDownloadedTotalSupplyUpdate,
 				p.runtime,
 				staleToken.Addr,
 				mutable.TotalSupply.String(),
-				staleToken.DownloadRound,
 			)
 		}
 	}
+	batch.Queue(queries.RuntimeEVMTokenDownloadRoundUpdate,
+		p.runtime,
+		staleToken.Addr,
+		staleToken.DownloadRound,
+	)
+
 	return nil
 }
 

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -573,7 +573,15 @@ var (
     UPDATE chain.evm_tokens
     SET
       total_supply = $3,
-      last_download_round = $4
+    WHERE
+      runtime = $1 AND
+      token_address = $2`
+
+	// Updates the last_download_round of an EVM token.
+	RuntimeEVMTokenDownloadRoundUpdate = `
+    UPDATE chain.evm_tokens
+    SET
+      last_download_round = $3
     WHERE
       runtime = $1 AND
       token_address = $2`


### PR DESCRIPTION
https://app.clickup.com/t/8692rqgz6

The root cause was that the `Oasis Swag EthCC 6` evm token on sapphire testnet would return a `nil` totalSupply. The resulting code path would not return an error or update `last_download_round`. This PR ensures that `last_download_round` is always updated unless an error occured.