### PR TITLE
runtime: fix owner update for burned NFT instances

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -715,13 +715,19 @@ var (
 
 	RuntimeEVMNFTUpsert = `
     INSERT INTO chain.evm_nfts AS old
-      (runtime, token_address, nft_id, owner, num_transfers, last_want_download_round)
+      (runtime, token_address, nft_id, num_transfers, last_want_download_round)
     VALUES
-      ($1, $2, $3, $4, $5, $6)
-    ON CONFLICT (runtime, token_address, nft_id) DO UPDATE
-    SET
-      owner = COALESCE(excluded.owner, old.owner),
-      num_transfers = old.num_transfers + excluded.num_transfers`
+      ($1, $2, $3, 0, $4)
+    ON CONFLICT (runtime, token_address, nft_id) DO NOTHING`
+
+	RuntimeEVMNFTUpdateTransfer = `
+    UPDATE chain.evm_nfts SET
+      owner = $4,
+      num_transfers = num_transfers + $5
+    WHERE
+      runtime = $1 AND
+      token_address = $2 AND
+      nft_id = $3`
 
 	RuntimeEVMNFTAnalysisStale = `
     SELECT

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -121,7 +121,11 @@ type NFTKey struct {
 }
 
 type PossibleNFT struct {
-	NewOwner     *apiTypes.Address
+	// NewOwner has the latest owner if .NumTransfers is more than zero. If
+	// the last transfer burned this NFT instance, then it's the empty string.
+	NewOwner apiTypes.Address
+	// NumTransfers is how many times we saw it transferred. If it's more than
+	// zero, the new owner is in .NewOwner.
 	NumTransfers int
 }
 
@@ -270,7 +274,7 @@ func registerNFTExist(nftChanges map[NFTKey]*PossibleNFT, contractAddr apiTypes.
 func registerNFTTransfer(nftChanges map[NFTKey]*PossibleNFT, contractAddr apiTypes.Address, tokenID *big.Int, newOwner apiTypes.Address) {
 	possibleNFT := findPossibleNFT(nftChanges, contractAddr, tokenID)
 	possibleNFT.NumTransfers++
-	possibleNFT.NewOwner = &newOwner
+	possibleNFT.NewOwner = newOwner
 }
 
 func findTokenChange(tokenChanges map[TokenChangeKey]*big.Int, contractAddr apiTypes.Address, accountAddr apiTypes.Address) *big.Int {

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/nexus/analyzer/queries"
 	evm "github.com/oasisprotocol/nexus/analyzer/runtime/evm"
 	uncategorized "github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/config"
 	"github.com/oasisprotocol/nexus/log"
@@ -399,9 +400,21 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			m.runtime,
 			key.TokenAddress,
 			key.TokenID,
-			possibleNFT.NewOwner,
-			possibleNFT.NumTransfers,
 			data.Header.Round,
 		)
+		if possibleNFT.NumTransfers > 0 {
+			var newOwner *apiTypes.Address
+			if possibleNFT.NewOwner != "" {
+				newOwner = &possibleNFT.NewOwner
+			}
+			batch.Queue(
+				queries.RuntimeEVMNFTUpdateTransfer,
+				m.runtime,
+				key.TokenAddress,
+				key.TokenID,
+				newOwner,
+				possibleNFT.NumTransfers,
+			)
+		}
 	}
 }


### PR DESCRIPTION
previously I tried using COALESCE(new owner, old owner) so that we can pass nil to leave the owner as it is when we don't see any transfers, but that didn't leave a way to NULL out the owner when an NFT instance gets burned. the old code turned out to try to set a non-NULL empty string owner, which the Oasis address type doesn't allow.

this PR splits up the runtime analyzer's upsert into an upsert for any NFT detected, plus a new update for when we see transfers, which sets a new owner that may be NULL and bumps the num_transfers.