### PR TITLE
runtime-transactions: fix calculated `charged_fee` for non-evm txs

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2434,7 +2434,8 @@ components:
           description: |
             The fee that was charged for the transaction execution (total, native denomination,
             ParaTime base units, as a string).
-            Calculated as `gas_price * gas_used`, where `gas_price = fee / gas_limit`.
+            For EVM transactions this is calculated as `gas_price * gas_used`, where `gas_price = fee / gas_limit`, for compatibility with Ethereum.
+            For other transactions this equals to `fee`.
         size:
           type: integer
           format: int32

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -317,7 +317,10 @@ const (
 			txs.fee,
 			txs.gas_limit,
 			txs.gas_used,
-			COALESCE(FLOOR(txs.fee / NULLIF(txs.gas_limit, 0)) * txs.gas_used, 0) AS charged_fee, -- charged_fee=gas_price * gas_used
+			CASE
+				WHEN txs.tx_eth_hash IS NULL THEN txs.fee 				     -- charged_fee=fee for non-EVM txs
+				ELSE COALESCE(FLOOR(txs.fee / NULLIF(txs.gas_limit, 0)) * txs.gas_used, 0)   -- charged_fee=gas_price * gas_used for EVM txs
+			END AS charged_fee,
 			txs.size,
 			txs.method,
 			txs.body,

--- a/tests/e2e_regression/expected/emerald_txs.body
+++ b/tests/e2e_regression/expected/emerald_txs.body
@@ -347,7 +347,7 @@
         },
         "to": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw"
       },
-      "charged_fee": "6131500000000000",
+      "charged_fee": "6132100000000000",
       "fee": "6132100000000000",
       "gas_limit": 61321,
       "gas_used": 61315,
@@ -683,7 +683,7 @@
         },
         "to": "oasis1qr5vpvmhxgymefgxx66mn5heayeyec69xgvzr5p9"
       },
-      "charged_fee": "6131400000000000",
+      "charged_fee": "7000000000000000",
       "fee": "7000000000000000",
       "gas_limit": 70000,
       "gas_used": 61314,
@@ -812,7 +812,7 @@
         },
         "to": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw"
       },
-      "charged_fee": "6131400000000000",
+      "charged_fee": "6132100000000000",
       "fee": "6132100000000000",
       "gas_limit": 61321,
       "gas_used": 61314,
@@ -1302,7 +1302,7 @@
         },
         "to": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw"
       },
-      "charged_fee": "6131500000000000",
+      "charged_fee": "6132100000000000",
       "fee": "6132100000000000",
       "gas_limit": 61321,
       "gas_used": 61315,
@@ -1716,7 +1716,7 @@
         },
         "to": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw"
       },
-      "charged_fee": "6131500000000000",
+      "charged_fee": "6132100000000000",
       "fee": "6132100000000000",
       "gas_limit": 61321,
       "gas_used": 61315,
@@ -2181,7 +2181,7 @@
         },
         "to": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw"
       },
-      "charged_fee": "6131500000000000",
+      "charged_fee": "6132100000000000",
       "fee": "6132100000000000",
       "gas_limit": 61321,
       "gas_used": 61315,


### PR DESCRIPTION
For non-evm transactions there are no fee refunds as there are for EVM transactions (where this is done to ensure EVM compatibility).