### PR TITLE
kvstore: Add prometheus metric for cache hits/misses

### DIFF
--- a/analyzer/aggregate_stats/aggregate_stats.go
+++ b/analyzer/aggregate_stats/aggregate_stats.go
@@ -75,14 +75,14 @@ func (a *aggregateStatsAnalyzer) Start(ctx context.Context) {
 }
 
 func (a *aggregateStatsAnalyzer) writeToDB(ctx context.Context, batch *storage.QueryBatch, opName string) error {
-	timer := a.metrics.DatabaseTimer(a.target.Name(), opName)
+	timer := a.metrics.DatabaseLatencies(a.target.Name(), opName)
 	defer timer.ObserveDuration()
 
 	if err := a.target.SendBatch(ctx, batch); err != nil {
-		a.metrics.DatabaseCounter(a.target.Name(), opName, "failure").Inc()
+		a.metrics.DatabaseOperations(a.target.Name(), opName, "failure").Inc()
 		return err
 	}
-	a.metrics.DatabaseCounter(a.target.Name(), opName, "success").Inc()
+	a.metrics.DatabaseOperations(a.target.Name(), opName, "success").Inc()
 
 	return nil
 }

--- a/analyzer/aggregate_stats/aggregate_stats.go
+++ b/analyzer/aggregate_stats/aggregate_stats.go
@@ -52,7 +52,7 @@ type aggregateStatsAnalyzer struct {
 	target storage.TargetStorage
 
 	logger  *log.Logger
-	metrics metrics.DatabaseMetrics
+	metrics metrics.StorageMetrics
 }
 
 var _ analyzer.Analyzer = (*aggregateStatsAnalyzer)(nil)
@@ -66,7 +66,7 @@ func NewAggregateStatsAnalyzer(target storage.TargetStorage, logger *log.Logger)
 	return &aggregateStatsAnalyzer{
 		target:  target,
 		logger:  logger.With("analyzer", aggregateStatsAnalyzerName),
-		metrics: metrics.NewDefaultDatabaseMetrics(aggregateStatsAnalyzerName),
+		metrics: metrics.NewDefaultStorageMetrics(aggregateStatsAnalyzerName),
 	}, nil
 }
 

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -252,14 +252,14 @@ func (m *processor) ProcessBlock(ctx context.Context, uheight uint64) error {
 
 	// Apply updates to DB.
 	opName := "process_block_consensus"
-	timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
+	timer := m.metrics.DatabaseLatencies(m.target.Name(), opName)
 	defer timer.ObserveDuration()
 
 	if err := m.target.SendBatch(ctx, batch); err != nil {
-		m.metrics.DatabaseCounter(m.target.Name(), opName, "failure").Inc()
+		m.metrics.DatabaseOperations(m.target.Name(), opName, "failure").Inc()
 		return err
 	}
-	m.metrics.DatabaseCounter(m.target.Name(), opName, "success").Inc()
+	m.metrics.DatabaseOperations(m.target.Name(), opName, "success").Inc()
 	return nil
 }
 

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -62,7 +62,7 @@ type processor struct {
 	source  storage.ConsensusSourceStorage
 	target  storage.TargetStorage
 	logger  *log.Logger
-	metrics metrics.DatabaseMetrics
+	metrics metrics.StorageMetrics
 }
 
 var _ block.BlockProcessor = (*processor)(nil)
@@ -75,7 +75,7 @@ func NewAnalyzer(blockRange config.BlockRange, batchSize uint64, mode analyzer.B
 		source:  sourceClient,
 		target:  target,
 		logger:  logger.With("analyzer", consensusAnalyzerName),
-		metrics: metrics.NewDefaultDatabaseMetrics(consensusAnalyzerName),
+		metrics: metrics.NewDefaultStorageMetrics(consensusAnalyzerName),
 	}
 
 	return block.NewAnalyzer(blockRange, batchSize, mode, consensusAnalyzerName, processor, target, logger)

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -152,14 +152,14 @@ func (m *processor) ProcessBlock(ctx context.Context, round uint64) error {
 	)
 
 	opName := fmt.Sprintf("process_block_%s", m.runtime)
-	timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
+	timer := m.metrics.DatabaseLatencies(m.target.Name(), opName)
 	defer timer.ObserveDuration()
 
 	if err := m.target.SendBatch(ctx, batch); err != nil {
-		m.metrics.DatabaseCounter(m.target.Name(), opName, "failure").Inc()
+		m.metrics.DatabaseOperations(m.target.Name(), opName, "failure").Inc()
 		return err
 	}
-	m.metrics.DatabaseCounter(m.target.Name(), opName, "success").Inc()
+	m.metrics.DatabaseOperations(m.target.Name(), opName, "success").Inc()
 	return nil
 }
 

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -30,7 +30,7 @@ type processor struct {
 	source          nodeapi.RuntimeApiLite
 	target          storage.TargetStorage
 	logger          *log.Logger
-	metrics         metrics.DatabaseMetrics
+	metrics         metrics.StorageMetrics
 }
 
 var _ block.BlockProcessor = (*processor)(nil)
@@ -54,7 +54,7 @@ func NewRuntimeAnalyzer(
 		source:          sourceClient,
 		target:          target,
 		logger:          logger.With("analyzer", runtime),
-		metrics:         metrics.NewDefaultDatabaseMetrics(string(runtime)),
+		metrics:         metrics.NewDefaultStorageMetrics(string(runtime)),
 	}
 
 	return block.NewAnalyzer(blockRange, batchSize, mode, string(runtime), processor, target, logger)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -65,7 +65,7 @@ func MetricsMiddleware(m metrics.RequestMetrics, logger log.Logger) func(next ht
 			)
 			t := time.Now()
 			metricName := normalizeEndpoint(r.URL.Path)
-			timer := m.RequestTimer(metricName)
+			timer := m.RequestLatencies(metricName)
 
 			// Serve the request.
 			next.ServeHTTP(w, r.WithContext(
@@ -99,7 +99,7 @@ func MetricsMiddleware(m metrics.RequestMetrics, logger log.Logger) func(next ht
 				statusTxt = "failure_4xx"
 				metricName = "ignored"
 			}
-			m.RequestCounter(metricName, statusTxt).Inc()
+			m.RequestCounts(metricName, statusTxt).Inc()
 		})
 	}
 }

--- a/metrics/requests.go
+++ b/metrics/requests.go
@@ -6,21 +6,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var (
-	// Labels to use for partitioning requests.
-	requestLabels = []string{"endpoint", "status", "cause"}
-
-	// Labels to use for partitioning request latencies.
-	requestLatencyLabels = []string{"endpoint"}
-)
-
 // Default service metrics for requests.
 type RequestMetrics struct {
 	// Counts of requests made to each service endpoint.
-	RequestCounts *prometheus.CounterVec
+	requestCounts *prometheus.CounterVec
 
 	// Latencies of serving incoming requests.
-	RequestLatencies *prometheus.HistogramVec
+	requestLatencies *prometheus.HistogramVec
 }
 
 // NewDefaultRequestMetrics creates Prometheus metric instrumentation for
@@ -30,41 +22,33 @@ type RequestMetrics struct {
 // 2. Latencies for requests.
 func NewDefaultRequestMetrics(pkg string) RequestMetrics {
 	metrics := RequestMetrics{
-		RequestCounts: prometheus.NewCounterVec(
+		requestCounts: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: fmt.Sprintf("%s_requests", pkg),
-				Help: "How many service requests were made, partitioned by request endpoint, status, and cause.",
+				Help: "How many service requests were made, partitioned by request endpoint and status.",
 			},
-			requestLabels,
+			[]string{"endpoint", "status"}, // Labels.
 		),
-		RequestLatencies: prometheus.NewHistogramVec(
+		requestLatencies: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: fmt.Sprintf("%s_request_latencies", pkg),
 				Help: "How long requests take to process, partitioned by request endpoint.",
 			},
-			requestLatencyLabels,
+			[]string{"endpoint"}, // Labels.
 		),
 	}
-	prometheus.MustRegister(metrics.RequestCounts)
-	prometheus.MustRegister(metrics.RequestLatencies)
+	prometheus.MustRegister(metrics.requestCounts)
+	prometheus.MustRegister(metrics.requestLatencies)
 	return metrics
 }
 
-// RequestCounter returns the counter for the calling request.
+// RequestCounts returns the counter for the calling request.
 // Provided labels should be endpoint, status, and cause.
-func (m *RequestMetrics) RequestCounter(labels ...string) prometheus.Counter {
-	if len(labels) > len(requestLabels) {
-		labels = labels[:len(requestLabels)]
-	}
-	labels = append(labels, make([]string, len(requestLabels)-len(labels))...)
-	return m.RequestCounts.WithLabelValues(labels...)
+func (m *RequestMetrics) RequestCounts(endpoint, status string) prometheus.Counter {
+	return m.requestCounts.WithLabelValues(endpoint, status)
 }
 
-// RequestTimer creates a new latency timer for the provided request endpoint.
-func (m *RequestMetrics) RequestTimer(labels ...string) *prometheus.Timer {
-	if len(labels) > len(requestLatencyLabels) {
-		labels = labels[:len(requestLatencyLabels)]
-	}
-	labels = append(labels, make([]string, len(requestLatencyLabels)-len(labels))...)
-	return prometheus.NewTimer(m.RequestLatencies.WithLabelValues(labels...))
+// RequestLatencies creates a new latency timer for the provided request endpoint.
+func (m *RequestMetrics) RequestLatencies(endpoint string) *prometheus.Timer {
+	return prometheus.NewTimer(m.requestLatencies.WithLabelValues(endpoint))
 }

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -8,7 +8,9 @@ import (
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 
+	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/metrics"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
@@ -27,6 +29,7 @@ func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiL
 	db, err := OpenKVStore(
 		log.NewDefaultLogger("cached-node-api").With("runtime", "consensus"),
 		cacheDir,
+		common.Ptr(metrics.NewDefaultStorageMetrics("consensus")),
 	)
 	if err != nil {
 		return nil, err

--- a/storage/oasis/nodeapi/file/kvstore_test.go
+++ b/storage/oasis/nodeapi/file/kvstore_test.go
@@ -14,7 +14,7 @@ import (
 func openTestKVStore(t *testing.T) (KVStore, func()) {
 	path, err := os.MkdirTemp("", "nexus-kv-test")
 	require.NoError(t, err)
-	kv, err := OpenKVStore(log.NewDefaultLogger("unit-test"), path)
+	kv, err := OpenKVStore(log.NewDefaultLogger("unit-test"), path, nil)
 	require.NoError(t, err)
 	return kv, func() {
 		err := kv.Close()

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/metrics"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
@@ -24,6 +25,7 @@ func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi n
 	db, err := OpenKVStore(
 		log.NewDefaultLogger("cached-node-api").With("runtime", runtime),
 		cacheDir,
+		common.Ptr(metrics.NewDefaultStorageMetrics(string(runtime))),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See title. This will be nice to have: We can make better sense of speed-of-indexing grafana charts if we know whether node I/O is involved.

This PR also includes a cleanup commit that enforces strong typing for labels when accessing metrics, and renames local variable that represent metrics so that the variable name matches the metric name. **I recommend reviewing that first commit separately** -- lots of noise, not much effect.