### PR TITLE
Rename enigma -> eden

### DIFF
--- a/coreapi/v22.2.11/staking/api/api.go
+++ b/coreapi/v22.2.11/staking/api/api.go
@@ -120,7 +120,7 @@ type TakeEscrowEvent struct {
 	Owner Address `json:"owner"`
 	// Total amount slashed across active and debonding stake.
 	Amount quantity.Quantity `json:"amount"`
-	// NOTE: DebondingAmount is not present in Damask; Enigma (v23.0) introduces it.
+	// NOTE: DebondingAmount is not present in Damask; Eden (v23.0) introduces it.
 	// If this field is `nil`, the amount of active vs debonding _slashed_ stake
 	// needs to be computed and is proportional to the total current active vs debonding
 	// staked amounts; the event itself does not provide enough info. If this field is not

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -114,7 +114,7 @@ type Event struct {
 	StakingAllowanceChange      *AllowanceChangeEvent
 
 	RegistryRuntimeStarted   *RuntimeStartedEvent
-	RegistryRuntimeSuspended *RuntimeSuspendedEvent // Available starting with Enigma.
+	RegistryRuntimeSuspended *RuntimeSuspendedEvent // Available starting with Eden.
 	RegistryEntity           *EntityEvent
 	RegistryNode             *NodeEvent
 	RegistryNodeUnfrozen     *NodeUnfrozenEvent

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -32,26 +32,26 @@ import (
 	stakingCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/staking/api"
 )
 
-// CobaltConsensusApiLite provides low-level access to the consensus API of a
+// ConsensusApiLite provides low-level access to the consensus API of a
 // Cobalt node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
-type CobaltConsensusApiLite struct {
+type ConsensusApiLite struct {
 	grpcConn *connections.LazyGrpcConn
 }
 
-var _ nodeapi.ConsensusApiLite = (*CobaltConsensusApiLite)(nil)
+var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewCobaltConsensusApiLite(grpcConn *connections.LazyGrpcConn) *CobaltConsensusApiLite {
-	return &CobaltConsensusApiLite{
+func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
+	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}
 }
 
-func (c *CobaltConsensusApiLite) Close() error {
+func (c *ConsensusApiLite) Close() error {
 	return c.grpcConn.Close()
 }
 
-func (c *CobaltConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
+func (c *ConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
 	var rsp genesisCobalt.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {
 		return nil, fmt.Errorf("GetGenesisDocument(cobalt): %w", err)
@@ -59,7 +59,7 @@ func (c *CobaltConsensusApiLite) GetGenesisDocument(ctx context.Context, chainCo
 	return ConvertGenesis(rsp), nil
 }
 
-func (c *CobaltConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+func (c *ConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	var rsp genesisCobalt.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/StateToGenesis", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
@@ -67,7 +67,7 @@ func (c *CobaltConsensusApiLite) StateToGenesis(ctx context.Context, height int6
 	return ConvertGenesis(rsp), nil
 }
 
-func (c *CobaltConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
+func (c *ConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
 	var rsp consensusCobalt.Block
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetBlock", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
@@ -75,7 +75,7 @@ func (c *CobaltConsensusApiLite) GetBlock(ctx context.Context, height int64) (*c
 	return convertBlock(rsp), nil
 }
 
-func (c *CobaltConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
+func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
 	var rsp consensusCobalt.TransactionsWithResults
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetTransactionsWithResults", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
@@ -105,7 +105,7 @@ func (c *CobaltConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	return txrs, nil
 }
 
-func (c *CobaltConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
+func (c *ConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
 	var rsp beaconCobalt.EpochTime
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Beacon/GetEpoch", height, &rsp); err != nil {
 		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
@@ -113,7 +113,7 @@ func (c *CobaltConsensusApiLite) GetEpoch(ctx context.Context, height int64) (be
 	return rsp, nil
 }
 
-func (c *CobaltConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*registryCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
@@ -125,7 +125,7 @@ func (c *CobaltConsensusApiLite) RegistryEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *CobaltConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*stakingCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Staking/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
@@ -137,7 +137,7 @@ func (c *CobaltConsensusApiLite) StakingEvents(ctx context.Context, height int64
 	return events, nil
 }
 
-func (c *CobaltConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*governanceCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
@@ -149,7 +149,7 @@ func (c *CobaltConsensusApiLite) GovernanceEvents(ctx context.Context, height in
 	return events, nil
 }
 
-func (c *CobaltConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*roothashCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.RootHash/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
@@ -161,7 +161,7 @@ func (c *CobaltConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *CobaltConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
+func (c *ConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
 	var rsp []*nodeapi.Node // ABI is stable across Cobalt and Damask
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetNodes", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetNodes(%d): %w", height, err)
@@ -173,7 +173,7 @@ func (c *CobaltConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]
 	return nodes, nil
 }
 
-func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+func (c *ConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	var rsp []*schedulerCobalt.Validator
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetValidators", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
@@ -185,7 +185,7 @@ func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64
 	return validators, nil
 }
 
-func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+func (c *ConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
 	var rsp []*schedulerCobalt.Committee
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittees", &scheduler.GetCommitteesRequest{
 		Height:    height,
@@ -200,7 +200,7 @@ func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64
 	return committees, nil
 }
 
-func (c *CobaltConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
 	var rsp *governanceCobalt.Proposal
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/Proposal", &governance.ProposalQuery{
 		Height:     height,

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -26,27 +26,27 @@ import (
 	txResultsDamask "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api/transaction/results"
 )
 
-// DamaskConsensusApiLite provides low-level access to the consensus API of a
+// ConsensusApiLite provides low-level access to the consensus API of a
 // Damask node. Since Nexus is linked against a version of oasis-core that is
 // compatible with Damask gRPC API, this struct just trivially wraps the
 // convenience methods provided by oasis-core.
-type DamaskConsensusApiLite struct {
+type ConsensusApiLite struct {
 	grpcConn *connections.LazyGrpcConn
 }
 
-var _ nodeapi.ConsensusApiLite = (*DamaskConsensusApiLite)(nil)
+var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewDamaskConsensusApiLite(grpcConn *connections.LazyGrpcConn) *DamaskConsensusApiLite {
-	return &DamaskConsensusApiLite{
+func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
+	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}
 }
 
-func (c *DamaskConsensusApiLite) Close() error {
+func (c *ConsensusApiLite) Close() error {
 	return c.grpcConn.Close()
 }
 
-func (c *DamaskConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
+func (c *ConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
 	var rsp genesis.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {
 		return nil, fmt.Errorf("GetGenesisDocument(damask): %w", err)
@@ -54,7 +54,7 @@ func (c *DamaskConsensusApiLite) GetGenesisDocument(ctx context.Context, chainCo
 	return &rsp, nil
 }
 
-func (c *DamaskConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+func (c *ConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	var rsp genesis.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/StateToGenesis", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
@@ -62,7 +62,7 @@ func (c *DamaskConsensusApiLite) StateToGenesis(ctx context.Context, height int6
 	return &rsp, nil
 }
 
-func (c *DamaskConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
+func (c *ConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
 	var rsp consensus.Block
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetBlock", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
@@ -70,7 +70,7 @@ func (c *DamaskConsensusApiLite) GetBlock(ctx context.Context, height int64) (*c
 	return &rsp, nil
 }
 
-func (c *DamaskConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
+func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
 	var rsp consensus.TransactionsWithResults
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetTransactionsWithResults", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
@@ -100,7 +100,7 @@ func (c *DamaskConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	return txrs, nil
 }
 
-func (c *DamaskConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
+func (c *ConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
 	var rsp beacon.EpochTime
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Beacon/GetEpoch", height, &rsp); err != nil {
 		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
@@ -108,7 +108,7 @@ func (c *DamaskConsensusApiLite) GetEpoch(ctx context.Context, height int64) (be
 	return rsp, nil
 }
 
-func (c *DamaskConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*registry.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
@@ -120,7 +120,7 @@ func (c *DamaskConsensusApiLite) RegistryEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *DamaskConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*staking.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Staking/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
@@ -132,7 +132,7 @@ func (c *DamaskConsensusApiLite) StakingEvents(ctx context.Context, height int64
 	return events, nil
 }
 
-func (c *DamaskConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*governance.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
@@ -144,7 +144,7 @@ func (c *DamaskConsensusApiLite) GovernanceEvents(ctx context.Context, height in
 	return events, nil
 }
 
-func (c *DamaskConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*roothash.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.RootHash/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
@@ -156,7 +156,7 @@ func (c *DamaskConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *DamaskConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
+func (c *ConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
 	var rsp []*nodeapi.Node
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetNodes", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetNodes(%d): %w", height, err)
@@ -168,7 +168,7 @@ func (c *DamaskConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]
 	return nodes, nil
 }
 
-func (c *DamaskConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+func (c *ConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	var rsp []*scheduler.Validator
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetValidators", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
@@ -180,7 +180,7 @@ func (c *DamaskConsensusApiLite) GetValidators(ctx context.Context, height int64
 	return validators, nil
 }
 
-func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+func (c *ConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
 	var rsp []*scheduler.Committee
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittees", &scheduler.GetCommitteesRequest{
 		Height:    height,
@@ -200,7 +200,7 @@ func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64
 	return committees, nil
 }
 
-func (c *DamaskConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
 	var rsp *governance.Proposal
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/Proposal", &governance.ProposalQuery{
 		Height:     height,

--- a/storage/oasis/nodeapi/eden/convert.go
+++ b/storage/oasis/nodeapi/eden/convert.go
@@ -1,4 +1,4 @@
-package enigma
+package eden
 
 import (
 	"strings"
@@ -21,17 +21,17 @@ import (
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
-	// data types for Enigma gRPC APIs.
-	nodeEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/common/node"
-	txResultsEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api/transaction/results"
-	genesisEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/genesis/api"
-	governanceEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/governance/api"
-	registryEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/registry/api"
-	schedulerEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/scheduler/api"
-	stakingEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
+	// data types for Eden gRPC APIs.
+	nodeEden "github.com/oasisprotocol/nexus/coreapi/v23.0/common/node"
+	txResultsEden "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api/transaction/results"
+	genesisEden "github.com/oasisprotocol/nexus/coreapi/v23.0/genesis/api"
+	governanceEden "github.com/oasisprotocol/nexus/coreapi/v23.0/governance/api"
+	registryEden "github.com/oasisprotocol/nexus/coreapi/v23.0/registry/api"
+	schedulerEden "github.com/oasisprotocol/nexus/coreapi/v23.0/scheduler/api"
+	stakingEden "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
 )
 
-func convertProposal(p *governanceEnigma.Proposal) *governance.Proposal {
+func convertProposal(p *governanceEden.Proposal) *governance.Proposal {
 	results := make(map[governance.Vote]quantity.Quantity)
 	for k, v := range p.Results {
 		results[governance.Vote(k)] = v
@@ -66,7 +66,7 @@ func convertProposal(p *governanceEnigma.Proposal) *governance.Proposal {
 	}
 }
 
-func convertAccount(a *stakingEnigma.Account) *staking.Account {
+func convertAccount(a *stakingEden.Account) *staking.Account {
 	rateSteps := make([]staking.CommissionRateStep, len(a.Escrow.CommissionSchedule.Rates))
 	for i, r := range a.Escrow.CommissionSchedule.Rates {
 		rateSteps[i] = staking.CommissionRateStep(r)
@@ -88,7 +88,7 @@ func convertAccount(a *stakingEnigma.Account) *staking.Account {
 	}
 }
 
-func convertRuntime(r *registryEnigma.Runtime) *registry.Runtime {
+func convertRuntime(r *registryEden.Runtime) *registry.Runtime {
 	return &registry.Runtime{
 		ID:          r.ID,
 		EntityID:    r.EntityID,
@@ -98,7 +98,7 @@ func convertRuntime(r *registryEnigma.Runtime) *registry.Runtime {
 	}
 }
 
-func convertNodeAddresses(addrs []nodeEnigma.Address) []node.Address {
+func convertNodeAddresses(addrs []nodeEden.Address) []node.Address {
 	ret := make([]node.Address, len(addrs))
 	for i, a := range addrs {
 		ret[i] = node.Address(a)
@@ -106,7 +106,7 @@ func convertNodeAddresses(addrs []nodeEnigma.Address) []node.Address {
 	return ret
 }
 
-func convertNodeConsensusAddresses(addrs []nodeEnigma.ConsensusAddress) []node.ConsensusAddress {
+func convertNodeConsensusAddresses(addrs []nodeEden.ConsensusAddress) []node.ConsensusAddress {
 	ret := make([]node.ConsensusAddress, len(addrs))
 	for i, a := range addrs {
 		ret[i] = node.ConsensusAddress{
@@ -117,8 +117,8 @@ func convertNodeConsensusAddresses(addrs []nodeEnigma.ConsensusAddress) []node.C
 	return ret
 }
 
-func convertNode(signedNode *nodeEnigma.MultiSignedNode) (*node.Node, error) {
-	var n nodeEnigma.Node
+func convertNode(signedNode *nodeEden.MultiSignedNode) (*node.Node, error) {
+	var n nodeEden.Node
 	if err := cbor.Unmarshal(signedNode.Blob, &n); err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func convertNode(signedNode *nodeEnigma.MultiSignedNode) (*node.Node, error) {
 		Expiration: n.Expiration,
 		TLS: node.TLSInfo{
 			PubKey: n.TLS.PubKey,
-			// `NextPubKey` and `Addresses` are not present in Enigma.
+			// `NextPubKey` and `Addresses` are not present in Eden.
 		},
 		P2P: node.P2PInfo{
 			ID:        n.P2P.ID,
@@ -152,11 +152,11 @@ func convertNode(signedNode *nodeEnigma.MultiSignedNode) (*node.Node, error) {
 	}, nil
 }
 
-// ConvertGenesis converts a genesis document from the Enigma format to the
+// ConvertGenesis converts a genesis document from the Eden format to the
 // nexus-internal format.
 // WARNING: This is a partial conversion, only the fields that are used by
 // Nexus are filled in the output document.
-func ConvertGenesis(d genesisEnigma.Document) (*genesis.Document, error) {
+func ConvertGenesis(d genesisEden.Document) (*genesis.Document, error) {
 	proposals := make([]*governance.Proposal, len(d.Governance.Proposals))
 	for i, p := range d.Governance.Proposals {
 		proposals[i] = convertProposal(p)
@@ -252,7 +252,7 @@ func ConvertGenesis(d genesisEnigma.Document) (*genesis.Document, error) {
 	}, nil
 }
 
-func convertEvent(e txResultsEnigma.Event) nodeapi.Event {
+func convertEvent(e txResultsEden.Event) nodeapi.Event {
 	ret := nodeapi.Event{}
 	switch {
 	case e.Staking != nil:
@@ -366,9 +366,9 @@ func convertEvent(e txResultsEnigma.Event) nodeapi.Event {
 					EntityID:           e.Registry.NodeEvent.Node.EntityID,
 					Expiration:         e.Registry.NodeEvent.Node.Expiration,
 					VRFPubKey:          vrfID,
-					TLSAddresses:       []string{}, // Not used any more in Enigma.
+					TLSAddresses:       []string{}, // Not used any more in Eden.
 					TLSPubKey:          e.Registry.NodeEvent.Node.TLS.PubKey,
-					TLSNextPubKey:      signature.PublicKey{}, // Not used any more in Enigma.
+					TLSNextPubKey:      signature.PublicKey{}, // Not used any more in Eden.
 					P2PID:              e.Registry.NodeEvent.Node.P2P.ID,
 					P2PAddresses:       p2pAddresses,
 					RuntimeIDs:         runtimeIDs,
@@ -433,7 +433,7 @@ func convertEvent(e txResultsEnigma.Event) nodeapi.Event {
 			ret = nodeapi.Event{
 				GovernanceProposalFinalized: &nodeapi.ProposalFinalizedEvent{
 					ID: e.Governance.ProposalFinalized.ID,
-					// The enum is compatible between Enigma and Damask.
+					// The enum is compatible between Eden and Damask.
 					State: governance.ProposalState(e.Governance.ProposalFinalized.State),
 				},
 				RawBody: common.TryAsJSON(e.Governance.ProposalFinalized),
@@ -457,7 +457,7 @@ func convertEvent(e txResultsEnigma.Event) nodeapi.Event {
 	return ret
 }
 
-func convertTxResult(r txResultsEnigma.Result) nodeapi.TxResult {
+func convertTxResult(r txResultsEden.Result) nodeapi.TxResult {
 	events := make([]nodeapi.Event, len(r.Events))
 	for i, e := range r.Events {
 		events[i] = convertEvent(*e)
@@ -469,16 +469,16 @@ func convertTxResult(r txResultsEnigma.Result) nodeapi.TxResult {
 	}
 }
 
-func convertCommittee(c schedulerEnigma.Committee) nodeapi.Committee {
+func convertCommittee(c schedulerEden.Committee) nodeapi.Committee {
 	members := make([]*scheduler.CommitteeNode, len(c.Members))
 	for j, m := range c.Members {
 		members[j] = &scheduler.CommitteeNode{
 			PublicKey: m.PublicKey,
-			Role:      scheduler.Role(m.Role), // The enum is compatible between Enigma and Damask.
+			Role:      scheduler.Role(m.Role), // The enum is compatible between Eden and Damask.
 		}
 	}
 	return nodeapi.Committee{
-		Kind:      nodeapi.CommitteeKind(c.Kind), // The enum is compatible between Enigma and Damask.
+		Kind:      nodeapi.CommitteeKind(c.Kind), // The enum is compatible between Eden and Damask.
 		Members:   members,
 		RuntimeID: c.RuntimeID,
 		ValidFor:  c.ValidFor,

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -1,4 +1,4 @@
-package enigma
+package eden
 
 import (
 	"context"
@@ -21,63 +21,63 @@ import (
 	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
-	// data types for Enigma gRPC APIs.
-	beaconEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/beacon/api"
-	consensusEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api"
-	txResultsEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api/transaction/results"
-	genesisEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/genesis/api"
-	governanceEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/governance/api"
-	registryEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/registry/api"
-	roothashEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/roothash/api"
-	schedulerEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/scheduler/api"
-	stakingEnigma "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
+	// data types for Eden gRPC APIs.
+	beaconEden "github.com/oasisprotocol/nexus/coreapi/v23.0/beacon/api"
+	consensusEden "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api"
+	txResultsEden "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api/transaction/results"
+	genesisEden "github.com/oasisprotocol/nexus/coreapi/v23.0/genesis/api"
+	governanceEden "github.com/oasisprotocol/nexus/coreapi/v23.0/governance/api"
+	registryEden "github.com/oasisprotocol/nexus/coreapi/v23.0/registry/api"
+	roothashEden "github.com/oasisprotocol/nexus/coreapi/v23.0/roothash/api"
+	schedulerEden "github.com/oasisprotocol/nexus/coreapi/v23.0/scheduler/api"
+	stakingEden "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
 )
 
-// EnigmaConsensusApiLite provides low-level access to the consensus API of a
-// Enigma node. To be able to use the old gRPC API, this struct uses gRPC
+// EdenConsensusApiLite provides low-level access to the consensus API of a
+// Eden node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
-type EnigmaConsensusApiLite struct {
+type EdenConsensusApiLite struct {
 	grpcConn *grpc.ClientConn
 }
 
-var _ nodeapi.ConsensusApiLite = (*EnigmaConsensusApiLite)(nil)
+var _ nodeapi.ConsensusApiLite = (*EdenConsensusApiLite)(nil)
 
-func NewEnigmaConsensusApiLite(grpcConn *grpc.ClientConn) *EnigmaConsensusApiLite {
-	return &EnigmaConsensusApiLite{
+func NewEdenConsensusApiLite(grpcConn *grpc.ClientConn) *EdenConsensusApiLite {
+	return &EdenConsensusApiLite{
 		grpcConn: grpcConn,
 	}
 }
 
-func (c *EnigmaConsensusApiLite) Close() error {
+func (c *EdenConsensusApiLite) Close() error {
 	return c.grpcConn.Close()
 }
 
-func (c *EnigmaConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
-	var rsp genesisEnigma.Document
+func (c *EdenConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
+	var rsp genesisEden.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {
-		return nil, fmt.Errorf("GetGenesisDocument(enigma): %w", err)
+		return nil, fmt.Errorf("GetGenesisDocument(eden): %w", err)
 	}
 	return ConvertGenesis(rsp)
 }
 
-func (c *EnigmaConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
-	var rsp genesisEnigma.Document
+func (c *EdenConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+	var rsp genesisEden.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/StateToGenesis", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
 	}
 	return ConvertGenesis(rsp)
 }
 
-func (c *EnigmaConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
-	var rsp consensusEnigma.Block
+func (c *EdenConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
+	var rsp consensusEden.Block
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetBlock", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
 	}
 	return (*consensus.Block)(&rsp), nil
 }
 
-func (c *EnigmaConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
-	var rsp consensusEnigma.TransactionsWithResults
+func (c *EdenConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
+	var rsp consensusEden.TransactionsWithResults
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetTransactionsWithResults", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
 	}
@@ -87,7 +87,7 @@ func (c *EnigmaConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			log.NewDefaultLogger("enigma-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
+			log.NewDefaultLogger("eden-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
 				"height", height,
 				"index", i,
 				"tx_bytes", txBytes,
@@ -106,64 +106,64 @@ func (c *EnigmaConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	return txrs, nil
 }
 
-func (c *EnigmaConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
-	var rsp beaconEnigma.EpochTime
+func (c *EdenConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
+	var rsp beaconEden.EpochTime
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Beacon/GetEpoch", height, &rsp); err != nil {
 		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
 	}
 	return rsp, nil
 }
 
-func (c *EnigmaConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
-	var rsp []*registryEnigma.Event
+func (c *EdenConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	var rsp []*registryEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
-		events[i] = convertEvent(txResultsEnigma.Event{Registry: e})
+		events[i] = convertEvent(txResultsEden.Event{Registry: e})
 	}
 	return events, nil
 }
 
-func (c *EnigmaConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
-	var rsp []*stakingEnigma.Event
+func (c *EdenConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	var rsp []*stakingEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Staking/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
-		events[i] = convertEvent(txResultsEnigma.Event{Staking: e})
+		events[i] = convertEvent(txResultsEden.Event{Staking: e})
 	}
 	return events, nil
 }
 
-func (c *EnigmaConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
-	var rsp []*governanceEnigma.Event
+func (c *EdenConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	var rsp []*governanceEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
-		events[i] = convertEvent(txResultsEnigma.Event{Governance: e})
+		events[i] = convertEvent(txResultsEden.Event{Governance: e})
 	}
 	return events, nil
 }
 
-func (c *EnigmaConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
-	var rsp []*roothashEnigma.Event
+func (c *EdenConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	var rsp []*roothashEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.RootHash/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
-		events[i] = convertEvent(txResultsEnigma.Event{RootHash: e})
+		events[i] = convertEvent(txResultsEden.Event{RootHash: e})
 	}
 	return events, nil
 }
 
-func (c *EnigmaConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
-	var rsp []*nodeapi.Node // ABI is stable across Enigma and Damask
+func (c *EdenConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
+	var rsp []*nodeapi.Node // ABI is stable across Eden and Damask
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetNodes", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetNodes(%d): %w", height, err)
 	}
@@ -174,8 +174,8 @@ func (c *EnigmaConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]
 	return nodes, nil
 }
 
-func (c *EnigmaConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
-	var rsp []*schedulerEnigma.Validator
+func (c *EdenConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+	var rsp []*schedulerEden.Validator
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetValidators", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
 	}
@@ -184,14 +184,14 @@ func (c *EnigmaConsensusApiLite) GetValidators(ctx context.Context, height int64
 		validators[i] = nodeapi.Validator{
 			ID:          v.ID,
 			VotingPower: v.VotingPower,
-			// Enigma introduces v.EntityID but we have it in the DB already, so no need to track it here also.
+			// Eden introduces v.EntityID but we have it in the DB already, so no need to track it here also.
 		}
 	}
 	return validators, nil
 }
 
-func (c *EnigmaConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
-	var rsp []*schedulerEnigma.Committee
+func (c *EdenConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+	var rsp []*schedulerEden.Committee
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittees", &scheduler.GetCommitteesRequest{
 		Height:    height,
 		RuntimeID: runtimeID,
@@ -205,8 +205,8 @@ func (c *EnigmaConsensusApiLite) GetCommittees(ctx context.Context, height int64
 	return committees, nil
 }
 
-func (c *EnigmaConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
-	var rsp *governanceEnigma.Proposal
+func (c *EdenConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+	var rsp *governanceEden.Proposal
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/Proposal", &governance.ProposalQuery{
 		Height:     height,
 		ProposalID: proposalID,

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -33,26 +33,26 @@ import (
 	stakingEden "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
 )
 
-// EdenConsensusApiLite provides low-level access to the consensus API of a
+// ConsensusApiLite provides low-level access to the consensus API of a
 // Eden node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
-type EdenConsensusApiLite struct {
+type ConsensusApiLite struct {
 	grpcConn *grpc.ClientConn
 }
 
-var _ nodeapi.ConsensusApiLite = (*EdenConsensusApiLite)(nil)
+var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewEdenConsensusApiLite(grpcConn *grpc.ClientConn) *EdenConsensusApiLite {
-	return &EdenConsensusApiLite{
+func NewConsensusApiLite(grpcConn *grpc.ClientConn) *ConsensusApiLite {
+	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}
 }
 
-func (c *EdenConsensusApiLite) Close() error {
+func (c *ConsensusApiLite) Close() error {
 	return c.grpcConn.Close()
 }
 
-func (c *EdenConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
+func (c *ConsensusApiLite) GetGenesisDocument(ctx context.Context, chainContext string) (*genesis.Document, error) {
 	var rsp genesisEden.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {
 		return nil, fmt.Errorf("GetGenesisDocument(eden): %w", err)
@@ -60,7 +60,7 @@ func (c *EdenConsensusApiLite) GetGenesisDocument(ctx context.Context, chainCont
 	return ConvertGenesis(rsp)
 }
 
-func (c *EdenConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+func (c *ConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	var rsp genesisEden.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/StateToGenesis", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
@@ -68,7 +68,7 @@ func (c *EdenConsensusApiLite) StateToGenesis(ctx context.Context, height int64)
 	return ConvertGenesis(rsp)
 }
 
-func (c *EdenConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
+func (c *ConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
 	var rsp consensusEden.Block
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetBlock", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
@@ -76,7 +76,7 @@ func (c *EdenConsensusApiLite) GetBlock(ctx context.Context, height int64) (*con
 	return (*consensus.Block)(&rsp), nil
 }
 
-func (c *EdenConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
+func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
 	var rsp consensusEden.TransactionsWithResults
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetTransactionsWithResults", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
@@ -106,7 +106,7 @@ func (c *EdenConsensusApiLite) GetTransactionsWithResults(ctx context.Context, h
 	return txrs, nil
 }
 
-func (c *EdenConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
+func (c *ConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
 	var rsp beaconEden.EpochTime
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Beacon/GetEpoch", height, &rsp); err != nil {
 		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
@@ -114,7 +114,7 @@ func (c *EdenConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beac
 	return rsp, nil
 }
 
-func (c *EdenConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*registryEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
@@ -126,7 +126,7 @@ func (c *EdenConsensusApiLite) RegistryEvents(ctx context.Context, height int64)
 	return events, nil
 }
 
-func (c *EdenConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*stakingEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Staking/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
@@ -138,7 +138,7 @@ func (c *EdenConsensusApiLite) StakingEvents(ctx context.Context, height int64) 
 	return events, nil
 }
 
-func (c *EdenConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*governanceEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
@@ -150,7 +150,7 @@ func (c *EdenConsensusApiLite) GovernanceEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *EdenConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+func (c *ConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*roothashEden.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.RootHash/GetEvents", height, &rsp); err != nil {
 		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
@@ -162,7 +162,7 @@ func (c *EdenConsensusApiLite) RoothashEvents(ctx context.Context, height int64)
 	return events, nil
 }
 
-func (c *EdenConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
+func (c *ConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]nodeapi.Node, error) {
 	var rsp []*nodeapi.Node // ABI is stable across Eden and Damask
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetNodes", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetNodes(%d): %w", height, err)
@@ -174,7 +174,7 @@ func (c *EdenConsensusApiLite) GetNodes(ctx context.Context, height int64) ([]no
 	return nodes, nil
 }
 
-func (c *EdenConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+func (c *ConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	var rsp []*schedulerEden.Validator
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetValidators", height, &rsp); err != nil {
 		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
@@ -190,7 +190,7 @@ func (c *EdenConsensusApiLite) GetValidators(ctx context.Context, height int64) 
 	return validators, nil
 }
 
-func (c *EdenConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+func (c *ConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
 	var rsp []*schedulerEden.Committee
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittees", &scheduler.GetCommitteesRequest{
 		Height:    height,
@@ -205,7 +205,7 @@ func (c *EdenConsensusApiLite) GetCommittees(ctx context.Context, height int64, 
 	return committees, nil
 }
 
-func (c *EdenConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
 	var rsp *governanceEden.Proposal
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/Proposal", &governance.ProposalQuery{
 		Height:     height,

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -24,12 +24,12 @@ type APIConstructor func(ctx context.Context, chainContext string, archiveConfig
 
 func damaskAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
 	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
-	return damask.NewDamaskConsensusApiLite(rawConn), nil
+	return damask.NewConsensusApiLite(rawConn), nil
 }
 
 func cobaltAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
 	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
-	return cobalt.NewCobaltConsensusApiLite(rawConn), nil
+	return cobalt.NewConsensusApiLite(rawConn), nil
 }
 
 func edenAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
@@ -37,7 +37,7 @@ func edenAPIConstructor(ctx context.Context, chainContext string, archiveConfig 
 	if err != nil {
 		return nil, fmt.Errorf("oasis-node RawConnect: %w", err)
 	}
-	return eden.NewEdenConsensusApiLite(rawConn), nil
+	return eden.NewConsensusApiLite(rawConn), nil
 }
 
 // APIConstructors map each (nexus-internal) archive name to the API constructor
@@ -50,7 +50,7 @@ var APIConstructors = map[string]APIConstructor{
 	// mainnet
 	"damask": damaskAPIConstructor,
 	"cobalt": cobaltAPIConstructor,
-	"eden": edenAPIConstructor,
+	"eden":   edenAPIConstructor,
 	// testnet
 	"2022-03-03": damaskAPIConstructor,
 	"2023-10-12": edenAPIConstructor,

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -15,7 +15,7 @@ import (
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/cobalt"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/damask"
-	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/enigma"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/eden"
 )
 
 var _ nodeapi.ConsensusApiLite = (*HistoryConsensusApiLite)(nil)
@@ -32,12 +32,12 @@ func cobaltAPIConstructor(ctx context.Context, chainContext string, archiveConfi
 	return cobalt.NewCobaltConsensusApiLite(rawConn), nil
 }
 
-func enigmaAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
+func edenAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
 	rawConn, err := connections.RawConnect(archiveConfig.ResolvedConsensusNode())
 	if err != nil {
 		return nil, fmt.Errorf("oasis-node RawConnect: %w", err)
 	}
-	return enigma.NewEnigmaConsensusApiLite(rawConn), nil
+	return eden.NewEdenConsensusApiLite(rawConn), nil
 }
 
 // APIConstructors map each (nexus-internal) archive name to the API constructor
@@ -50,10 +50,10 @@ var APIConstructors = map[string]APIConstructor{
 	// mainnet
 	"damask": damaskAPIConstructor,
 	"cobalt": cobaltAPIConstructor,
-	"enigma": enigmaAPIConstructor,
+	"eden": edenAPIConstructor,
 	// testnet
 	"2022-03-03": damaskAPIConstructor,
-	"2023-10-12": enigmaAPIConstructor,
+	"2023-10-12": edenAPIConstructor,
 }
 
 type HistoryConsensusApiLite struct {

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -3,13 +3,13 @@ analysis:
     custom_chain:
       history:
         records:
-          - archive_name: enigma
+          - archive_name: eden
             # ^ "Fake" name (because this is not the real chain), but used by nexus to choose the version of the node client
             genesis_height: 1
             chain_context: 182e2b0cd78c263e276ac127d04b0ab390a421e9b2b7073dd56823f11dd7b853
       sdk_network: {}
     nodes:
-      enigma:
+      eden:
         default:
           rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
   analyzers:


### PR DESCRIPTION
On the heels of https://github.com/oasisprotocol/docs/pull/600

This PR also renames `{Cobalt,Damask,Eden}ConsensusApiLite` to just `ConsensusApiLite`, letting the package names disambiguate between the various instances of `ConsensusApiLite`. That's less explicit but more idiomatic in Go and was requested/suggested by @ptrus recently.

Steps:
```
find -not -path '*/.git/*' -not -path './cache/*' -not -path '*/net-runner/*' -type f | xargs sed -i -E 's/enigma/eden/g'                                                
find -not -path '*/.git/*' -not -path './cache/*' -not -path '*/net-runner/*' -type f | xargs sed -i -E 's/Enigma/Eden/g'
git mv storage/oasis/nodeapi/{enigma,eden}
```
+ rename the ConsensusApiLite structs with IDE refactorings.
