### PR TITLE
runtime: upsert evm contract creation info

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -502,10 +502,14 @@ var (
       VALUES ($1, $2, $3, $4)
     ON CONFLICT DO NOTHING`
 
-	RuntimeEVMContractInsert = `
+	RuntimeEVMContractCreationUpsert = `
     INSERT INTO chain.evm_contracts
       (runtime, contract_address, creation_tx, creation_bytecode)
-    VALUES ($1, $2, $3, $4)`
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (runtime, contract_address) DO UPDATE
+    SET
+      creation_tx = $3,
+      creation_bytecode = $4`
 
 	RuntimeEVMContractRuntimeBytecodeUpsert = `
     INSERT INTO chain.evm_contracts(runtime, contract_address, runtime_bytecode)

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -293,7 +293,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 
 		if transactionData.EVMContract != nil {
 			batch.Queue(
-				queries.RuntimeEVMContractInsert,
+				queries.RuntimeEVMContractCreationUpsert,
 				m.runtime,
 				transactionData.EVMContract.Address,
 				transactionData.EVMContract.CreationTx,


### PR DESCRIPTION
in fast sync, a later call to the contract can get it marked as a contract candidate, and the bytecode analyzer may upsert it into the EVM contracts db before we get to analyzing its creation.