### PR TITLE
runtime/evm: ignore unsupported token types

### DIFF
--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -236,7 +236,7 @@ func EVMDownloadMutatedToken(ctx context.Context, logger *log.Logger, source nod
 	// see https://github.com/oasisprotocol/nexus/issues/225
 
 	default:
-		return nil, fmt.Errorf("download mutated token type %v not handled", tokenType)
+		return nil, nil
 	}
 }
 
@@ -250,7 +250,7 @@ func EVMDownloadNewNFT(ctx context.Context, logger *log.Logger, source nodeapi.R
 		return nftData, nil
 
 	default:
-		return nil, fmt.Errorf("download stale nft type %v not handled", tokenType)
+		return &EVMNFTData{}, nil
 	}
 }
 
@@ -279,7 +279,7 @@ func EVMDownloadTokenBalance(ctx context.Context, logger *log.Logger, source nod
 	// see https://github.com/oasisprotocol/nexus/issues/225
 
 	default:
-		return nil, fmt.Errorf("download stale token balance type %v not handled", tokenType)
+		return nil, nil
 	}
 }
 

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -46,8 +46,8 @@ type EVMTokenMutableData struct {
 }
 
 type EVMNFTData struct {
-	MetadataURI      string
-	MetadataAccessed time.Time
+	MetadataURI      *string
+	MetadataAccessed *time.Time
 	Metadata         *string
 	Name             *string
 	Description      *string

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -208,6 +208,10 @@ func EVMDownloadNewToken(ctx context.Context, logger *log.Logger, source nodeapi
 	}
 
 	// No applicable token discovered.
+	logger.Info("new token did not meet any supported standards",
+		"round", round,
+		"token_eth_addr_hex", hex.EncodeToString(tokenEthAddr),
+	)
 	return &EVMTokenData{Type: common.TokenTypeUnsupported}, nil
 }
 
@@ -236,6 +240,11 @@ func EVMDownloadMutatedToken(ctx context.Context, logger *log.Logger, source nod
 	// see https://github.com/oasisprotocol/nexus/issues/225
 
 	default:
+		logger.Info("mutated token is not from a supported token type",
+			"round", round,
+			"token_eth_addr_hex", hex.EncodeToString(tokenEthAddr),
+			"token_type", tokenType,
+		)
 		return nil, nil
 	}
 }
@@ -250,6 +259,12 @@ func EVMDownloadNewNFT(ctx context.Context, logger *log.Logger, source nodeapi.R
 		return nftData, nil
 
 	default:
+		logger.Info("new NFT is not a supported token type",
+			"round", round,
+			"token_eth_addr_hex", hex.EncodeToString(tokenEthAddr),
+			"id", id,
+			"token_type", tokenType,
+		)
 		return &EVMNFTData{}, nil
 	}
 }
@@ -279,6 +294,12 @@ func EVMDownloadTokenBalance(ctx context.Context, logger *log.Logger, source nod
 	// see https://github.com/oasisprotocol/nexus/issues/225
 
 	default:
+		logger.Info("changed balance is not from a supported token type",
+			"round", round,
+			"token_eth_addr_hex", hex.EncodeToString(tokenEthAddr),
+			"account_eth_addr_hex", hex.EncodeToString(accountEthAddr),
+			"token_type", tokenType,
+		)
 		return nil, nil
 	}
 }

--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -48,7 +48,7 @@ func TestERC165(t *testing.T) {
 	supportsERC165, err := detectERC165(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
 	require.NoError(t, err)
 	require.True(t, supportsERC165)
-	supportsERC721, err := detectInterface(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr, ERC165InterfaceID)
+	supportsERC721, err := detectInterface(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr, ERC721InterfaceID)
 	require.NoError(t, err)
 	require.True(t, supportsERC721)
 }


### PR DESCRIPTION
a contract may arbitrarily lie to be detected as a certain token type and then emit events for a different kind of token. when these events cause analyzers to try to download information in a way that doesn't make sense, e.g. getting NFT information from an ERC-20 token, successfully complete the job with no data instead of aborting the download batch with an error.

this came up recently when a contract that didn't report itself as ERC-165 compatible and thus not ERC-721 compatible (as ERC-721 requires ERC-165 support) emitted ERC-721 Transfer events. the contract also implemented ERC721Enumerable, meaning it had a totalSupply() function, which is sufficient for us to recognize as an ERC-20 token.