### PR TITLE
Add "bisect" tool for finding where oasis-node and db diverge

### DIFF
--- a/cmd/bisect/data_fetch.go
+++ b/cmd/bisect/data_fetch.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/nexus/common"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/history"
+	"github.com/oasisprotocol/nexus/storage/postgres"
+
+	staking "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
+)
+
+// Returns number of shares delegated by `delegator` to `delegatee` at `height`.
+func delegationViaNodeApi(ctx context.Context, nodeApi *history.HistoryConsensusApiLite, height int64, delegator, delegatee staking.Address) common.BigInt {
+	api, err := nodeApi.APIForHeight(4743433)
+	if err != nil {
+		panic(err)
+	}
+	grpcConn := api.GrpcConn()
+
+	m := map[staking.Address]*staking.Delegation{}
+	// DelegationsTo is faster than DelegationsFor on old archive nodes.
+	if err := grpcConn.Invoke(ctx, "/oasis-core.Staking/DelegationsTo", staking.OwnerQuery{Height: height, Owner: delegatee}, &m); err != nil {
+		panic(err)
+	}
+
+	delegation, ok := m[delegator]
+	if !ok {
+		return common.BigInt{}
+	}
+	return common.BigIntFromQuantity(delegation.Shares)
+}
+
+// Returns number of shares delegated by `delegator` to `delegatee` at `height`, according to dead-reckoned DB values.
+func delegationViaDeadReckon(ctx context.Context, db *postgres.Client, height int64, delegator, delegatee staking.Address) common.BigInt {
+	// We cannot simply "SELECT shares FROM chain.delegations WHERE delegatee=$1 AND delegator=$2" because that only gives the most recent value.
+	// Simulate dead-reckoning instead.
+	shares := common.BigInt{}
+	if err := db.QueryRow(ctx, `
+		WITH candidate_events AS (
+			SELECT * FROM chain.events WHERE
+			ARRAY[$1, $2] <@ related_accounts AND  -- implied by the next condition anyway, but this speeds up the query
+			body->>'owner'=$1 and body->>'escrow'=$2 AND
+			tx_block <= $3
+		)
+		SELECT (
+			  (SELECT COALESCE(SUM((body->>'new_shares'   )::NUMERIC), 0) FROM candidate_events WHERE type='staking.escrow.add')
+			- (SELECT COALESCE(SUM((body->>'active_shares')::NUMERIC), 0) FROM candidate_events WHERE type='staking.escrow.debonding_start')
+		)`,
+		delegatee, delegator, height,
+	).Scan(&shares); err != nil {
+		panic(err)
+	}
+	return shares
+}

--- a/cmd/bisect/main.go
+++ b/cmd/bisect/main.go
@@ -1,0 +1,162 @@
+// Runs bisection on a range of heights to find the height at which the DB and the node
+// diverge wrt to a specific value (e.g. an account's escrow balance).
+//
+// This is a one-off debugging tool and is intended to be configured partially via code.
+// Config comes from:
+//   - The config file (passed as a command-line argument): the DB connection string and the node connection string.
+//     This is the same YAML config file that the analyzer uses.
+//   - The hardcoded values and functions below. They determine which value to compare,
+//     and at which heights. See also docstring for bisect().
+//
+// To connect to the relevant Oasis-internal DB locally, see internal documentation:
+//    https://app.clickup.com/24394368/v/dc/q8em0-18570/q8em0-15212
+//
+// To run:
+//	go run ./cmd/bisect <YAML_CONFIG_FILE>
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/oasisprotocol/nexus/common"
+	"github.com/oasisprotocol/nexus/config"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi/history"
+	"github.com/oasisprotocol/nexus/storage/postgres"
+
+	staking "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
+)
+
+var logger = log.NewDefaultLogger("cmd/bisect")
+
+func main() {
+	ctx := context.Background()
+	nodeApi, db := initBackends(ctx)
+
+	// CHANGEME: Job-specific config.
+	delegator := addressFromBech32("oasis1qryftd0e9588mrd93pznmmuhulu6rzzgngmtkl8x")
+	delegatee := addressFromBech32("oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm")
+	bisect(
+		3027601, // minHeight; the DB matches the node at this height
+		4743434, // maxHeight; the DB does NOT match the node at this height
+		func(h int64) common.BigInt { return delegationViaDeadReckon(ctx, db, h, delegator, delegatee) },
+		func(h int64) common.BigInt { return delegationViaNodeApi(ctx, nodeApi, h, delegator, delegatee) },
+	)
+}
+
+// Performs bisection on a range of heights to find the height at which `dbFetch(height)` and `nodeFetch(height)` diverge.
+// Prints results in human-readable form to stdout.
+//
+// Inputs:
+//   - A min and max height between which to bisect, inclusive.
+//   - A function that recreates the DB value at a given height h. We don't have _actual_ old dead-reckoned values
+//     readily stored in the DB, but we do store all events in the DB, so we can recreate the dead-reckoned value
+//     with a DB SUM() or similar.
+//   - A function that fetches the expected value from the node.
+//
+// Assumptions:
+//   - The DB matches the node at `minHeight`
+//   - The DB does not match the node at `maxHeight`
+//   - The correctness of the DB switches only once between `minHeight` and `maxHeight`
+func bisect(minHeight, maxHeight int64, dbFetch, nodeFetch func(h int64) common.BigInt) {
+	// Validate assumptions about endpoints.
+	comparisons := []Comparison{
+		{Height: minHeight, NodeVal: nodeFetch(minHeight), DbVal: dbFetch(minHeight)},
+		{Height: maxHeight, NodeVal: nodeFetch(maxHeight), DbVal: dbFetch(maxHeight)},
+	}
+	printResults(comparisons)
+	if !Eq(comparisons[0].NodeVal, comparisons[0].DbVal) || Eq(comparisons[1].NodeVal, comparisons[1].DbVal) {
+		logger.Error("DB and the node should agree at minHeight and disagree at maxHeight")
+		os.Exit(1)
+	}
+
+	// Perform bisection.
+	for minHeight < maxHeight {
+		h := (minHeight + maxHeight) / 2
+		dbVal := dbFetch(h)
+		nodeVal := nodeFetch(h)
+		comparisons = append(comparisons, Comparison{Height: h, NodeVal: nodeVal, DbVal: dbVal})
+		printResults(comparisons)
+		if Eq(dbVal, nodeVal) {
+			minHeight = h + 1
+		} else {
+			maxHeight = h
+		}
+	}
+}
+
+type Comparison struct {
+	Height  int64
+	NodeVal common.BigInt
+	DbVal   common.BigInt
+}
+
+// Returns a sorted copy of `lst`.
+func sortedResults(lst []Comparison) []Comparison {
+	lst = append([]Comparison{}, lst...) // create a copy
+	sort.Slice(lst, func(i, j int) bool { return lst[i].Height < lst[j].Height })
+	return lst
+}
+
+// Prints the results of a bisection-in-progress.
+func printResults(lst []Comparison) {
+	fmt.Println("----------------------------------")
+	mostRecentHeight := lst[len(lst)-1].Height
+	lst = sortedResults(lst)
+	for _, r := range lst {
+		goodOrBad := "BAD "
+		if Eq(r.NodeVal, r.DbVal) {
+			goodOrBad = "GOOD"
+		}
+
+		recencyIndicator := " "
+		if r.Height == mostRecentHeight {
+			recencyIndicator = "*"
+		}
+
+		fmt.Printf("%s%s height %d:   node %-15s   db %-15s\n", recencyIndicator, goodOrBad, r.Height, r.NodeVal.String(), r.DbVal.String())
+	}
+}
+
+func Eq(a, b common.BigInt) bool {
+	return a.Cmp(&b.Int) == 0
+}
+
+func initBackends(ctx context.Context) (*history.HistoryConsensusApiLite, *postgres.Client) {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: bisect <YAML_CONFIG_FILE>\n\nThe config file is in the same YAML format that the analyzer uses; it determines the connection string for the DB and the node.")
+		os.Exit(1)
+	}
+
+	cfg, err := config.InitConfig(os.Args[1])
+	if err != nil {
+		logger.Error("config init failed", "error", err)
+		os.Exit(1)
+	}
+
+	nodeApi, err := history.NewHistoryConsensusApiLite(ctx, cfg.Analysis.Source.History(), cfg.Analysis.Source.Nodes, true /*fastStartup*/)
+	if err != nil {
+		logger.Error("cannot instantiate consensus API", "error", err)
+		os.Exit(1)
+	}
+
+	db, err := postgres.NewClient(cfg.Analysis.Storage.Endpoint, logger)
+	if err != nil {
+		logger.Error("cannot connect to DB", "error", err)
+		os.Exit(1)
+	}
+
+	return nodeApi, db
+}
+
+func addressFromBech32(addr string) staking.Address {
+	var a staking.Address
+	if err := a.UnmarshalText([]byte(addr)); err != nil {
+		panic(err)
+	}
+	return a
+}

--- a/storage/oasis/connections/raw_grpc.go
+++ b/storage/oasis/connections/raw_grpc.go
@@ -14,6 +14,18 @@ import (
 	"github.com/oasisprotocol/nexus/config"
 )
 
+// Minimal interface for gRPC connections.
+type GrpcConn interface {
+	Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error
+	Close() error
+}
+
+// The minimal interface is implemented by both `grpc.ClientConn` and `LazyGrpcConn`.
+var (
+	_ GrpcConn = (*grpc.ClientConn)(nil)
+	_ GrpcConn = (*LazyGrpcConn)(nil)
+)
+
 // RawConnect establishes gRPC connection with the target URL,
 // omitting the chain context check.
 // This is based on oasis-sdk `ConnectNoVerify()` function,
@@ -36,7 +48,7 @@ func RawConnect(nodeConfig *config.NodeConfig) (*grpc.ClientConn, error) {
 	return cmnGrpc.Dial(nodeConfig.RPC, dialOpts...)
 }
 
-func LazyGrpcConnect(nodeConfig config.NodeConfig) *LazyGrpcConn {
+func NewLazyGrpcConn(nodeConfig config.NodeConfig) *LazyGrpcConn {
 	return &LazyGrpcConn{
 		inner:      nil, // The underlying connection will be initialized lazily.
 		lock:       sync.Mutex{},

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -21,6 +21,7 @@ import (
 	registry "github.com/oasisprotocol/nexus/coreapi/v22.2.11/registry/api"
 	scheduler "github.com/oasisprotocol/nexus/coreapi/v22.2.11/scheduler/api"
 	staking "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api"
+	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 
 	sdkClient "github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -61,6 +62,10 @@ type ConsensusApiLite interface {
 	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*Proposal, error)
 	Close() error
+	// Exposes the underlying gRPC connection, if applicable. Implementations may return nil.
+	// NOTE: Intended only for debugging purposes, e.g. one-off testing of gRPC methods that
+	//       are not exposed via one of the above wrappers.
+	GrpcConn() connections.GrpcConn
 }
 
 // A lightweight subset of `consensus.TransactionsWithResults`.

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -36,12 +36,12 @@ import (
 // Cobalt node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
 type ConsensusApiLite struct {
-	grpcConn *connections.LazyGrpcConn
+	grpcConn connections.GrpcConn
 }
 
 var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
+func NewConsensusApiLite(grpcConn connections.GrpcConn) *ConsensusApiLite {
 	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -210,3 +210,7 @@ func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, propos
 	}
 	return (*nodeapi.Proposal)(convertProposal(rsp)), nil
 }
+
+func (c *ConsensusApiLite) GrpcConn() connections.GrpcConn {
+	return c.grpcConn
+}

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -31,12 +31,12 @@ import (
 // compatible with Damask gRPC API, this struct just trivially wraps the
 // convenience methods provided by oasis-core.
 type ConsensusApiLite struct {
-	grpcConn *connections.LazyGrpcConn
+	grpcConn connections.GrpcConn
 }
 
 var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
+func NewConsensusApiLite(grpcConn connections.GrpcConn) *ConsensusApiLite {
 	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -210,3 +210,7 @@ func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, propos
 	}
 	return (*nodeapi.Proposal)(rsp), nil
 }
+
+func (c *ConsensusApiLite) GrpcConn() connections.GrpcConn {
+	return c.grpcConn
+}

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -214,3 +214,7 @@ func (c *ConsensusApiLite) GetProposal(ctx context.Context, height int64, propos
 	}
 	return (*nodeapi.Proposal)(convertProposal(rsp)), nil
 }
+
+func (c *ConsensusApiLite) GrpcConn() connections.GrpcConn {
+	return c.grpcConn
+}

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -17,6 +17,7 @@ import (
 	scheduler "github.com/oasisprotocol/nexus/coreapi/v22.2.11/scheduler/api"
 
 	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
 	// data types for Eden gRPC APIs.
@@ -35,12 +36,12 @@ import (
 // Eden node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
 type ConsensusApiLite struct {
-	grpcConn *connections.LazyGrpcConn
+	grpcConn connections.GrpcConn
 }
 
 var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
+func NewConsensusApiLite(grpcConn connections.GrpcConn) *ConsensusApiLite {
 	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"google.golang.org/grpc"
-
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
 	// nexus-internal data types.
@@ -37,12 +35,12 @@ import (
 // Eden node. To be able to use the old gRPC API, this struct uses gRPC
 // directly, skipping the convenience wrappers provided by oasis-core.
 type ConsensusApiLite struct {
-	grpcConn *grpc.ClientConn
+	grpcConn *connections.LazyGrpcConn
 }
 
 var _ nodeapi.ConsensusApiLite = (*ConsensusApiLite)(nil)
 
-func NewConsensusApiLite(grpcConn *grpc.ClientConn) *ConsensusApiLite {
+func NewConsensusApiLite(grpcConn *connections.LazyGrpcConn) *ConsensusApiLite {
 	return &ConsensusApiLite{
 		grpcConn: grpcConn,
 	}

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/metrics"
+	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 )
 
@@ -164,4 +165,8 @@ func (c *FileConsensusApiLite) GetProposal(ctx context.Context, height int64, pr
 		generateCacheKey("GetProposal", height, proposalID),
 		func() (*nodeapi.Proposal, error) { return c.consensusApi.GetProposal(ctx, height, proposalID) },
 	)
+}
+
+func (c *FileConsensusApiLite) GrpcConn() connections.GrpcConn {
+	return c.consensusApi.GrpcConn()
 }

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -222,3 +222,9 @@ func (c *HistoryConsensusApiLite) GetProposal(ctx context.Context, height int64,
 	}
 	return api.GetProposal(ctx, height, proposalID)
 }
+
+func (c *HistoryConsensusApiLite) GrpcConn() connections.GrpcConn {
+	// To access the gRPC connection, you must know the height of the block.
+	// Use APIForHeight(h).GrpcConn() instead.
+	return nil
+}

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -23,17 +23,17 @@ var _ nodeapi.ConsensusApiLite = (*HistoryConsensusApiLite)(nil)
 type APIConstructor func(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error)
 
 func damaskAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
+	rawConn := connections.NewLazyGrpcConn(*archiveConfig.ResolvedConsensusNode())
 	return damask.NewConsensusApiLite(rawConn), nil
 }
 
 func cobaltAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
+	rawConn := connections.NewLazyGrpcConn(*archiveConfig.ResolvedConsensusNode())
 	return cobalt.NewConsensusApiLite(rawConn), nil
 }
 
 func edenAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
+	rawConn := connections.NewLazyGrpcConn(*archiveConfig.ResolvedConsensusNode())
 	return eden.NewConsensusApiLite(rawConn), nil
 }
 

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -33,10 +33,7 @@ func cobaltAPIConstructor(ctx context.Context, chainContext string, archiveConfi
 }
 
 func edenAPIConstructor(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-	rawConn, err := connections.RawConnect(archiveConfig.ResolvedConsensusNode())
-	if err != nil {
-		return nil, fmt.Errorf("oasis-node RawConnect: %w", err)
-	}
+	rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedConsensusNode())
 	return eden.NewConsensusApiLite(rawConn), nil
 }
 

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -29,7 +29,7 @@ func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkP
 				return nil, err
 			}
 			sdkClient := sdkConn.Runtime(sdkPT)
-			rawConn := connections.LazyGrpcConnect(*archiveConfig.ResolvedRuntimeNode(runtime))
+			rawConn := connections.NewLazyGrpcConn(*archiveConfig.ResolvedRuntimeNode(runtime))
 			apis[record.ArchiveName] = nodeapi.NewUniversalRuntimeApiLite(sdkPT.Namespace(), rawConn, &sdkClient)
 		}
 	}

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -35,7 +35,7 @@ type UniversalRuntimeApiLite struct {
 	// A raw gRPC connection to the node. Used for fetching raw CBOR-encoded
 	// responses for RPCs whose encodings changed over time, and this class
 	// needs to handle the various formats/types.
-	grpcConn *connections.LazyGrpcConn
+	grpcConn connections.GrpcConn
 
 	// An oasis-sdk managed connection to the node. Used for RPCs that have
 	// had a stable ABI over time. That is the majority of them, and oasis-sdk
@@ -46,7 +46,7 @@ type UniversalRuntimeApiLite struct {
 
 var _ RuntimeApiLite = (*UniversalRuntimeApiLite)(nil)
 
-func NewUniversalRuntimeApiLite(runtimeID coreCommon.Namespace, grpcConn *connections.LazyGrpcConn, sdkClient *connection.RuntimeClient) *UniversalRuntimeApiLite {
+func NewUniversalRuntimeApiLite(runtimeID coreCommon.Namespace, grpcConn connections.GrpcConn, sdkClient *connection.RuntimeClient) *UniversalRuntimeApiLite {
 	return &UniversalRuntimeApiLite{
 		runtimeID: runtimeID,
 		grpcConn:  grpcConn,


### PR DESCRIPTION
Debug tool in support of https://app.clickup.com/t/8692rq7ev (wherein the indexer dead-reckoned a negative number of escrow shares). But the tool is also intended for future debugging of any badly dead-reckoned values.

Sample output:
```
----------------------------------
 GOOD height 3027601:   node 0                 db 0              
 GOOD height 3885517:   node 0                 db 0              
 GOOD height 4314476:   node 0                 db 0              
 GOOD height 4528955:   node 0                 db 0              
 GOOD height 4636195:   node 0                 db 0              
 GOOD height 4663005:   node 0                 db 0              
 GOOD height 4676410:   node 0                 db 0              
 GOOD height 4683113:   node 0                 db 0              
 GOOD height 4686464:   node 0                 db 0              
 GOOD height 4687302:   node 0                 db 0              
 GOOD height 4687512:   node 0                 db 0              
 GOOD height 4687617:   node 0                 db 0              
*GOOD height 4687618:   node 0                 db 0              
 BAD  height 4687619:   node 111589494653242   db 0              
 BAD  height 4687621:   node 111589494653242   db 0              
 BAD  height 4687624:   node 111589494653242   db 0              
 BAD  height 4687630:   node 111589494653242   db 0              
 BAD  height 4687643:   node 111589494653242   db 0              
 BAD  height 4687669:   node 111589494653242   db 0              
 BAD  height 4687721:   node 111589494653242   db 0              
 BAD  height 4688140:   node 111589494653242   db 0              
 BAD  height 4689815:   node 111589494653242   db 0              
 BAD  height 4743434:   node 110589494653242   db 0      
 ```