### PR TITLE
runtime: add explicit PossibleNFT.Burned field

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -722,8 +722,8 @@ var (
 
 	RuntimeEVMNFTUpdateTransfer = `
     UPDATE chain.evm_nfts SET
-      owner = $4,
-      num_transfers = num_transfers + $5
+      num_transfers = num_transfers + $4,
+      owner = $5
     WHERE
       runtime = $1 AND
       token_address = $2 AND

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -404,7 +404,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		)
 		if possibleNFT.NumTransfers > 0 {
 			var newOwner *apiTypes.Address
-			if possibleNFT.NewOwner != "" {
+			if !possibleNFT.Burned {
 				newOwner = &possibleNFT.NewOwner
 			}
 			batch.Queue(
@@ -412,8 +412,8 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 				m.runtime,
 				key.TokenAddress,
 				key.TokenID,
-				newOwner,
 				possibleNFT.NumTransfers,
+				newOwner,
 			)
 		}
 	}


### PR DESCRIPTION
less use of special empty-string fake Address to signal weird conditions.

fields reordered too, so that the more important NumTransfers, which affects the validity of other fields, comes first