### PR TITLE
analyzer/fast-sync: Reduce DB contention by writing updates into a writeahead log

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -117,6 +117,12 @@ func (m *processor) PreWork(ctx context.Context) error {
 // If that block is the first block of a chain (cobalt, damask, etc), we download the chain's
 // original genesis document. Otherwise, we download the genesis-formatted state at `lastFastSyncHeight`.
 func (m *processor) FinalizeFastSync(ctx context.Context, lastFastSyncHeight int64) error {
+	// Aggregate append-only tables that were used during fast sync.
+	if err := m.aggregateFastSyncTables(ctx); err != nil {
+		return err
+	}
+
+	// Fetch a data snapshot (= genesis doc) from the node; see function docstring.
 	firstSlowSyncHeight := lastFastSyncHeight + 1
 	r, err := m.history.RecordForHeight(firstSlowSyncHeight)
 	if err != nil {
@@ -145,6 +151,21 @@ func (m *processor) FinalizeFastSync(ctx context.Context, lastFastSyncHeight int
 	}
 
 	return m.processGenesis(ctx, genesisDoc, nodes)
+}
+
+// Aggregates rows from the temporary, append-only  `todo_updates.*` tables, and appropriately updates
+// the regular DB tables.
+func (m *processor) aggregateFastSyncTables(ctx context.Context) error {
+	batch := &storage.QueryBatch{}
+
+	m.logger.Info("computing epoch boundaries for epochs scanned during fast-sync")
+	batch.Queue(queries.ConsensusEpochsRecompute)
+	batch.Queue("DELETE FROM todo_updates.epochs")
+
+	if err := m.target.SendBatch(ctx, batch); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Dumps the genesis document to a JSON file if instructed via env variables. For debug only.
@@ -318,11 +339,18 @@ func (m *processor) queueBlockInserts(batch *storage.QueryBatch, data *consensus
 
 func (m *processor) queueEpochInserts(batch *storage.QueryBatch, data *consensusBlockData) error {
 	batch.Queue(
-		queries.ConsensusEpochUpsert,
+		queries.ConsensusFastSyncEpochHeightInsert,
 		data.Epoch,
 		data.BlockHeader.Height,
 	)
 
+	if m.mode != analyzer.FastSyncMode {
+		batch.Queue(
+			queries.ConsensusEpochUpsert,
+			data.Epoch,
+			data.BlockHeader.Height,
+		)
+	}
 	return nil
 }
 

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -574,7 +574,7 @@ var (
       SELECT runtime, token_address, account_address, MAX(last_mutate_round)
       FROM todo_updates.evm_token_balances
       WHERE runtime = $1
-      GROUP BY 1, 2, 3
+      GROUP BY runtime, token_address, account_address
     )
     ON CONFLICT (runtime, token_address, account_address) DO UPDATE
     SET
@@ -633,7 +633,7 @@ var (
       SELECT runtime, token_address, SUM(total_supply) AS total_supply, SUM(num_transfers) AS num_transfers, MAX(last_mutate_round) AS last_mutate_round
       FROM todo_updates.evm_tokens
       WHERE runtime = $1
-      GROUP BY 1, 2
+      GROUP BY runtime, token_address
     )
     ON CONFLICT (runtime, token_address) DO UPDATE SET
       total_supply = old.total_supply + excluded.total_supply,

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -91,7 +91,6 @@ func RunMigrations(sourceURL string, databaseURL string) error {
 	if err != nil {
 		return err
 	}
-
 	return m.Up()
 }
 

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -212,7 +212,7 @@ CREATE TABLE chain.evm_tokens
   -- last_download_round UINT63
 );
 
-CREATE TABLE chain.evm_token_analysis  -- Moved to analysis.evm_tokens in 06_analysis_schema.up.sql
+CREATE TABLE chain.evm_token_analysis  -- Moved to analysis.evm_tokens in 06_analysis_schema.up.sql, then dropped (merged into chain.evm_tokens) in 18_refactor_dead_reckoning.up.go
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,

--- a/storage/migrations/24_fast_sync_temp_tables.up.sql
+++ b/storage/migrations/24_fast_sync_temp_tables.up.sql
@@ -11,6 +11,15 @@ BEGIN;
 --       existing tables at the end of fast sync, not to overwrite them.
 CREATE SCHEMA IF NOT EXISTS todo_updates;
 
-CREATE TABLE todo_updates.epochs(epoch UINT63, height UINT63);
+CREATE TABLE todo_updates.epochs( -- Tracks updates to chain.epochs(first_height,last_height)
+  epoch UINT63,
+  height UINT63
+);
+CREATE TABLE todo_updates.evm_token_balances( -- Tracks updates to analysis.evm_token_balances(last_mutate_round)
+  runtime runtime NOT NULL,
+  token_address oasis_addr NOT NULL,
+  account_address oasis_addr NOT NULL,
+  last_mutate_round UINT63 NOT NULL
+)
 
 COMMIT;

--- a/storage/migrations/24_fast_sync_temp_tables.up.sql
+++ b/storage/migrations/24_fast_sync_temp_tables.up.sql
@@ -20,6 +20,13 @@ CREATE TABLE todo_updates.evm_token_balances( -- Tracks updates to analysis.evm_
   token_address oasis_addr NOT NULL,
   account_address oasis_addr NOT NULL,
   last_mutate_round UINT63 NOT NULL
-)
+);
+CREATE TABLE todo_updates.evm_tokens( -- Tracks updates to chain.evm_tokens(last_mutate_round)
+  runtime runtime NOT NULL,
+  token_address oasis_addr NOT NULL,
+  total_supply NUMERIC(1000,0) NOT NULL DEFAULT 0,
+  num_transfers UINT63 NOT NULL DEFAULT 0,
+  last_mutate_round UINT63 NOT NULL
+);
 
 COMMIT;

--- a/storage/migrations/24_fast_sync_temp_tables.up.sql
+++ b/storage/migrations/24_fast_sync_temp_tables.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Tables in this namespace are intended only for use during fast-sync.
+--
+-- They contain append-only data that would normally (during slow-sync) be
+-- inserted into existing tables, but doing so during fast-sync would
+-- cause too much DB lock contention.
+--
+-- NOTE: The data in these tables is NOT COMPLETE in that it is never guaranteed
+--       to cover the full set of heights indexed so far. It should be used to update
+--       existing tables at the end of fast sync, not to overwrite them.
+CREATE SCHEMA IF NOT EXISTS todo_updates;
+
+CREATE TABLE todo_updates.epochs(epoch UINT63, height UINT63);
+
+COMMIT;


### PR DESCRIPTION
Running the fast-sync analyzer with almost any parallelism (as low as parallelism=5) caused significant DB lock contention and consequently slowdowns.
This PR mostly removes the contention by replacing table UPDATEs with INSERTs into new temporary tables in a new `updates_todo` schema. Then after fast-sync, those temp tables get merged back into the "real" tables.

Testing: I locally modified the e2e_regression config to use fast-sync for the majority of the scanned range. Confirmed there were no diffs to the expected output.

Resolves https://app.clickup.com/t/8692uydfe