### PR TITLE
tests: require.Nil -> require.NoError

### DIFF
--- a/analyzer/runtime/extract_test.go
+++ b/analyzer/runtime/extract_test.go
@@ -117,7 +117,7 @@ func TestExtractSuccessfulEncryptedTx(t *testing.T) {
 		Error:   nil,
 	}
 	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	verifyTxData(t, &expected, blockData.TransactionData[0])
 }
@@ -165,7 +165,7 @@ func TestExtractFailedEncryptedTx(t *testing.T) {
 		},
 	}
 	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	verifyTxData(t, &expected, blockData.TransactionData[0])
 }
@@ -198,7 +198,7 @@ func TestExtractSuccessfulUnecryptedTx(t *testing.T) {
 		Error:        nil,
 	}
 	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	verifyTxData(t, &expected, blockData.TransactionData[0])
 }
@@ -239,7 +239,7 @@ func TestExtractFailedUnecryptedTx(t *testing.T) {
 		},
 	}
 	blockData, err := ExtractRound(nodeapi.RuntimeBlockHeader{}, txrs, []nodeapi.RuntimeEvent{}, log.NewDefaultLogger("testing"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	verifyTxData(t, &expected, blockData.TransactionData[0])
 }

--- a/analyzer/util/util_test.go
+++ b/analyzer/util/util_test.go
@@ -16,7 +16,7 @@ import (
 // updated correctly.
 func TestBackoffWait(t *testing.T) {
 	backoff, err := NewBackoff(time.Millisecond, 10*time.Second)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		backoff.Failure()
@@ -28,7 +28,7 @@ func TestBackoffWait(t *testing.T) {
 // reset correctly.
 func TestBackoffReset(t *testing.T) {
 	backoff, err := NewBackoff(time.Millisecond, 10*time.Second)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	backoff.Failure()
 	backoff.Reset()
@@ -39,7 +39,7 @@ func TestBackoffReset(t *testing.T) {
 // appropriately upper bounded.
 func TestBackoffMaximum(t *testing.T) {
 	backoff, err := NewBackoff(time.Millisecond, 10*time.Millisecond)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		backoff.Failure()
@@ -51,7 +51,7 @@ func TestBackoffMaximum(t *testing.T) {
 // appropriately lower bounded.
 func TestBackoffMinimum(t *testing.T) {
 	backoff, err := NewBackoff(time.Millisecond, 10*time.Millisecond)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	backoff.Failure()
 	for i := 0; i < 100; i++ {
@@ -63,7 +63,7 @@ func TestBackoffMinimum(t *testing.T) {
 // TestBackoff tests the backoff logic.
 func TestBackoff(t *testing.T) {
 	backoff, err := NewBackoff(100*time.Millisecond, 6*time.Second)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for i := 0; i < 2; i++ {
 		backoff.Failure()

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -14,7 +14,7 @@ const tsRegex = `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{0,9}Z`
 func TestLoggerLogfmt(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtLogfmt, LevelDebug)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Debug("a statement")
 	require.Regexp(t, regexp.MustCompile(
@@ -25,7 +25,7 @@ func TestLoggerLogfmt(t *testing.T) {
 func TestLoggerJSON(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelDebug)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Debug("a statement")
 	//nolint:goconst
@@ -43,7 +43,7 @@ func TestLoggerInvalid(t *testing.T) {
 func TestWith(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelDebug)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.With("height", 8000000).Debug("a statement")
 	require.Regexp(t, regexp.MustCompile(
@@ -54,7 +54,7 @@ func TestWith(t *testing.T) {
 func TestWithModule(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelDebug)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.WithModule("log-test-2").Debug("a statement")
 	require.Regexp(t, regexp.MustCompile(
@@ -65,13 +65,13 @@ func TestWithModule(t *testing.T) {
 func TestDebug(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelInfo)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Debug("a statement")
 	require.Equal(t, 0, b.Len())
 
 	l, err = NewLogger("log-test", &b, FmtJSON, LevelDebug)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Debug("another statement")
 	require.NotEqual(t, 0, b.Len())
@@ -80,13 +80,13 @@ func TestDebug(t *testing.T) {
 func TestInfo(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelWarn)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Info("a statement")
 	require.Equal(t, 0, b.Len())
 
 	l, err = NewLogger("log-test", &b, FmtJSON, LevelInfo)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Info("another statement")
 	require.NotEqual(t, 0, b.Len())
@@ -95,13 +95,13 @@ func TestInfo(t *testing.T) {
 func TestWarn(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelError)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Warn("a statement")
 	require.Equal(t, 0, b.Len())
 
 	l, err = NewLogger("log-test", &b, FmtJSON, LevelWarn)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Warn("another statement")
 	require.NotEqual(t, 0, b.Len())
@@ -110,7 +110,7 @@ func TestWarn(t *testing.T) {
 func TestError(t *testing.T) {
 	var b bytes.Buffer
 	l, err := NewLogger("log-test", &b, FmtJSON, LevelError)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	l.Error("a statement")
 	require.NotEqual(t, 0, b.Len())
@@ -122,7 +122,7 @@ func TestLevel(t *testing.T) {
 
 	for _, l := range strings.Split(ls[1:len(ls)-1], ",") {
 		err := lvl.Set(l)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, l, lvl.String())
 	}
 	err := lvl.Set("invalid")
@@ -138,7 +138,7 @@ func TestFormat(t *testing.T) {
 
 	for _, f := range strings.Split(fs[1:len(fs)-1], ",") {
 		err := fmt.Set(f)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, f, fmt.String())
 	}
 	err := fmt.Set("invalid")

--- a/storage/postgres/client_test.go
+++ b/storage/postgres/client_test.go
@@ -161,7 +161,7 @@ func TestSendBatch(t *testing.T) {
 			err := client.QueryRow(context.Background(), `
 				SELECT name FROM films WHERE fid = $1;
 			`, i).Scan(&result)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, film, result)
 		}(i, film)
 	}

--- a/storage/postgres/testutil/testutil.go
+++ b/storage/postgres/testutil/testutil.go
@@ -14,9 +14,9 @@ import (
 func NewTestClient(t *testing.T) *postgres.Client {
 	connString := os.Getenv("CI_TEST_CONN_STRING")
 	logger, err := log.NewLogger("postgres-test", os.Stdout, log.FmtJSON, log.LevelError)
-	require.Nil(t, err, "log.NewLogger")
+	require.NoError(t, err, "log.NewLogger")
 
 	client, err := postgres.NewClient(connString, logger)
-	require.Nil(t, err, "postgres.NewClient")
+	require.NoError(t, err, "postgres.NewClient")
 	return client
 }

--- a/tests/http/v1/governance_test.go
+++ b/tests/http/v1/governance_test.go
@@ -71,7 +71,7 @@ func TestListProposals(t *testing.T) {
 
 	var list storage.ProposalList
 	err := tests.GetFrom("/consensus/proposals", &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(list.Proposals))
 
 	for i, proposal := range list.Proposals {
@@ -90,7 +90,7 @@ func TestGetProposal(t *testing.T) {
 	for i, testProposal := range testProposals {
 		var proposal storage.Proposal
 		err := tests.GetFrom(fmt.Sprintf("/consensus/proposals/%d", i+1), &proposal)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, testProposal, proposal)
 	}
 }
@@ -106,7 +106,7 @@ func TestGetProposalVotes(t *testing.T) {
 	for i, expected := range expectedVotes {
 		var votes storage.ProposalVotes
 		err := tests.GetFrom(fmt.Sprintf("/consensus/proposals/%d/votes", i+1), &votes)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(i+1), votes.ProposalID)
 		require.Equal(t, expected, len(votes.Votes))
 	}

--- a/tests/http/v1/registry_test.go
+++ b/tests/http/v1/registry_test.go
@@ -52,7 +52,7 @@ func TestListEntities(t *testing.T) {
 
 	var list storage.EntityList
 	err := tests.GetFrom("/consensus/entities", &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	check := func(e storage.Entity) bool {
 		for _, entity := range list.Entities {
@@ -80,7 +80,7 @@ func TestGetEntity(t *testing.T) {
 
 	var entity storage.Entity
 	err := tests.GetFrom(fmt.Sprintf("/consensus/entities/%s", escape(testEntities[0].ID)), &entity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, testEntities[0].ID, entity.ID)
 	require.Equal(t, testEntities[0].Address, entity.Address)
@@ -98,7 +98,7 @@ func TestListEntityNodes(t *testing.T) {
 
 	var list storage.NodeList
 	err := tests.GetFrom(fmt.Sprintf("/consensus/entities/%s/nodes", escape(testNodes[0].EntityID)), &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(testNodes), len(list.Nodes))
 
 	for i, node := range list.Nodes {
@@ -119,7 +119,7 @@ func TestGetEntityNode(t *testing.T) {
 
 	var node storage.Node
 	err := tests.GetFrom(fmt.Sprintf("/consensus/entities/%s/nodes/%s", escape(testNodes[0].EntityID), escape(testNodes[0].ID)), &node)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// The expiration is dynamic, until we have oasis-net-runner with a halt epoch.
 	testNodes[0].Expiration = node.Expiration
 	require.Equal(t, testNodes[0], node)

--- a/tests/http/v1/staking_test.go
+++ b/tests/http/v1/staking_test.go
@@ -41,7 +41,7 @@ func TestListAccounts(t *testing.T) {
 
 	var list storage.AccountList
 	err := tests.GetFrom("/consensus/accounts?minAvailable=1000000000000000000", &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(list.Accounts))
 
 	// The big kahuna (Binance Staking).
@@ -60,7 +60,7 @@ func TestGetAccount(t *testing.T) {
 	for _, testAccount := range testAccounts {
 		var account storage.Account
 		err := tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", testAccount.Address), &account)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, testAccount, account)
 	}
 }

--- a/tests/http/v1/status_test.go
+++ b/tests/http/v1/status_test.go
@@ -18,7 +18,7 @@ func TestGetStatus(t *testing.T) {
 
 	var status storage.Status
 	err := tests.GetFrom("/", &status)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.LessOrEqual(t, tests.GenesisHeight, status.LatestBlock)
 }

--- a/tests/http/v1/transactions_test.go
+++ b/tests/http/v1/transactions_test.go
@@ -52,7 +52,7 @@ func makeTestBlocks(t *testing.T) []storage.Block {
 
 	for i := 0; i < len(blocks); i++ {
 		timestamp, err := time.Parse(time.RFC3339, timestamps[i])
-		require.Nil(t, err)
+		require.NoError(t, err)
 		blocks[i].Timestamp = timestamp
 	}
 	return blocks
@@ -120,7 +120,7 @@ func TestListBlocks(t *testing.T) {
 
 	var list storage.BlockList
 	err := tests.GetFrom(fmt.Sprintf("/consensus/blocks?from=%d&to=%d", tests.GenesisHeight, endHeight), &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(testBlocks), len(list.Blocks))
 
 	for i, block := range list.Blocks {
@@ -139,7 +139,7 @@ func TestGetBlock(t *testing.T) {
 
 	var block storage.Block
 	err := tests.GetFrom(fmt.Sprintf("/consensus/blocks/%d", endHeight), &block)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, testBlocks[len(testBlocks)-1], block)
 }
 
@@ -154,7 +154,7 @@ func TestListTransactions(t *testing.T) {
 
 	var list storage.TransactionList
 	err := tests.GetFrom(fmt.Sprintf("/consensus/transactions?block=%d", testTransactions[0].Block), &list)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(testTransactions), len(list.Transactions))
 
 	// Get a consistent ordering.
@@ -179,7 +179,7 @@ func TestGetTransaction(t *testing.T) {
 
 	var transaction storage.Transaction
 	err := tests.GetFrom(fmt.Sprintf("/consensus/transactions/%s", testTransactions[0].Hash), &transaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, transaction.Body)
 	transaction.Body = nil
 	require.Equal(t, testTransactions[0], transaction)

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
@@ -25,7 +26,7 @@ const (
 func newTargetClient(t *testing.T) (*postgres.Client, error) {
 	connString := os.Getenv("HEALTHCHECK_TEST_CONN_STRING")
 	logger, err := log.NewLogger("db-test", io.Discard, log.FmtJSON, log.LevelInfo)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return postgres.NewClient(connString, logger)
 }


### PR DESCRIPTION
Use `{require,assert}.NoError` instead of `.Nil` in all test cases where error existence is checked. This makes the output more readable, which is especially useful in the statecheck tests:

```
    consensus_test.go:168:
                Error Trace:    /nexus/tests/statecheck/consensus_test.go:168
                Error:          Expected nil, but got: &status.Error{s:(*status.Status)(0xc000307448)}
                Test:           TestGenesisFull
```
vs
```
    consensus_test.go:164:
                Error Trace:    /nexus/tests/statecheck/consensus_test.go:164
                Error:          Received unexpected error:
                                rpc error: code = Unimplemented desc = Only some methods are allowed on this proxy.
                Test:           TestGenesisFull
```