### PR TITLE
Parse encrypted evm.Create txs correctly

### DIFF
--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -448,7 +448,12 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					}
 
 					// Handle encrypted txs.
-					if evmEncrypted, err2 := evm.EVMMaybeUnmarshalEncryptedData(body.InitCode, ok); err2 == nil {
+					// We don't pass the tx result (`ok`) to EVMMaybeUnmarshalEncryptedData because it's the
+					// (unencrypted) address of the created contract. The function expects a CBOR-encoded
+					// encryption envelope as its second argument, so passing the unencrypted address
+					// makes it incorrectly declare the whole tx unencrypted.
+					// Note: The address of the created contract is tracked in blockTransactionData.To.
+					if evmEncrypted, err2 := evm.EVMMaybeUnmarshalEncryptedData(body.InitCode, nil); err2 == nil {
 						blockTransactionData.EVMEncrypted = evmEncrypted
 					} else {
 						logger.Error("error unmarshalling encrypted init code and result, omitting encrypted fields",


### PR DESCRIPTION
Resolves https://github.com/oasisprotocol/nexus/issues/445

don't pass tx.result to evmMaybeUnmarshalEncrypted for evm.Create calls bc its the address of the created contract, which is already stored as `tx.To`.

Todo:
- Think about backfilling. It can't be done with a simple db migration; it almost certainly requires a full reindex
- During the early days of testnet there were some encrypted sapphire evm.Create txs that have a cbor-encoded callResult. There are 360 of these txs ranging from blocks 2293->5023 on testnet. [Sample tx](https://explorer.dev.oasis.io/testnet/sapphire/tx/0x669d9e79702eef3b1347f7b846331dab0bc0751f3859b42dc998a432147e9c4a) After this PR, the encrypted result data/nonce will no longer be available. In lieu of complicating the code with a special case to extract the encrypted result from those txs, I'd rather lose that small amount of data. Those txs will still be recognized as encrypted.
- Perhaps not in scope for this PR, but while investigating I noticed that most encrypted evm.Call txs that return unencrypted results do not have the result data/nonce parsed/stored. We likely want to remedy this?

Testing:
Ran successfully on blocks 2345636 and 2345646 which have failed and successful evm.Create txs, respectively. Db dump:
```
 runtime  |  round  | tx_index |                           tx_eth_hash
     | success |   evm_encrypted_format    |     evm_encrypted_data_nonce     | evm_encrypted
_result_nonce
----------+---------+----------+-------------------------------------------------------------
-----+---------+---------------------------+----------------------------------+--------------
--------------
 sapphire | 2345636 |        0 | 4bfb9d438aaae054755b1127740cb0b050bc36e25b796e643082d0418f14
6ce9 | t       | encrypted/x25519-deoxysii | \x02007b412ff6b64f9c828959528a95 |
 sapphire | 2345636 |        1 | 8494cb50d70a630b67a5e701d2ddb8ae90b69a8a9b7957bdfa009765f929
f3e1 | t       |                           |                                  |
 sapphire | 2345636 |        2 | 10f3f1462087b17115afa19c0a0ebda812dac75924f6b68891cb8476aa6d
7e3c | t       |                           |                                  |
 sapphire | 2345636 |        3 | c07dcd5ac47b60a0249cac18f54cf49bc6b7d00ac3113dbe96448156a398
e3f6 | f       | encrypted/x25519-deoxysii | \xfca287834084b9d986435f4fd4fcad |
 sapphire | 2345636 |        4 | 7690a6e96985aa349608d07e0f68f7bd7253bb8a5495a3df1db3c2fc224b
b3fe | f       | encrypted/x25519-deoxysii | \x48e7fe1633ff874772e57807ccb8ea |
 sapphire | 2345636 |        5 | 4a2d2034b1f447a971ba75e9e15b00e4c24f1a56a965f11636adb94e3daa
7239 | t       |                           |                                  |
 sapphire | 2345637 |        0 | 6928df5dc6483d0323481cc0a2d37c18ed8f34aac6d9ff253954ffaf8866
7bc3 | t       |                           |                                  |
 sapphire | 2345638 |        0 | 90020c05f3f7563b2ced323e80db96ee7a5c0eedd98b71f900e3c0d26437
4f99 | t       |                           |                                  |
 sapphire | 2345639 |        0 | 61b70dfd1a43a6e79d362aebc9196c54a086675469af01c03eead1f30abf
d8fd | t       |                           |                                  |
 sapphire | 2345640 |        0 | 0e928116f0f87e4284e0f7bfcaa6d22bde9d8f3fe402e1ff5a8ee4d661c8
ec20 | t       |                           |                                  |
 sapphire | 2345641 |        0 | e476d486ca74fc81e03224fea4384af31b1aa1b0767cf763073867f315db
2c89 | t       |                           |                                  |
 sapphire | 2345642 |        0 | 3b3fa6f00a73d2bda936d7515f50e8dd608cb073f64ed8dbcfeda520bab6
1cf2 | t       |                           |                                  |
 sapphire | 2345643 |        0 | b9a454c0ba569b7b8829694f5e3106127772e5ade5ef0eb9496cbd0f7ff6
af96 | t       |                           |                                  |
 sapphire | 2345644 |        0 | 86d160dfdaf0962860ec0263e9828934c375b5ad5a291163e402755d4baa
b5c2 | t       |                           |                                  |
 sapphire | 2345645 |        0 | bab9509d6146617ee122f0f19599b51fdbf644f25739c0be8406a8e9a256
d1f9 | t       |                           |                                  |
 sapphire | 2345646 |        0 | b2ab98468dd320804a3ead5fc10f4bda85c11cfe3bce7232f2d59e91d747
88dc | t       | encrypted/x25519-deoxysii | \x46eb621d1dc131eb5b8a8829c21f2e |
```