### PR TITLE
analyzer/item: GetItems: Use stronger isolation level

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -62,6 +62,7 @@ func MetricsMiddleware(m metrics.RequestMetrics, logger log.Logger) func(next ht
 			logger.Info("starting request",
 				"endpoint", r.URL.Path,
 				"request_id", requestID,
+				"remote_addr", r.RemoteAddr,
 			)
 			t := time.Now()
 			metricName := normalizeEndpoint(r.URL.Path)

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -108,7 +108,7 @@ func Init(cfg *config.AnalysisConfig) (*Service, error) {
 		logger.Info("storage wiped")
 	}
 
-	logger.Info("checking if migrations need to be applied...")
+	logger.Info("applying relevant DB migrations, if any ...")
 	switch err := RunMigrations(cfg.Storage.Migrations, cfg.Storage.Endpoint); {
 	case err == migrate.ErrNoChange:
 		logger.Info("no migrations needed to be applied")

--- a/storage/api.go
+++ b/storage/api.go
@@ -96,6 +96,9 @@ type TargetStorage interface {
 	// Query submits a query to fetch data from target storage.
 	Query(ctx context.Context, sql string, args ...interface{}) (QueryResults, error)
 
+	// Query submits a query to fetch data from target storage, with custom tx options.
+	QueryWithOptions(ctx context.Context, txOpts pgx.TxOptions, sql string, args ...interface{}) (QueryResults, error)
+
 	// QueryRow submits a query to fetch a single row of data from target storage.
 	QueryRow(ctx context.Context, sql string, args ...interface{}) QueryResult
 


### PR DESCRIPTION
This PR addresses a possible source of data inaccuracies. We do not know if this has actually caused problems in the past.

The evm_token_balances analyzer fetches the list of work items using the default `READ COMMITTED` mode, which [allows nonrepeatable reads](https://www.postgresql.org/docs/current/transaction-iso.html). This means that the work item could say something like "we think the balance of token X at height H was N", with the following sequencing:
1. balances analyzer reads H at the beginning of the SELECT as the highest round processed so far, 
2. block analyzer completes block H+1 (async) and commits all changes. It also records that H+1 is now analyzed, and updates the balance of X with a dead-reckoned step
3. balances analyzer reads N, thinking that it represents the state at H when it really represents the state at H+1.

Testing: None yet.