### PR TITLE
usable changes from roothash work

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -161,6 +161,13 @@ func TryAsJSON(v interface{}) json.RawMessage {
 	return json.RawMessage(encoded)
 }
 
+func StringOrNil[T fmt.Stringer](v *T) *string {
+	if v == nil {
+		return nil
+	}
+	return Ptr((*v).String())
+}
+
 // Key used to set values in a web request context. API uses this to set
 // values, backend uses this to retrieve values.
 type ContextKey string

--- a/storage/migrations/00_consensus.up.sql
+++ b/storage/migrations/00_consensus.up.sql
@@ -72,7 +72,7 @@ CREATE TABLE chain.events
   tx_block UINT63 NOT NULL,
   tx_index  UINT31,
 
-  type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/nexus/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
+  type    TEXT NOT NULL,  -- Enum with many values, see ConsensusEventType in api/spec/v1.yaml.
   body    JSONB,
   tx_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency
   related_accounts TEXT[],

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -7,11 +7,10 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 
-	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
-
 	// nexus-internal data types.
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 
+	consensus "github.com/oasisprotocol/nexus/coreapi/v22.2.11/consensus/api"
 	genesis "github.com/oasisprotocol/nexus/coreapi/v22.2.11/genesis/api"
 	governance "github.com/oasisprotocol/nexus/coreapi/v22.2.11/governance/api"
 	registry "github.com/oasisprotocol/nexus/coreapi/v22.2.11/registry/api"


### PR DESCRIPTION
here's some changes we can extract from the roothash events line of work

new for nexus developers: common.StringOrNil(v) replaces:

```go
var vStringPointer *string
if (v != nil) {
  vString := v.String()
  vStringPointer = &vString
}
```

which comes up a lot in cases where we use *Address (or whatever) for optional fields going to the database