### PR TITLE
logging: Use global logging config everywhere

### DIFF
--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -45,10 +45,10 @@ func TestERC165(t *testing.T) {
 	// AI ROSE on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("0f4c5A429166608f9225E094F7E66B0bF68a53B9")
 	require.NoError(t, err)
-	supportsERC165, err := detectERC165(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
+	supportsERC165, err := detectERC165(ctx, cmdCommon.RootLogger(), source, runtimeClient.RoundLatest, tokenEthAddr)
 	require.NoError(t, err)
 	require.True(t, supportsERC165)
-	supportsERC721, err := detectInterface(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr, ERC721InterfaceID)
+	supportsERC721, err := detectInterface(ctx, cmdCommon.RootLogger(), source, runtimeClient.RoundLatest, tokenEthAddr, ERC721InterfaceID)
 	require.NoError(t, err)
 	require.True(t, supportsERC721)
 }
@@ -60,7 +60,7 @@ func TestEVMDownloadTokenERC20(t *testing.T) {
 	// Wormhole bridged USDT on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")
 	require.NoError(t, err)
-	data, err := evmDownloadTokenERC20(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
+	data, err := evmDownloadTokenERC20(ctx, cmdCommon.RootLogger(), source, runtimeClient.RoundLatest, tokenEthAddr)
 	require.NoError(t, err)
 	t.Logf("data %#v", data)
 }
@@ -72,7 +72,7 @@ func TestEVMDownloadTokenERC721(t *testing.T) {
 	// AI ROSE on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("0f4c5A429166608f9225E094F7E66B0bF68a53B9")
 	require.NoError(t, err)
-	data, err := evmDownloadTokenERC721(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr)
+	data, err := evmDownloadTokenERC721(ctx, cmdCommon.RootLogger(), source, runtimeClient.RoundLatest, tokenEthAddr)
 	require.NoError(t, err)
 	t.Logf("data %#v", data)
 }
@@ -87,7 +87,7 @@ func TestEVMDownloadTokenBalanceERC20(t *testing.T) {
 	// An address that possesses no USDT.
 	accountEthAddr, err := hex.DecodeString("5555555555555555555555555555555555555555")
 	require.NoError(t, err)
-	balanceData, err := evmDownloadTokenBalanceERC20(ctx, cmdCommon.Logger(), source, runtimeClient.RoundLatest, tokenEthAddr, accountEthAddr)
+	balanceData, err := evmDownloadTokenBalanceERC20(ctx, cmdCommon.RootLogger(), source, runtimeClient.RoundLatest, tokenEthAddr, accountEthAddr)
 	require.NoError(t, err)
 	t.Logf("balance %#v", balanceData)
 }

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -72,7 +72,7 @@ func runAnalyzer(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	logger := cmdCommon.Logger()
+	logger := cmdCommon.RootLogger()
 
 	if cfg.Analysis == nil {
 		logger.Error("analysis config not provided")
@@ -97,7 +97,7 @@ func RunMigrations(sourceURL string, databaseURL string) error {
 
 // Init initializes the analysis service.
 func Init(cfg *config.AnalysisConfig) (*Service, error) {
-	logger := cmdCommon.Logger()
+	logger := cmdCommon.RootLogger()
 
 	logger.Info("initializing analysis service", "config", cfg)
 	if cfg.Storage.WipeStorage {
@@ -132,7 +132,7 @@ func Init(cfg *config.AnalysisConfig) (*Service, error) {
 }
 
 func wipeStorage(cfg *config.StorageConfig) error {
-	logger := cmdCommon.Logger().WithModule(moduleName)
+	logger := cmdCommon.RootLogger().WithModule(moduleName)
 
 	// Initialize target storage.
 	storage, err := cmdCommon.NewClient(cfg, logger)
@@ -267,7 +267,7 @@ var (
 // NewService creates new Service.
 func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 	ctx := context.Background()
-	logger := cmdCommon.Logger().WithModule(moduleName)
+	logger := cmdCommon.RootLogger().WithModule(moduleName)
 	logger.Info("initializing analysis service", "config", cfg)
 
 	// Initialize source storage.

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -68,7 +68,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	logger := common.Logger()
+	logger := common.RootLogger()
 
 	if cfg.Server == nil {
 		logger.Error("server config not provided")
@@ -85,7 +85,7 @@ func runServer(cmd *cobra.Command, args []string) {
 
 // Init initializes the API service.
 func Init(cfg *config.ServerConfig) (*Service, error) {
-	logger := common.Logger()
+	logger := common.RootLogger()
 
 	service, err := NewService(cfg)
 	if err != nil {
@@ -106,7 +106,7 @@ type Service struct {
 
 // NewService creates a new API service.
 func NewService(cfg *config.ServerConfig) (*Service, error) {
-	logger := common.Logger().WithModule(moduleName)
+	logger := common.RootLogger().WithModule(moduleName)
 
 	// Initialize target storage.
 	backing, err := common.NewClient(cfg.Storage, logger)

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -4,8 +4,10 @@ package common
 import (
 	"fmt"
 	"io"
+	stdLog "log"
 	"os"
 
+	"github.com/akrylysov/pogreb"
 	coreLogging "github.com/oasisprotocol/oasis-core/go/common/logging"
 
 	"github.com/oasisprotocol/nexus/config"
@@ -49,6 +51,10 @@ func Init(cfg *config.Config) error {
 		logger.Error("failed to initialize oasis-core logging", "err", err)
 		return err
 	}
+
+	// Initialize pogreb logging.
+	pogrebLogger := RootLogger().WithModule("pogreb").WithCallerUnwind(7)
+	pogreb.SetLogger(stdLog.New(log.WriterIntoLogger(*pogrebLogger), "", 0))
 
 	// Initialize Prometheus service.
 	if cfg.Metrics != nil {

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -62,8 +62,8 @@ func Init(cfg *config.Config) error {
 	return nil
 }
 
-// Logger returns the logger defined by logging flags.
-func Logger() *log.Logger {
+// RootLogger returns the logger defined by logging flags.
+func RootLogger() *log.Logger {
 	return rootLogger
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ func rootMain(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	logger := common.Logger()
+	logger := common.RootLogger()
 
 	// Initialize services.
 	var wg sync.WaitGroup

--- a/log/log.go
+++ b/log/log.go
@@ -18,6 +18,7 @@ type Logger struct {
 }
 
 // NewDefaultLogger initializes a new logger instance with default settings.
+// For usage outside tests, prefer RootLogger() from package `cmd/common`.
 func NewDefaultLogger(module string) *Logger {
 	logger, err := NewLogger(module, os.Stdout, FmtJSON, LevelInfo)
 	if err != nil {

--- a/log/log.go
+++ b/log/log.go
@@ -112,7 +112,40 @@ func (l *Logger) WithModule(module string) *Logger {
 	}
 }
 
+// WithCallerUnwind returns a clone of the logger where the `caller`
+// value will show the n-th entry on the call stack at the time of logging.
+func (l *Logger) WithCallerUnwind(n int) *Logger {
+	return &Logger{
+		logger: log.With(l.logger, "caller", log.Caller(n)),
+		level:  l.level,
+		module: l.module,
+	}
+}
+
 // Level is the logging level.
 func (l *Logger) Level() Level {
 	return l.level
+}
+
+// An io.Writer impl that writes every string to the backing logger `l` at Info level.
+type writerIntoLoggerImpl struct {
+	Logger
+}
+
+var _ io.Writer = (*writerIntoLoggerImpl)(nil)
+
+func (l *writerIntoLoggerImpl) Write(msg []byte) (n int, err error) {
+	// Strip trailing newlines from message.
+	origLen := len(msg)
+	for len(msg) > 0 && msg[len(msg)-1] == '\n' {
+		msg = msg[:len(msg)-1]
+	}
+
+	// Write message to backing logger.
+	l.Info(string(msg))
+	return origLen, nil
+}
+
+func WriterIntoLogger(l Logger) io.Writer {
+	return &writerIntoLoggerImpl{l}
 }

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -9,6 +9,7 @@ import (
 	// nexus-internal data types.
 	"github.com/oasisprotocol/oasis-core/go/common"
 
+	cmdCommon "github.com/oasisprotocol/nexus/cmd/common"
 	beacon "github.com/oasisprotocol/nexus/coreapi/v22.2.11/beacon/api"
 	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
 	consensusTx "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api/transaction"
@@ -16,7 +17,6 @@ import (
 	governance "github.com/oasisprotocol/nexus/coreapi/v22.2.11/governance/api"
 	scheduler "github.com/oasisprotocol/nexus/coreapi/v22.2.11/scheduler/api"
 
-	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
@@ -86,7 +86,7 @@ func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, heigh
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			log.NewDefaultLogger("cobalt-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
+			cmdCommon.RootLogger().WithModule("cobalt-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
 				"height", height,
 				"index", i,
 				"tx_bytes", txBytes,

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -7,6 +7,8 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
+	cmdCommon "github.com/oasisprotocol/nexus/cmd/common"
+
 	// nexus-internal data types.
 	beacon "github.com/oasisprotocol/nexus/coreapi/v22.2.11/beacon/api"
 	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
@@ -18,7 +20,6 @@ import (
 	scheduler "github.com/oasisprotocol/nexus/coreapi/v22.2.11/scheduler/api"
 	staking "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api"
 
-	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
@@ -81,7 +82,7 @@ func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, heigh
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			log.NewDefaultLogger("damask-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
+			cmdCommon.RootLogger().WithModule("damask-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
 				"height", height,
 				"index", i,
 				"tx_bytes", txBytes,

--- a/storage/oasis/nodeapi/eden/node.go
+++ b/storage/oasis/nodeapi/eden/node.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
-	// nexus-internal data types.
-	"github.com/oasisprotocol/oasis-core/go/common"
+	cmdCommon "github.com/oasisprotocol/nexus/cmd/common"
 
+	// nexus-internal data types.
 	beacon "github.com/oasisprotocol/nexus/coreapi/v22.2.11/beacon/api"
 	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
 	consensusTx "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api/transaction"
@@ -16,7 +17,6 @@ import (
 	governance "github.com/oasisprotocol/nexus/coreapi/v22.2.11/governance/api"
 	scheduler "github.com/oasisprotocol/nexus/coreapi/v22.2.11/scheduler/api"
 
-	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
 
@@ -86,7 +86,7 @@ func (c *ConsensusApiLite) GetTransactionsWithResults(ctx context.Context, heigh
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			log.NewDefaultLogger("eden-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
+			cmdCommon.RootLogger().WithModule("eden-consensus-api-lite").Error("malformed consensus transaction, leaving empty",
 				"height", height,
 				"index", i,
 				"tx_bytes", txBytes,

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -5,12 +5,13 @@ import (
 
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 
+	cmdCommon "github.com/oasisprotocol/nexus/cmd/common"
+
 	beacon "github.com/oasisprotocol/nexus/coreapi/v22.2.11/beacon/api"
 	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
 	genesis "github.com/oasisprotocol/nexus/coreapi/v22.2.11/genesis/api"
 
 	"github.com/oasisprotocol/nexus/common"
-	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/metrics"
 	"github.com/oasisprotocol/nexus/storage/oasis/connections"
 	"github.com/oasisprotocol/nexus/storage/oasis/nodeapi"
@@ -29,7 +30,7 @@ var _ nodeapi.ConsensusApiLite = (*FileConsensusApiLite)(nil)
 
 func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiLite) (*FileConsensusApiLite, error) {
 	db, err := OpenKVStore(
-		log.NewDefaultLogger("cached-node-api").With("runtime", "consensus"),
+		cmdCommon.RootLogger().WithModule("file-consensus-api-lite").With("runtime", "consensus"),
 		cacheDir,
 		common.Ptr(metrics.NewDefaultAnalysisMetrics("consensus")),
 	)


### PR DESCRIPTION
This PR has two related small improvements to logging:
- We used NewDefaultLogger in a few places before; this is not great as the default logger does not reflect the .yml config (e.g. the desired logging level, the format, etc). We now use RootLogger (which is derived from the config) instead.
- `pogreb` was logging straight to `stderr`, so all its info-level logs were interpreted as errors by GCP, and stood out in the log browser. We now route pogreb logs through our JSON-formatted logger, at INFO level.