### PR TITLE
common/types: BigInt: CBOR-serialize correctly

### DIFF
--- a/common/types_test.go
+++ b/common/types_test.go
@@ -3,12 +3,14 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBigInt(t *testing.T) {
+func TestBigIntJSON(t *testing.T) {
 	var v BigInt
 
 	textRef := []byte("11111111111111111111")
@@ -30,4 +32,37 @@ func TestBigInt(t *testing.T) {
 	require.NoError(t, err)
 	stringRoundTrip := fmt.Sprintf("%v", v)
 	require.Equal(t, stringRef, stringRoundTrip)
+}
+
+func TestBigIntPlus(t *testing.T) {
+	a := NewBigInt(10)
+	b := a.Plus(NewBigInt(1))
+	require.EqualValues(t, 10, a.Int64())
+	require.EqualValues(t, 11, b.Int64())
+}
+
+func TestBigIntTimes(t *testing.T) {
+	a := NewBigInt(10)
+	b := a.Times(NewBigInt(-2))
+	require.EqualValues(t, 10, a.Int64())
+	require.EqualValues(t, -20, b.Int64())
+}
+
+func TestBigIntCBOR(t *testing.T) {
+	// Test round-trip for the following values
+	for _, b := range []BigInt{
+		NewBigInt(0),
+		NewBigInt(-1),
+		NewBigInt(1),
+		NewBigInt(-1000),
+		NewBigInt(1000),
+		NewBigInt(math.MaxInt64).Times(NewBigInt(math.MaxInt64)),
+		NewBigInt(math.MinInt64).Times(NewBigInt(math.MaxInt64)),
+	} {
+		var roundtripped BigInt
+		serialized := cbor.Marshal(b)
+		err := cbor.Unmarshal(serialized, &roundtripped)
+		require.NoError(t, err)
+		require.Equal(t, b.String(), roundtripped.String(), "CBOR serialization should round-trip")
+	}
 }


### PR DESCRIPTION
This PR adds custom (de)serialization for BigInt because it was broken.

The current version of our code CBOR-serializes every `BigInt` instance as `{}`, the empty struct (CBOR: `0xa0`). It was then deserialized as `0`.

BigInt is defined in our code as
```go
type BigInt struct {
	big.Int
}
```

https://github.com/fxamacker/cbor/blob/master/encode.go explains that structs are serialized as maps. The inner `big.Int` is stored in an implicit `BigInt.Int` field, and is public (as evidenced by some sloppy usage in our own code). So IDK why it's not being serialized by cbor, and I'm fairly sure it was serialized correctly in the past.

Regardless, we did not have tests, which this PR also adds.

**Note:** Because the new serialization format is no longer map-based (if it ever was), my hope was that old cached values won't be decoded successfully, and affected cache entries will be automatically invalidated. That's not the case; the `cbor` library decodes `0xa0` (empty map) into the default object automatically. I found a workaround but it's verbose and would require us to special-case 0 when encoding.

The only affected cached value is the return value of `GetNativeBalance()`. I suggest we rename its cache key to "forget" old cache values in the near future. (Thanks @pro-wh for the idea.) I can't do so in this PR because the node is having issues ("Bad Gateway").

