### PR TITLE
evmtokenbalances: correct a log field

### DIFF
--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -237,7 +237,7 @@ func (p *processor) ProcessItem(ctx context.Context, batch *storage.QueryBatch, 
 				)
 			}
 		} else {
-			p.logger.Debug("EVM token balance: nothing to correct", "token_addr", staleTokenBalance.TokenAddr, "account_addr", staleTokenBalance.AccountAddr, "balance", balanceData.Balance)
+			p.logger.Debug("EVM token balance: nothing to correct", "token_addr", staleTokenBalance.TokenAddr, "account_addr", staleTokenBalance.AccountAddr, "balance", staleTokenBalance.Balance.String())
 		}
 	}
 	batch.Queue(queries.RuntimeEVMTokenBalanceAnalysisUpdate,


### PR DESCRIPTION
it's checked above that balanceData is nil. this should have used the stale balance, as it's reporting that we didn't get a balance from the contract