### PR TITLE
parse unencrypted results for confidential txs

### DIFF
--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -74,6 +74,11 @@ type EVMEncryptedData struct {
 	DataData    []byte
 	ResultNonce []byte
 	ResultData  []byte
+	// Unlike `ResultData` and `DataData`, this field is not encrypted data. Rather,
+	// it is extracted during encrypted tx parsing and processed in extract.go.
+	// If non-null, the tx is an older Sapphire tx and it failed, and `ResultNonce`
+	// and `ResultData` will be empty.
+	FailedCallResult *sdkTypes.FailedCallResult
 }
 
 type EVMContractData struct {
@@ -307,6 +312,111 @@ func EVMDownloadTokenBalance(ctx context.Context, logger *log.Logger, source nod
 // EVMMaybeUnmarshalEncryptedData breaks down a possibly encrypted data +
 // result into their encryption envelope fields. If the data is not encrypted,
 // it returns nil with no error.
+//
+// LESSON: Oasis paratime transaction structure.
+//
+// Oasis paratime transactions conform to the oasis format transaction payload:
+// https://github.com/oasisprotocol/oasis-sdk/blob/04e8918a9b3eb90caffe115ea2d46b5742438714/client-sdk/go/types/transaction.go#L212
+//
+// Transaction payloads may be encrypted in oasis. To express that, the
+// Transaction.Call field of the transaction would have a call format set, e.g.
+//     Call.Format: 'encrypted/x25519-deoxysii'
+//
+// This gives rise to the concept of outer/inner calls for oasis-format
+// transactions, where the inner call would be encrypted and stored in the
+// outer Call.Body. However, when the runtime evm module converts ethereum
+// format transactions to oasis format transaction payloads, they are never
+// in this encrypted mode because there is no native ethereum way to express
+// an encrypted transaction.
+//
+// Thus, for ethereum format transactions, the outer oasis format Call.Format
+// is always 0/plain (or equivalently, unset). This outer Call directly has
+// the method and body of the transaction. For example, the method may be
+// "evm.Call" and the body would be the corresponding struct:
+// https://github.com/oasisprotocol/oasis-sdk/blob/04e8918a9b3eb90caffe115ea2d46b5742438714/client-sdk/go/modules/evm/types.go#L13
+//
+// Here is where we may encounter sapphire-style encryption. In the first and
+// most basic case, there is no sapphire-style encryption at all and the fields
+// of the evm.Call struct are the exact bytes that would go into the evm.
+// Note that Sapphire supports this mode.
+//
+// The result of this transaction is stored in the associated CallResult struct
+// that is returned alongside the transaction in TransactionWithResult:
+// https://github.com/oasisprotocol/oasis-sdk/blob/main/client-sdk/go/client/client.go#L146
+//
+// A transaction may also be in sapphire encrypted mode. In this case, the
+// evm.Call.Data or evm.Create.Initcode field is itself a cbor-encoded oasis
+// format runtime-sdk Call struct that we term the "sapphire outer call". This
+// struct is the same oasis format Transaction.Call mentioned above:
+// https://github.com/oasisprotocol/oasis-sdk/blob/04e8918a9b3eb90caffe115ea2d46b5742438714/client-sdk/go/types/transaction.go#L363
+//
+// In encrypted mode, the sapphire outer call has a Call.Format of
+// 'encrypted/x25519-deoxysii', and the call.Body is a cbor-encoded encryption
+// envelope, which can be decrypted and parsed into another oasis format Call
+// struct that we term the "sapphire inner call". Note that Nexus never has
+// the keys the decrypt this envelope to get the inner struct since the
+// Sapphire transaction is encrypted. The sapphire inner call.Body has the evm
+// input data, and the inner call.Format is always unset.
+//
+// The results of sapphire encrypted transactions are stored similarly. In the
+// first case, we should note that sapphire encrypted transactions may have
+// unencrypted results if the inputs were not encrypted. Unencrypted transaction
+// results are stored in the same associated CallResult as the results of
+// unencrypted transactions. We term this CallResult the "outer call result."
+//
+// Encrypted results can be recovered by cbor-unmarshalling the outer
+// CallResult.Ok field into another CallResult struct that we term the
+// "sapphire outer call result." Currently, the sapphire outer CallResult.Ok
+// stores the result envelope of successful sapphire encrypted transactions.
+// However, in older versions of Sapphire and for non-evm transactions, this
+// result envelope is stored in the sapphire outer CallResult.Unknown.
+//
+// The result envelope contains the encrypted "sapphire inner call result",
+// where the sapphire inner CallResult.Ok field contains the output data
+// from the evm. Note that Nexus does not have the keys to decrypt and access
+// this sapphire inner call result.
+//
+// Side note: The CallResult struct does not specify its own encryption format.
+// Rather, it follows the format of its corresponding oasis format Call. The
+// "outer call" Call.Format corresponds to the outer call result, and the
+// "sapphire outer call" Call.Format corresponds to the sapphire outer call
+// result.
+//
+// Currently, if an encrypted transaction fails, the error is bubbled up to
+// the outer CallResult.Failed. However, in older versions of Sapphire the
+// error was stored in the sapphire outer CallResult.Failed.
+//
+// Lastly, there's also a "not-encryption-but-sapphire-something" case where
+// the sapphire outer Call.Format is set to "plain". In this case, there's no
+// sapphire inner call and the sapphire outer Call.Body has the evm input data.
+// Nexus does not extract the evm input data directly here like the way it does
+// for unencrypted evm.Call transactions.
+//
+// The results of these "plain" transactions are returned in the outer
+// CallResult.
+//
+// Outer oasis Call.Body
+//   -> inner oasis Call
+//   -> evm.Call
+//        -> sapphire outer Call.Body
+//             -> sapphire inner Call
+//
+// To summarize:
+// * Non-Sapphire
+//   * Tx Body: Stored in oasis outer Call.Body
+//   * Success Result: Stored in outer oasis CallResult.Ok
+//   * Failure Result: Stored in outer oasis CallResult.Failed
+// * Sapphire Encrypted
+//   * Tx Body: Encryption envelope stored in sapphire outer Call.Body
+//   * Success Result: Encryption envelope stored in either sapphire outer
+//                     CallResult.Ok (new) or CallResult.Unknown (old)
+//   * Failure Result: Stored in either the sapphire outer CallResult.Failed (old)
+//                     or the outer CallResult.Failed (new)
+// * Sapphire Plain(0)
+//   * Tx Body: Stored in the sapphire outer Call.Body
+//   * Success Result: Stored in outer oasis CallResult.Ok
+//   * Failure Result: Stored in outer oasis CallResult.Failed
+
 func EVMMaybeUnmarshalEncryptedData(data []byte, result *[]byte) (*EVMEncryptedData, error) {
 	var encryptedData EVMEncryptedData
 	var call sdkTypes.Call
@@ -325,6 +435,9 @@ func EVMMaybeUnmarshalEncryptedData(data []byte, result *[]byte) (*EVMEncryptedD
 		encryptedData.PublicKey = callEnvelope.Pk[:]
 		encryptedData.DataNonce = callEnvelope.Nonce[:]
 		encryptedData.DataData = callEnvelope.Data
+	// Plain txs have no encrypted fields to extract.
+	case sdkTypes.CallFormatPlain:
+		return nil, nil
 	// If you are adding new call formats, remember to add them to the
 	// database call_format enum too.
 	default:
@@ -335,21 +448,40 @@ func EVMMaybeUnmarshalEncryptedData(data []byte, result *[]byte) (*EVMEncryptedD
 		if err := cbor.Unmarshal(*result, &callResult); err != nil {
 			return nil, fmt.Errorf("unmarshal outer call result: %w", err)
 		}
-		if callResult.IsUnknown() {
-			switch call.Format {
-			case sdkTypes.CallFormatEncryptedX25519DeoxysII:
-				var resultEnvelope sdkTypes.ResultEnvelopeX25519DeoxysII
+		switch call.Format {
+		case sdkTypes.CallFormatEncryptedX25519DeoxysII:
+			var resultEnvelope sdkTypes.ResultEnvelopeX25519DeoxysII
+			switch {
+			// The result is encrypted, in which case it is stored in callResult.Unknown
+			case callResult.IsUnknown():
 				if err := cbor.Unmarshal(callResult.Unknown, &resultEnvelope); err != nil {
 					return nil, fmt.Errorf("outer call result unmarshal unknown: %w", err)
 				}
-				encryptedData.ResultNonce = resultEnvelope.Nonce[:]
-				encryptedData.ResultData = resultEnvelope.Data
+			// The result may be unencrypted, in which case it is stored in callResult.Ok
+			//
+			// Note: IsUnknown() is already checked above, but we keep it here to make the
+			// logic explicit in the event of future refactors. IsSuccess() returns true both
+			// when the call succeeded and when it is unknown. However, we want this case
+			// to run iff the call succeeded.
+			case callResult.IsSuccess() && !callResult.IsUnknown():
+				if err := cbor.Unmarshal(callResult.Ok, &resultEnvelope); err != nil {
+					return nil, fmt.Errorf("outer call result unmarshal ok: %w", err)
+				}
+			// For non-evm txs as well as older Sapphire txs, the outer callResult may
+			// be Unknown and the inner callResult Failed. In this case, we extract the
+			// failed callResult.
+			case callResult.Failed != nil:
+				encryptedData.FailedCallResult = callResult.Failed
 			default:
-				// We have already checked when decoding the call envelope,
-				// but I'm keeping this default case here so we don't forget
-				// if this code gets restructured.
-				return nil, fmt.Errorf("outer call format %s (%d) not supported", call.Format, call.Format)
+				return nil, fmt.Errorf("unknown inner callResult type")
 			}
+			encryptedData.ResultNonce = resultEnvelope.Nonce[:]
+			encryptedData.ResultData = resultEnvelope.Data
+		default:
+			// We have already checked when decoding the call envelope,
+			// but I'm keeping this default case here so we don't forget
+			// if this code gets restructured.
+			return nil, fmt.Errorf("outer call format %s (%d) not supported", call.Format, call.Format)
 		}
 	}
 	return &encryptedData, nil

--- a/analyzer/runtime/extract_test.go
+++ b/analyzer/runtime/extract_test.go
@@ -1,15 +1,42 @@
 package runtime
 
 import (
+	"encoding/base64"
 	"testing"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/nexus/common"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
 type mockError struct {
 	module  string
 	code    uint32
 	message string
+}
+
+// Mocks the BlockTransactionData struct, but replaces many []byte
+// field types with strings to reduce boilerplate.
+type mockTxData struct {
+	Raw          string
+	RawResult    string
+	Method       string
+	EvmEncrypted *mockEvmEncrypted
+	Success      *bool
+	Error        *TxError
+}
+
+type mockEvmEncrypted struct {
+	Format      common.CallFormat
+	PublicKey   string
+	DataNonce   string
+	DataData    string
+	ResultNonce string
+	ResultData  string
 }
 
 func TestPlaintextError(t *testing.T) {
@@ -52,4 +79,200 @@ func TestEmptyError(t *testing.T) {
 	input := &mockError{module: "evm", code: 8, message: "reverted: "}
 	msg := tryParseErrorMessage(input.module, input.code, input.message)
 	require.Nil(t, msg, "tryParseErrorMessage extracted a message when it should not have")
+}
+
+func TestExtractSuccessfulEncryptedTx(t *testing.T) {
+	txBody, _ := base64.StdEncoding.DecodeString("+QE3gjc+hRdIdugAgw9CQJQR1RPa4nTJ35R1o7lWypg7lLsNwIC4zaJkYm9keaNicGtYIIn0UYPeSB9UEuOdJ0HJltloztQGqFScIJMYUkKfmatxZGRhdGFYfO8udYN5tJJ50o5td4lgzWdwuZid8rWYXeO+SmY8RwDivlwELbaNRDges0gQUbfLEgPrA74C+X/eqsKLSlBJAKFsApLZsfkTfKViwucwwclHnIpoWCYaNSroY0eiIHjoK0FBhh6MOHSU0ov2OVsvlDPqSwCmbyys6bk7DD5lbm9uY2VPl0SS+WcwWj+n5rKn+wzvZmZvcm1hdAGCtiKgQ+aU2gbOviF0Oq4JO+ywOVm7L6fxisKTXmcpx24vX1+gDi0QM72w2tYqHYPqt6VcGWmvK5GyXm79xIEAVrLKPGU=")
+	txResult, _ := base64.StdEncoding.DecodeString("WDahYm9romRkYXRhVfd11jNj4IPuD//0n3CIDG7/Lf2T22Vub25jZU8AAAAAADJSEQAAAAAAAAA=")
+	txResultCbor := cbor.RawMessage(txResult)
+	// round: 3297810, index: 0
+	txrs := []nodeapi.RuntimeTransactionWithResults{
+		{
+			Tx: types.UnverifiedTransaction{
+				Body: txBody,
+				AuthProofs: []types.AuthProof{
+					{
+						Module: "evm.ethereum.v0",
+					},
+				},
+			},
+			Result: types.CallResult{
+				Ok: txResultCbor,
+			},
+		},
+	}
+	expected := mockTxData{
+		Raw:       "glkBOvkBN4I3PoUXSHboAIMPQkCUEdUT2uJ0yd+UdaO5VsqYO5S7DcCAuM2iZGJvZHmjYnBrWCCJ9FGD3kgfVBLjnSdByZbZaM7UBqhUnCCTGFJCn5mrcWRkYXRhWHzvLnWDebSSedKObXeJYM1ncLmYnfK1mF3jvkpmPEcA4r5cBC22jUQ4HrNIEFG3yxID6wO+Avl/3qrCi0pQSQChbAKS2bH5E3ylYsLnMMHJR5yKaFgmGjUq6GNHoiB46CtBQYYejDh0lNKL9jlbL5Qz6ksApm8srOm5Oww+ZW5vbmNlT5dEkvlnMFo/p+ayp/sM72Zmb3JtYXQBgrYioEPmlNoGzr4hdDquCTvssDlZuy+n8YrCk15nKcduL19foA4tEDO9sNrWKh2D6relXBlpryuRsl5u/cSBAFayyjxlgaFmbW9kdWxlb2V2bS5ldGhlcmV1bS52MA==",
+		RawResult: "oWJva1g2oWJva6JkZGF0YVX3ddYzY+CD7g//9J9wiAxu/y39k9tlbm9uY2VPAAAAAAAyUhEAAAAAAAAA",
+		Method:    "evm.Call",
+		EvmEncrypted: &mockEvmEncrypted{
+			Format:      "encrypted/x25519-deoxysii",
+			PublicKey:   "ifRRg95IH1QS450nQcmW2WjO1AaoVJwgkxhSQp+Zq3E=",
+			DataNonce:   "l0SS+WcwWj+n5rKn+wzv",
+			DataData:    "7y51g3m0knnSjm13iWDNZ3C5mJ3ytZhd475KZjxHAOK+XAQtto1EOB6zSBBRt8sSA+sDvgL5f96qwotKUEkAoWwCktmx+RN8pWLC5zDByUecimhYJho1KuhjR6IgeOgrQUGGHow4dJTSi/Y5Wy+UM+pLAKZvLKzpuTsMPg==",
+			ResultNonce: "AAAAAAAyUhEAAAAAAAAA",
+			ResultData:  "93XWM2Pgg+4P//SfcIgMbv8t/ZPb",
+		},
+		Success: common.Ptr(true),
+		Error:   nil,
+	}
+	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
+	require.Nil(t, err)
+
+	verifyTxData(t, &expected, blockData.TransactionData[0])
+}
+
+func TestExtractFailedEncryptedTx(t *testing.T) {
+	txBody, _ := base64.StdEncoding.DecodeString("+QE4gwL1bIUXSHboAIMPQkCU2h48CsdPLxC7DHY1ydxovT2gyVuAuM2iZGJvZHmjYnBrWCDUnh5gkwUk6Cw4huLOP3lTMFtCmN8n4ltIpAlVZ94NZ2RkYXRhWHyVr0ki6C9hWguv2FPHI046DSIKbXpE5K4ls2RFbPy9M6M5HzuqJBbuA74qCub93GK1QV/kHqcsxBZP2MVRgGlfj81krakaipNzwho+Xe/ETHPigxbBCtO/gA92dewZfYnZ6WrFSZ4MUpNOh0RI+mGbZkrpuyJogMk7B4ehZW5vbmNlT2U966XgO5N7jx2V90nP42Zmb3JtYXQBgrYhoCbdbtYSkhEAaGzp4EOa6vymDawzpqGUAcRKUpCItUoPoGFF2WiD2hvI89jTHHP6lCvJVMBdA0+vdSAO29YnCMeq")
+	// round: 3297812, index: 0
+	txrs := []nodeapi.RuntimeTransactionWithResults{
+		{
+			Tx: types.UnverifiedTransaction{
+				Body: txBody,
+				AuthProofs: []types.AuthProof{
+					{
+						Module: "evm.ethereum.v0",
+					},
+				},
+			},
+			Result: types.CallResult{
+				Failed: &types.FailedCallResult{
+					Module:  "evm",
+					Code:    8,
+					Message: "reverted: CMN5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABJ0b28gbGF0ZSB0byBzdWJtaXQAAAAAAAAAAAAAAAAAAA==",
+				},
+			},
+		},
+	}
+	expected := mockTxData{
+		Raw:       "glkBO/kBOIMC9WyFF0h26ACDD0JAlNoePArHTy8Quwx2NcncaL09oMlbgLjNomRib2R5o2Jwa1gg1J4eYJMFJOgsOIbizj95UzBbQpjfJ+JbSKQJVWfeDWdkZGF0YVh8la9JIugvYVoLr9hTxyNOOg0iCm16ROSuJbNkRWz8vTOjOR87qiQW7gO+Kgrm/dxitUFf5B6nLMQWT9jFUYBpX4/NZK2pGoqTc8IaPl3vxExz4oMWwQrTv4APdnXsGX2J2elqxUmeDFKTTodESPphm2ZK6bsiaIDJOweHoWVub25jZU9lPeul4DuTe48dlfdJz+NmZm9ybWF0AYK2IaAm3W7WEpIRAGhs6eBDmur8pg2sM6ahlAHESlKQiLVKD6BhRdlog9obyPPY0xxz+pQryVTAXQNPr3UgDtvWJwjHqoGhZm1vZHVsZW9ldm0uZXRoZXJldW0udjA=",
+		RawResult: "oWRmYWlso2Rjb2RlCGZtb2R1bGVjZXZtZ21lc3NhZ2V4knJldmVydGVkOiBDTU41b0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQWdBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUJKMGIyOGdiR0YwWlNCMGJ5QnpkV0p0YVhRQUFBQUFBQUFBQUFBQUFBQUFBQT09",
+		Method:    "evm.Call",
+		EvmEncrypted: &mockEvmEncrypted{
+			Format:      "encrypted/x25519-deoxysii",
+			PublicKey:   "1J4eYJMFJOgsOIbizj95UzBbQpjfJ+JbSKQJVWfeDWc=",
+			DataNonce:   "ZT3rpeA7k3uPHZX3Sc/j",
+			DataData:    "la9JIugvYVoLr9hTxyNOOg0iCm16ROSuJbNkRWz8vTOjOR87qiQW7gO+Kgrm/dxitUFf5B6nLMQWT9jFUYBpX4/NZK2pGoqTc8IaPl3vxExz4oMWwQrTv4APdnXsGX2J2elqxUmeDFKTTodESPphm2ZK6bsiaIDJOweHoQ==",
+			ResultNonce: "",
+			ResultData:  "",
+		},
+		Success: common.Ptr(false),
+		Error: &TxError{
+			Code:       8,
+			Module:     "evm",
+			RawMessage: common.Ptr("reverted: CMN5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABJ0b28gbGF0ZSB0byBzdWJtaXQAAAAAAAAAAAAAAAAAAA=="),
+			Message:    common.Ptr("reverted: too late to submit"),
+		},
+	}
+	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
+	require.Nil(t, err)
+
+	verifyTxData(t, &expected, blockData.TransactionData[0])
+}
+
+func TestExtractSuccessfulUnecryptedTx(t *testing.T) {
+	txBody, _ := base64.StdEncoding.DecodeString("+HGDEpOvhRdIdugAgnUwlO2jlWZuVt2eLvO9x27uNztzhkDdiAFjRXjCzycUgIK2IqDZ9hicLCKMvkYPfcnxp7uKn+9ayRFBIZlSKutUaXuM/KBAnuTyW6fGXEVAEPOiMdEYPzyQDkW4EjFUMVVhpNf9/Q==")
+	txResult, _ := base64.StdEncoding.DecodeString("QA==")
+	// round: 3297812, index: 1
+	txrs := []nodeapi.RuntimeTransactionWithResults{
+		{
+			Tx: types.UnverifiedTransaction{
+				Body: txBody,
+				AuthProofs: []types.AuthProof{
+					{
+						Module: "evm.ethereum.v0",
+					},
+				},
+			},
+			Result: types.CallResult{
+				Ok: cbor.RawMessage(txResult),
+			},
+		},
+	}
+	expected := mockTxData{
+		Raw:          "glhz+HGDEpOvhRdIdugAgnUwlO2jlWZuVt2eLvO9x27uNztzhkDdiAFjRXjCzycUgIK2IqDZ9hicLCKMvkYPfcnxp7uKn+9ayRFBIZlSKutUaXuM/KBAnuTyW6fGXEVAEPOiMdEYPzyQDkW4EjFUMVVhpNf9/YGhZm1vZHVsZW9ldm0uZXRoZXJldW0udjA=",
+		RawResult:    "oWJva0A=",
+		Method:       "evm.Call",
+		EvmEncrypted: nil,
+		Success:      common.Ptr(true),
+		Error:        nil,
+	}
+	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
+	require.Nil(t, err)
+
+	verifyTxData(t, &expected, blockData.TransactionData[0])
+}
+
+func TestExtractFailedUnecryptedTx(t *testing.T) {
+	txBody, _ := base64.StdEncoding.DecodeString("+QEuggdghRdIdugAgw9CQJSm2rSCCcCmlseYXunsRiANpUt3A4C4xKKU2XUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZTaGFyb24AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANUGhpbG1hX0tyYWtlbgAAAAAAAAAAAAAAAAAAAAAAAACCtiGgFPX+w6su01SbkC+02CPG+dt9p94lDkuyFrCb46AfnyWgXBA3aAX4QyXQZqO4DW+/Owk1kL0g/Sir5ftcBkz83BU=")
+	// round: 3297811, index: 0
+	txrs := []nodeapi.RuntimeTransactionWithResults{
+		{
+			Tx: types.UnverifiedTransaction{
+				Body: txBody,
+				AuthProofs: []types.AuthProof{
+					{
+						Module: "evm.ethereum.v0",
+					},
+				},
+			},
+			Result: types.CallResult{
+				Failed: &types.FailedCallResult{
+					Module:  "evm",
+					Code:    2,
+					Message: "execution failed: out of gas",
+				},
+			},
+		},
+	}
+	expected := mockTxData{
+		Raw:          "glkBMfkBLoIHYIUXSHboAIMPQkCUptq0ggnAppbHmF7p7EYgDaVLdwOAuMSilNl1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGU2hhcm9uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADVBoaWxtYV9LcmFrZW4AAAAAAAAAAAAAAAAAAAAAAAAAgrYhoBT1/sOrLtNUm5AvtNgjxvnbfafeJQ5Lshawm+OgH58loFwQN2gF+EMl0GajuA1vvzsJNZC9IP0oq+X7XAZM/NwVgaFmbW9kdWxlb2V2bS5ldGhlcmV1bS52MA==",
+		RawResult:    "oWRmYWlso2Rjb2RlAmZtb2R1bGVjZXZtZ21lc3NhZ2V4HGV4ZWN1dGlvbiBmYWlsZWQ6IG91dCBvZiBnYXM=",
+		Method:       "evm.Call",
+		EvmEncrypted: nil,
+		Success:      common.Ptr(false),
+		Error: &TxError{
+			Code:       2,
+			Module:     "evm",
+			RawMessage: common.Ptr("execution failed: out of gas"),
+			Message:    common.Ptr("execution failed: out of gas"),
+		},
+	}
+	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
+	require.Nil(t, err)
+
+	verifyTxData(t, &expected, blockData.TransactionData[0])
+}
+
+func verifyTxData(t *testing.T, expected *mockTxData, actual *BlockTransactionData) {
+	require.Equal(t, expected.Raw, base64.StdEncoding.EncodeToString(actual.Raw))
+	require.Equal(t, expected.RawResult, base64.StdEncoding.EncodeToString(actual.RawResult))
+	require.Equal(t, expected.Method, actual.Method)
+	require.Equal(t, *expected.Success, *actual.Success)
+	if expected.EvmEncrypted != nil {
+		require.NotNil(t, actual.EVMEncrypted)
+		require.Equal(t, expected.EvmEncrypted.Format, actual.EVMEncrypted.Format)
+		require.Equal(t, expected.EvmEncrypted.PublicKey, base64.StdEncoding.EncodeToString(actual.EVMEncrypted.PublicKey))
+		require.Equal(t, expected.EvmEncrypted.DataNonce, base64.StdEncoding.EncodeToString(actual.EVMEncrypted.DataNonce))
+		require.Equal(t, expected.EvmEncrypted.DataData, base64.StdEncoding.EncodeToString(actual.EVMEncrypted.DataData))
+		require.Equal(t, expected.EvmEncrypted.ResultNonce, base64.StdEncoding.EncodeToString(actual.EVMEncrypted.ResultNonce))
+		require.Equal(t, expected.EvmEncrypted.ResultData, base64.StdEncoding.EncodeToString(actual.EVMEncrypted.ResultData))
+	} else {
+		require.Nil(t, actual.EVMEncrypted)
+	}
+	if expected.Error != nil {
+		require.NotNil(t, actual.Error)
+		require.Equal(t, expected.Error.Code, actual.Error.Code)
+		require.Equal(t, expected.Error.Module, actual.Error.Module)
+		if expected.Error.RawMessage != nil {
+			require.NotNil(t, actual.Error.RawMessage)
+			require.Equal(t, *expected.Error.RawMessage, *actual.Error.RawMessage)
+		}
+		if expected.Error.Message != nil {
+			require.NotNil(t, actual.Error.Message)
+			require.Equal(t, *expected.Error.Message, *actual.Error.Message)
+		}
+	} else {
+		require.Nil(t, actual.Error)
+	}
 }

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -113,7 +113,7 @@ func VisitCall(call *sdkTypes.Call, result *sdkTypes.CallResult, handler *CallHa
 			if !result.IsUnknown() && result.IsSuccess() {
 				var ok []byte
 				if err := cbor.Unmarshal(result.Ok, &ok); err != nil {
-					return fmt.Errorf("unmarshal evm create result: %w", err)
+					return fmt.Errorf("unmarshal evm call result: %w", err)
 				}
 				okP = &ok
 			}


### PR DESCRIPTION
https://app.clickup.com/t/8692tq704

```
oasisindexer=> select count(*) from chain.runtime_transactions where evm_encrypted_format='encrypted/x25519-deoxysii' and method='evm.Call' and success=true and evm_encrypted_result_data is not NULL;
 count
-------
 15318 <-- encrypted results
(1 row)

oasisindexer=> select count(*) from chain.runtime_transactions where evm_encrypted_format='encrypted/x25519-deoxysii' and method='evm.Call' and success=true and evm_encrypted_result_data is NULL;
 count
--------
 212680 <-- unencrypted results
```

Before:
```
indexer=# select runtime, round, tx_index, method, success, evm_encrypted_result_data from chain.runtime_transactions
;
 runtime  |  round  | tx_index |  method  | success | evm_encrypted_result_data
----------+---------+----------+----------+---------+---------------------------
 sapphire | 2993605 |        0 | evm.Call | t       |
 sapphire | 2993605 |        1 | evm.Call | t       |
 sapphire | 2993606 |        0 | evm.Call | t       |
 sapphire | 2993606 |        1 | evm.Call | t       |
 sapphire | 2993607 |        0 | evm.Call | t       |
 sapphire | 2993607 |        1 | evm.Call | t       |
 sapphire | 2993608 |        0 | evm.Call | f       |
(7 rows)
```

After
```
indexer=# select runtime, round, tx_index, method, success, evm_encrypted_result_data from chain.runtime_transactions
;
 runtime  |  round  | tx_index |  method  | success |          evm_encrypted_result_data
----------+---------+----------+----------+---------+----------------------------------------------
 sapphire | 2993605 |        0 | evm.Call | t       | \x76115a6703f475bdc9eee0747ba441cedc4ed9ebfe
 sapphire | 2993605 |        1 | evm.Call | t       | \x7c495d2602e702b7b490779a5e029f436fcfb02c7b
 sapphire | 2993606 |        0 | evm.Call | t       |
 sapphire | 2993606 |        1 | evm.Call | t       | \x40d51310f0ab71197168e70d45b3bff595c10840d5
 sapphire | 2993607 |        0 | evm.Call | t       | \xa8eafc2f40b431323d3017142d8c87208f8e5d8d28
 sapphire | 2993607 |        1 | evm.Call | t       | \x74c6ed9bd74cdbfeec89c4c55e3ada66dc94f2b8b5
 sapphire | 2993608 |        0 | evm.Call | f       |
(7 rows)
```

On testnet, after block 542000 we stopped parsing the tx results correctly... will need a full reindex.

Future Todo: Make sure this is covered in the e2e_regression tests when we add sapphire to them.