### PR TITLE
db: Make eth_preimage() et al visible to api layer

### DIFF
--- a/storage/migrations/05_util_fns.up.sql
+++ b/storage/migrations/05_util_fns.up.sql
@@ -6,7 +6,7 @@ BEGIN;
 -- via lookups in the address_preimages table.
 
 -- Convenience function for retrieving the ethereum address associated with a given oasis address.
-CREATE OR REPLACE FUNCTION eth_preimage(addr oasis_addr)
+CREATE OR REPLACE FUNCTION public.eth_preimage(addr oasis_addr)
 RETURNS BYTEA
 LANGUAGE plpgsql
 AS $$
@@ -25,7 +25,7 @@ END;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION derive_oasis_addr(eth_addr bytea)
+CREATE OR REPLACE FUNCTION public.derive_oasis_addr(eth_addr bytea)
 RETURNS TEXT
 LANGUAGE plpgsql
 AS $$


### PR DESCRIPTION
The old migration files accidentally created the fns in the default schema, which is !=`public` in our deployment. Therefore, the `api` component wasn't able to call them, and the query at https://github.com/oasisprotocol/nexus/blob/fc099d75003d9b79ea20a040cd4cecf9e3168396/storage/client/queries/queries.go#L416-L416 crashed.

This PR fixes the issue for future runs that are starting with a wiped DB.
I manually moved the fns to `public` in mainnet and testnet staging, where they were in the wrong schema. Verified that in the new setup, the fn is accessible to analyzers _and_ the api.