### PR TITLE
analyzer: Fix syntax error in SQL (TakeEscrow)

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -309,7 +309,7 @@ var (
     UPDATE chain.accounts
       SET
         escrow_balance_active = escrow_balance_active - $2,
-        escrow_balance_debonding = escrow_balance_debonding - $3,
+        escrow_balance_debonding = escrow_balance_debonding - $3
       WHERE address = $1`
 
 	ConsensusDebondingStartEscrowBalanceUpdate = `


### PR DESCRIPTION
Pretty bad testing fail :/ -- this has been released since v0.1.19.
Our e2e regressions did not catch this; I guess there was no suitable event in the range we're testing.

I'm building locally and will deploying as a hotfix on top of 0.1.20 to testnet prod and staging. (testnet prod is where this first led to a live error)