### PR TITLE
Improve documentation of the block hash argument

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -212,7 +212,7 @@ paths:
           name: hash
           schema:
             type: string
-          description: The block hash of the block to return.
+          description: A filter on the block hash.
           example: *block_hash_1
       responses:
         '200':
@@ -825,7 +825,7 @@ paths:
           name: hash
           schema:
             type: string
-          description: The block hash of the block to return.
+          description: A filter on the block hash.
           example: *block_hash_1
       responses:
         '200':


### PR DESCRIPTION
Follow-up to #581

The updated wording of the docs is more in sync with how we describe the other filters. 