### PR TITLE
[metrics] add block analyzer queuelength metrics

### DIFF
--- a/analyzer/block/block_test.go
+++ b/analyzer/block/block_test.go
@@ -112,7 +112,7 @@ func setupAnalyzer(t *testing.T, testDb *postgres.Client, p *mockProcessor, cfg 
 	p.isFastSync = (mode == analyzer.FastSyncMode)
 
 	// Initialize the block analyzer.
-	logger, err := log.NewLogger(fmt.Sprintf("test-analyzer-%s", p.name), os.Stdout, log.FmtJSON, log.LevelInfo)
+	logger, err := log.NewLogger(fmt.Sprintf("test_analyzer-%s", p.name), os.Stdout, log.FmtJSON, log.LevelInfo)
 	require.NoError(t, err, "log.NewLogger")
 	var blockRange config.BlockRange
 	switch mode {
@@ -152,7 +152,7 @@ func TestFastSyncBlockAnalyzer(t *testing.T) {
 	ctx := context.Background()
 
 	db := setupDB(t)
-	p := &mockProcessor{name: "test-analyzer", storage: db}
+	p := &mockProcessor{name: "test_analyzer", storage: db}
 	analyzer := setupAnalyzer(t, db, p, testBlockBasedConfig, analyzer.SlowSyncMode)
 
 	// Run the analyzer and ensure all blocks are processed.
@@ -188,7 +188,7 @@ func TestMultipleFastSyncBlockAnalyzers(t *testing.T) {
 	ps := []*mockProcessor{}
 	as := []analyzer.Analyzer{}
 	for i := 0; i < numAnalyzers; i++ {
-		p := &mockProcessor{name: "test-analyzer", storage: db}
+		p := &mockProcessor{name: "test_analyzer", storage: db}
 		analyzer := setupAnalyzer(t, db, p, testFastSyncBlockBasedConfig, analyzer.FastSyncMode)
 		ps = append(ps, p)
 		as = append(as, analyzer)
@@ -238,7 +238,7 @@ func TestFailingFastSyncBlockAnalyzers(t *testing.T) {
 				return fmt.Errorf("failing analyzer")
 			}
 		}
-		p := &mockProcessor{name: "test-analyzer", storage: db, fail: fail}
+		p := &mockProcessor{name: "test_analyzer", storage: db, fail: fail}
 		analyzer := setupAnalyzer(t, db, p, testFastSyncBlockBasedConfig, analyzer.FastSyncMode)
 		ps = append(ps, p)
 		as = append(as, analyzer)
@@ -281,7 +281,7 @@ func TestDistinctFastSyncBlockAnalyzers(t *testing.T) {
 	ps := []*mockProcessor{}
 	as := []analyzer.Analyzer{}
 	for i := 0; i < numAnalyzers; i++ {
-		p := &mockProcessor{name: fmt.Sprintf("test-analyzer-%d", i), storage: db}
+		p := &mockProcessor{name: fmt.Sprintf("test_analyzer_%d", i), storage: db}
 		analyzer := setupAnalyzer(t, db, p, testFastSyncBlockBasedConfig, analyzer.FastSyncMode)
 		ps = append(ps, p)
 		as = append(as, analyzer)
@@ -318,7 +318,7 @@ func TestSlowSyncBlockAnalyzer(t *testing.T) {
 	ctx := context.Background()
 
 	db := setupDB(t)
-	p := &mockProcessor{name: "test-analyzer", storage: db}
+	p := &mockProcessor{name: "test_analyzer", storage: db}
 	analyzer := setupAnalyzer(t, db, p, testBlockBasedConfig, analyzer.SlowSyncMode)
 
 	// Run the analyzer and ensure all blocks are processed.
@@ -351,7 +351,7 @@ func TestFailingSlowSyncBlockAnalyzer(t *testing.T) {
 	ctx := context.Background()
 
 	db := setupDB(t)
-	p := &mockProcessor{name: "test-analyzer", storage: db, fail: func(height uint64) error {
+	p := &mockProcessor{name: "test_analyzer", storage: db, fail: func(height uint64) error {
 		// Fail ~5% of the time.
 		if rand.Float64() > 0.95 { // /nolint:gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand).
 			return fmt.Errorf("failed by chance")
@@ -394,7 +394,7 @@ func TestDistinctSlowSyncBlockAnalyzers(t *testing.T) {
 	ps := []*mockProcessor{}
 	as := []analyzer.Analyzer{}
 	for i := 0; i < numAnalyzers; i++ {
-		p := &mockProcessor{name: fmt.Sprintf("test-analyzer-%d", i), storage: db}
+		p := &mockProcessor{name: fmt.Sprintf("test_analyzer_%d", i), storage: db}
 		analyzer := setupAnalyzer(t, db, p, testBlockBasedConfig, analyzer.SlowSyncMode)
 		ps = append(ps, p)
 		as = append(as, analyzer)

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -297,13 +297,13 @@ func (m *processor) ProcessBlock(ctx context.Context, uheight uint64) error {
 	// Fetch all data.
 	fetchTimer := m.metrics.BlockFetchLatencies()
 	data, err := fetchAllData(ctx, m.source, m.network, height, m.mode == analyzer.FastSyncMode)
+	fetchTimer.ObserveDuration()
 	if err != nil {
 		if strings.Contains(err.Error(), fmt.Sprintf("%d must be less than or equal to the current blockchain height", height)) {
 			return analyzer.ErrOutOfRange
 		}
 		return err
 	}
-	fetchTimer.ObserveDuration() // We make no observation in case of a data fetch error; those timings are misleading.
 
 	// Process data, prepare updates.
 	analysisTimer := m.metrics.BlockAnalysisLatencies()

--- a/analyzer/node_stats/node_stats.go
+++ b/analyzer/node_stats/node_stats.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
 	consensusAPI "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
+	runtimeAPI "github.com/oasisprotocol/nexus/coreapi/v22.2.11/runtime/client/api"
 )
 
 const (
@@ -22,16 +23,22 @@ const (
 )
 
 type processor struct {
-	source nodeapi.ConsensusApiLite
-	target storage.TargetStorage
-	logger *log.Logger
+	layers         []common.Layer
+	source         nodeapi.ConsensusApiLite
+	emeraldSource  nodeapi.RuntimeApiLite
+	sapphireSource nodeapi.RuntimeApiLite
+	target         storage.TargetStorage
+	logger         *log.Logger
 }
 
 var _ item.ItemProcessor[common.Layer] = (*processor)(nil)
 
 func NewAnalyzer(
 	cfg config.ItemBasedAnalyzerConfig,
+	layers []common.Layer,
 	sourceClient nodeapi.ConsensusApiLite,
+	emeraldClient nodeapi.RuntimeApiLite,
+	sapphireClient nodeapi.RuntimeApiLite,
 	target storage.TargetStorage,
 	logger *log.Logger,
 ) (analyzer.Analyzer, error) {
@@ -39,10 +46,17 @@ func NewAnalyzer(
 		cfg.Interval = 3 * time.Second
 	}
 	logger = logger.With("analyzer", nodeStatsAnalyzerName)
+	// Default to [consensus, emerald, sapphire] if layers is not specified.
+	if len(layers) == 0 {
+		layers = []common.Layer{common.LayerConsensus, common.LayerEmerald, common.LayerSapphire}
+	}
 	p := &processor{
-		source: sourceClient,
-		target: target,
-		logger: logger.With("analyzer", nodeStatsAnalyzerName),
+		layers:         layers,
+		source:         sourceClient,
+		emeraldSource:  emeraldClient,
+		sapphireSource: sapphireClient,
+		target:         target,
+		logger:         logger.With("analyzer", nodeStatsAnalyzerName),
 	}
 
 	return item.NewAnalyzer[common.Layer](
@@ -54,22 +68,37 @@ func NewAnalyzer(
 }
 
 func (p *processor) GetItems(ctx context.Context, limit uint64) ([]common.Layer, error) {
-	return []common.Layer{common.LayerConsensus}, nil
+	return p.layers, nil
 }
 
 func (p *processor) ProcessItem(ctx context.Context, batch *storage.QueryBatch, layer common.Layer) error {
 	p.logger.Debug("fetching node height", "layer", layer)
-	// We currently only support consensus. Update when this is no longer the case.
-	if layer != common.LayerConsensus {
+	latestHeight := uint64(0) // will be fetched from the node
+	switch layer {
+	case common.LayerConsensus:
+		latestBlock, err := p.source.GetBlock(ctx, consensusAPI.HeightLatest)
+		if err != nil {
+			return fmt.Errorf("error fetching latest block height for layer %s: %w", layer, err)
+		}
+		latestHeight = uint64(latestBlock.Height)
+	case common.LayerEmerald:
+		latestBlock, err := p.emeraldSource.GetBlockHeader(ctx, runtimeAPI.RoundLatest)
+		if err != nil {
+			return fmt.Errorf("error fetching latest block height for layer %s: %w", layer, err)
+		}
+		latestHeight = latestBlock.Round
+	case common.LayerSapphire:
+		latestBlock, err := p.sapphireSource.GetBlockHeader(ctx, runtimeAPI.RoundLatest)
+		if err != nil {
+			return fmt.Errorf("error fetching latest block height for layer %s: %w", layer, err)
+		}
+		latestHeight = latestBlock.Round
+	default:
 		return fmt.Errorf("unsupported layer %s", layer)
 	}
-	latestBlock, err := p.source.GetBlock(ctx, consensusAPI.HeightLatest)
-	if err != nil {
-		return fmt.Errorf("error fetching latest block height for layer %s, %w", layer, err)
-	}
-	batch.Queue(queries.ConsensusNodeHeightUpsert,
+	batch.Queue(queries.NodeHeightUpsert,
 		layer,
-		latestBlock.Height,
+		latestHeight,
 	)
 
 	return nil

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -152,7 +152,12 @@ var (
       SET processed_time = CURRENT_TIMESTAMP, is_fast_sync = $3
       WHERE height = $1 AND analyzer = $2`
 
-	ConsensusNodeHeightUpsert = `
+	NodeHeight = `
+    SELECT height
+    FROM chain.latest_node_heights
+    WHERE layer = $1`
+
+	NodeHeightUpsert = `
     INSERT INTO chain.latest_node_heights (layer, height)
       VALUES
         ($1, $2)

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -471,7 +471,15 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return nodestats.NewAnalyzer(cfg.Analyzers.NodeStats.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
+			emeraldClient, err1 := sources.Runtime(ctx, common.RuntimeEmerald)
+			if err1 != nil {
+				return nil, err1
+			}
+			sapphireClient, err1 := sources.Runtime(ctx, common.RuntimeSapphire)
+			if err1 != nil {
+				return nil, err1
+			}
+			return nodestats.NewAnalyzer(cfg.Analyzers.NodeStats.ItemBasedAnalyzerConfig, cfg.Analyzers.NodeStats.Layers, sourceClient, emeraldClient, sapphireClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.AggregateStats != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -433,11 +433,23 @@ func (cfg *MetadataRegistryConfig) Validate() error {
 // NodeStatsConfig is the configuration for the node stats analyzer.
 type NodeStatsConfig struct {
 	ItemBasedAnalyzerConfig `koanf:",squash"`
+
+	// Layers is the list of runtimes and/or consensus that the node-stats analyzer
+	// should query for the latest node height.
+	Layers []common.Layer `koanf:"layers"`
 }
 
 func (cfg *NodeStatsConfig) Validate() error {
 	if cfg.Interval > 6*time.Second {
 		return fmt.Errorf("node stats interval must be less than or equal to the block time of 6 seconds")
+	}
+	// Deduplicate layers
+	seen := make(map[common.Layer]struct{})
+	for _, layer := range cfg.Layers {
+		if _, ok := seen[layer]; ok {
+			return fmt.Errorf("duplicate layer detected in layers")
+		}
+		seen[layer] = struct{}{}
 	}
 	return nil
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/8692qbwf4

To enable the queuelength metric for runtime block analyzers, nexus needs the current chain heights of the runtimes. The `node_stats` analyzer currently fetches/stores this data only for consensus, so this PR also adds runtime support for the node_stats analyzer.

Note: We _could_ avoid this by fetching the chain heights directly in the block analyzers. Although the height would be fresher, it would also require a second round-trip in the main block processing loop. Since the metrics are internal-only I opted to use the chain heights we already store in `chain.latest_node_heights`. Open to suggestions though.

Alternatively alternatively, we could put the metric updating thing in a concurrent loop separate from the main block processing loop. Not sure if it's worth the extra complexity since slow-sync is, by name, expected to be slower.

```
~/oasis/oasis-block-indexer(andrew7234/block-analyzer-queuelength*) » curl localhost:8009/metrics | grep queue_length                 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 43060    0 43060    0     0  7934k      0 --:--:-- --:--:-- --:--:-- 41.0M
# HELP consensus_queue_length number of blocks left to process for the consensus analyzer
# TYPE consensus_queue_length gauge
consensus_queue_length 0 
^ failed bc couldn't run consensus analyzer locally. Default value of a prometheus gauge is 0, which is what we see here

# HELP emerald_queue_length number of blocks left to process for the emerald analyzer
# TYPE emerald_queue_length gauge
emerald_queue_length 2.392834e+06
# HELP sapphire_queue_length number of blocks left to process for the sapphire analyzer
# TYPE sapphire_queue_length gauge
sapphire_queue_length 3.726054e+06
```