### PR TITLE
storage: avoid nil derference when closing uninitialized kvstore

### DIFF
--- a/storage/oasis/nodeapi/file/kvstore.go
+++ b/storage/oasis/nodeapi/file/kvstore.go
@@ -77,6 +77,12 @@ func (s *pogrebKVStore) Put(key []byte, value []byte) error {
 
 // Close implements KVStore.
 func (s pogrebKVStore) Close() error {
+	if !s.isInitialized() {
+		// If pogreb is in the middle of recovery in the background, it will
+		// die and have to start over next time.
+		s.logger.Warn("skipping closing uninitialized KVStore")
+		return nil
+	}
 	s.logger.Info("closing KVStore", "path", s.path)
 	return s.db.Close()
 }


### PR DESCRIPTION
it's nasty either way, but by not panicking here, we allow other kvstores to close gracefully