### PR TITLE
bugfix: kvstore: Error messages do not decode the key correctly

### DIFF
--- a/storage/oasis/nodeapi/file/kvstore.go
+++ b/storage/oasis/nodeapi/file/kvstore.go
@@ -125,11 +125,12 @@ func OpenKVStore(logger *log.Logger, path string) (KVStore, error) {
 // Pretty() returns a pretty-printed, human-readable version of the cache key.
 // It tries to interpret it as CBOR and returns the pretty-printed struct, otherwise
 // it returns the key's raw bytes as hex.
+// Intended only for debugging. Not guaranteed to be a stable representation.
 func (cacheKey CacheKey) Pretty() string {
 	var pretty string
 	var parsed interface{}
 	err := cbor.Unmarshal(cacheKey, &parsed)
-	if err != nil {
+	if err == nil {
 		pretty = fmt.Sprintf("%+v", parsed)
 	} else {
 		pretty = fmt.Sprintf("%x", cacheKey)

--- a/storage/oasis/nodeapi/file/kvstore_test.go
+++ b/storage/oasis/nodeapi/file/kvstore_test.go
@@ -111,3 +111,23 @@ func TestGetFromCacheOrCallTypeMismatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 123, *myInt)
 }
+
+func TestPrettyPrint(t *testing.T) {
+	// Generate a complex key
+	myStruct := struct {
+		Words  []string
+		Number int
+	}{
+		Words:  []string{"hello", "world"},
+		Number: 123,
+	}
+	key := generateCacheKey("foo", "bar", myStruct)
+
+	// Pretty-print it
+	reconstructed := key.Pretty()
+
+	// The pretty-printed version should be printf("%+v") of the values that constructed the key.
+	// The exact string format is not so important as it's only used for debug and not guaranteed to be stable,
+	// but it should be human-readable.
+	require.Equal(t, "[foo [bar map[Number:123 Words:[hello world]]]]", reconstructed)
+}


### PR DESCRIPTION
Fixes silly typo that resulted in less-readable error messages (as recently seen on slack) about invalidly-typed cache values.