### PR TITLE
backfill token num_xfers

### DIFF
--- a/storage/migrations/19_evm_token_num_xfers.up.sql
+++ b/storage/migrations/19_evm_token_num_xfers.up.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+-- Backfill num_transfers
 WITH transfers AS (
     SELECT runtime, DECODE(body ->> 'address', 'base64') AS eth_addr, COUNT(*) AS num_xfers
         FROM chain.runtime_events
@@ -18,5 +19,28 @@ UPDATE chain.evm_tokens as tokens
 	WHERE
 		tokens.runtime = transfers.runtime AND
 		tokens.token_address = preimages.address;
+
+-- Backfill total_supply
+-- We dead-reckon total_supply using evm_token_balances and use
+-- this value as a default for erc721 tokens, since they might 
+-- not support totalSupply()
+WITH total_supplies AS (
+    SELECT runtime, token_address, sum(balance) as total_supply
+        FROM chain.evm_token_balances 
+        GROUP BY runtime, token_address 
+)
+UPDATE chain.evm_tokens as tokens
+    SET
+        total_supply = total_supplies.total_supply
+    FROM total_supplies
+    WHERE
+        total_supplies.runtime = tokens.runtime AND 
+        total_supplies.token_address = tokens.token_address AND
+        tokens.token_type = 721;
+-- Re-download all tokens to update total_supply, and potentially 
+-- overwrite the dead-reckoned value
+UPDATE chain.evm_tokens
+    SET
+        last_download_round = 0;
 
 COMMIT;

--- a/storage/migrations/19_evm_token_num_xfers.up.sql
+++ b/storage/migrations/19_evm_token_num_xfers.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+WITH transfers AS (
+    SELECT runtime, DECODE(body ->> 'address', 'base64') AS eth_addr, COUNT(*) AS num_xfers
+        FROM chain.runtime_events
+        WHERE evm_log_signature='\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'::bytea -- ERC-20 and ERC-721 Transfer
+        GROUP BY runtime, eth_addr
+)
+UPDATE chain.evm_tokens as tokens 
+	SET 
+		num_transfers = transfers.num_xfers
+	FROM transfers
+	LEFT JOIN chain.address_preimages as preimages
+	ON 
+		preimages.address_data = transfers.eth_addr AND
+	    preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+	    preimages.context_version = 0
+	WHERE
+		tokens.runtime = transfers.runtime AND
+		tokens.token_address = preimages.address;
+
+COMMIT;


### PR DESCRIPTION
Michal pointed out that the `num_transfers` for evm tokens is currently off in production. For example, for [nftrout](https://nexus.oasis.io/v1/sapphire/evm_tokens/oasis1qpwe6h0hw6s0x4skujhznld065300p83wgxnvu0n) it shows 0 transfers (supposed to be 208), and for [YuzuToken](https://nexus.oasis.io/v1/emerald/evm_tokens/oasis1qqz8706pmf38wmptl6dkcaec8yykw0rvfv7ql6fc) it shows 258 transfers (should be >7mil)

```
oasisindexer=> select count(*) from chain.runtime_events
        where
                runtime='emerald' and
                body->>'address'='8Cs+Q3MEiSEFmSUSU592lCOlFcs=' and
                evm_log_signature='\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'::bytea;
  count
---------
 7212488
```

This PR creates a new migration meant to backfill the num_transfers using the runtime_events table. It first filters events using the evm_log_signature of a `Transfer` event (`ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`), and then sorts events by runtime and eth address, where the eth address is the address contained in the event body. 


Note: this migration _will not work_ for staging: we are missing large amounts of data on staging, including the `evm_` fields like `evm_log_signature` for most of the runtime events there. The alternative to this is to filter by first event topic directly 
```
body#>>'{topics,0}' = '3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8='
```
but this is considerably slower since there's no index on the event body column (which is a json object). Staging needs a full reindex anyway so I'm in favor of just doing that; otherwise we can use the alternate filter above.

For production, we have all the `evm_log_signatures` parsed for runtime events, so this won't be an issue.

Note: This backfill query will be quite slow; might cause some downtime of ~ an hour when it is run.

EDIT**
Added queries to backfill total_supply as well. The approach is to fetch the total_supply directly from the contract if possible, otherwise dead-reckon using the `evm_token_balances` table


Todo:
- check staging to see if the transfers are off and by how much