### PR TITLE
prometheus: Histograms: Use more buckets

### DIFF
--- a/metrics/analysis.go
+++ b/metrics/analysis.go
@@ -45,8 +45,8 @@ const (
 func defaultTimeBuckets() []float64 {
 	const (
 		minThreshold                  = 0.0001
-		maxThreshold                  = 10 // The resulting output might be one bucket short due to rounding errors.
-		thresholdsPerOrderOfMagnitude = 10 // "order of magnitude" being 10x.
+		maxThreshold                  = 1000 // The resulting output might be one bucket short due to rounding errors.
+		thresholdsPerOrderOfMagnitude = 10   // "Order of magnitude" being 10x.
 	)
 
 	buckets := []float64{}


### PR DESCRIPTION
This PR introduces more buckets for timing histograms. It does not change the density, it only introduces buckets for larger values.

Prior to this PR, the highest-value bucket had a lower boundary of 10^0.9 = 7.94s. In a recent high-load situation, block processing in sapphire took longer than that, leading to clipped graphs in Grafana.
