### PR TITLE
active_accounts query optimization

### DIFF
--- a/storage/migrations/00_consensus.up.sql
+++ b/storage/migrations/00_consensus.up.sql
@@ -291,7 +291,8 @@ CREATE TABLE chain.accounts_related_transactions
   tx_index UINT31 NOT NULL,
   FOREIGN KEY (tx_block, tx_index) REFERENCES chain.transactions(block, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX ix_accounts_related_transactions_address_block_index ON chain.accounts_related_transactions (account_address);
+CREATE INDEX ix_accounts_related_transactions_address ON chain.accounts_related_transactions (account_address);
+CREATE INDEX ix_accounts_related_transactions_block ON chain.accounts_related_transactions (tx_block);
 
 -- Tracks the current (consensus) height of the node.
 CREATE TABLE chain.latest_node_heights


### PR DESCRIPTION
@lukaw3d reported that the latest transaction volume stats weren't up to date:

https://nexus.oasis.io/v1/emerald/blocks
```
"timestamp":"2024-01-19T17:30:48Z"
```
https://nexus.oasis.io/v1/emerald/stats/tx_volume?window_size_seconds=86400&window_step_seconds=86400&limit=30&offset=0
```
"window_end":"2023-11-26T00:00:00Z"
```

Upon closer inspection, the root cause was that the aggregate stats analyzer query to calculate `active_accounts` was taking a long time and blocking the calculation of other stats, including the transaction volume. This PR makes the queries more performant by 1) adding an index for consensus, and 2) rewriting the runtime active accounts query per @mitjat 's suggestion so that postgres now uses the existing index on the `runtime_related_transactions` table.

The index has been added to {mainnet, testnet} x {staging, production} manually, and the existing migrations were edited directly.

Minor change: renames an index to `ix_accounts_related_transactions_address` for accuracy.

Todo: Consider adding a generous timeout to the query context so that 1) queries will not block each other, 2) timeout errors will show up in the logs. Edit*: done