### PR TITLE
openapi: Use named types everywhere

### DIFF
--- a/analyzer/uncategorized/addresses.go
+++ b/analyzer/uncategorized/addresses.go
@@ -48,7 +48,7 @@ func ExtractAddresses(accounts map[apiTypes.Address]bool) []string {
 	addrs := make([]string, len(accounts))
 	i := 0
 	for a := range accounts {
-		addrs[i] = string(a)
+		addrs[i] = a
 		i++
 	}
 	return addrs

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -242,13 +242,13 @@ paths:
         - in: query
           name: minFee
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on minimum transaction fee, inclusive.
           example: "1000"
         - in: query
           name: maxFee
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on maximum transaction fee, inclusive.
           example: "100000000000000000000000"
         - in: query
@@ -494,42 +494,42 @@ paths:
         - in: query
           name: minAvailable
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the minimum available account balance.
         - in: query
           name: maxAvailable
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the maximum available account balance.
         - in: query
           name: minEscrow
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the minimum active escrow account balance.
         - in: query
           name: maxEscrow
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the maximum active escrow account balance.
         - in: query
           name: minDebonding
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the minimum debonding account balance.
         - in: query
           name: maxDebonding
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the maximum debonding account balance.
         - in: query
           name: minTotalBalance
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the minimum total account balance.
         - in: query
           name: maxTotalBalance
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: A filter on the maximum total account balance.
       responses:
         '200':
@@ -1079,7 +1079,7 @@ paths:
           name: id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/BigInt']
+            allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The ID of the NFT instance.
       responses:
         '200':
@@ -1226,7 +1226,7 @@ components:
       x-go-type: staking.Address
       x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
       description: An Oasis-style (bech32) address.
-    BigInt:
+    TextBigInt:
       type: string
       pattern: '^-?[0-9]+$'
       format: bigint  # Annotation is not used by Nexus's Go codegen; might be helpful to client generators to recognize this type.
@@ -1349,10 +1349,10 @@ components:
       required: [amount, shares, validator, delegator]
       properties:
         amount:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The amount of tokens delegated in base units.
         shares:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1383,10 +1383,10 @@ components:
       required: [amount, shares, validator, delegator, debond_end]
       properties:
         amount:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The amount of tokens delegated in base units.
         shares:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1485,7 +1485,7 @@ components:
           description: The nonce used with this transaction, to prevent replay.
           example: 0
         fee:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: |
             The fee that this transaction's sender committed
             to pay to execute it.
@@ -1726,7 +1726,7 @@ components:
           description: The public key identifying this Validator's node.
           example: *node_id_1
         escrow:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The amount staked.
         active:
           type: boolean
@@ -1871,7 +1871,7 @@ components:
       required: [balance, token_symbol, token_decimals]
       properties:
         balance:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: Number of tokens held, in base units.
         token_symbol:
           type: string
@@ -1888,7 +1888,7 @@ components:
       required: [balance, token_contract_addr, token_contract_addr_eth, token_decimals, token_type]
       properties:
         balance:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: Number of tokens held, in base units.
         token_contract_addr:
           type: string
@@ -1939,7 +1939,7 @@ components:
           description: The Ethereum address of the same account holder, if meaningfully defined.
           example: *eth_address_1
         balance:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: Number of tokens held, in base units.
 
 
@@ -1957,21 +1957,21 @@ components:
           description: A nonce used to prevent replay.
           example: 0
         available:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The available balance, in base units.
         escrow:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The active escrow balance, in base units.
         debonding:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The debonding escrow balance, in base units.
         delegations_balance:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: |
             The delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
         debonding_delegations_balance:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: |
             The debonding delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
@@ -1993,7 +1993,7 @@ components:
           description: The allowed account.
           example: *staking_address_2
         amount:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The amount allowed for the allowed account.
 
     EpochList:
@@ -2082,7 +2082,7 @@ components:
         state:
           $ref: '#/components/schemas/ProposalState'
         deposit:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The deposit attached to this proposal.
         handler:
           type: string
@@ -2122,7 +2122,7 @@ components:
           description: The epoch at which voting for this proposal will close.
           example: *epoch_2
         invalid_votes:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: |
             The number of invalid votes for this proposal, after tallying.
       description: |
@@ -2715,7 +2715,7 @@ components:
             ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
             detected or is not supported, this field will be null/absent.
         total_supply:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The total number of base units available.
         num_transfers:
           type: integer
@@ -2759,7 +2759,7 @@ components:
         token:
           $ref: '#/components/schemas/EvmToken'
         id:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The instance ID of this NFT within the collection represented by `token`.
         owner:
           allOf: [$ref: '#/components/schemas/Address']
@@ -2800,10 +2800,10 @@ components:
       required: [total_sent, total_received, num_txns]
       properties:
         total_sent:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The total number of tokens sent, in base units.
         total_received:
-          allOf: [$ref: '#/components/schemas/BigInt']
+          allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The total number of tokens received, in base units.
         num_txns:
           description: The total number of transactions this account was involved with.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -47,7 +47,7 @@ x-query-params:
     name: runtime
     required: true
     schema:
-      $ref: '#/components/schemas/Runtime'
+      allOf: [$ref: '#/components/schemas/Runtime']
     description: |
       The runtime which to query.
   - &window_size_seconds
@@ -226,12 +226,12 @@ paths:
         - in: query
           name: method
           schema:
-            $ref: '#/components/schemas/ConsensusTxMethod'
+            allOf: [$ref: '#/components/schemas/ConsensusTxMethod']
           description: A filter on transaction method.
         - in: query
           name: sender
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: A filter on transaction sender.
         - in: query
           name: rel
@@ -242,13 +242,13 @@ paths:
         - in: query
           name: minFee
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on minimum transaction fee, inclusive.
           example: "1000"
         - in: query
           name: maxFee
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on maximum transaction fee, inclusive.
           example: "100000000000000000000000"
         - in: query
@@ -337,7 +337,7 @@ paths:
         - in: query
           name: rel
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: |
             A filter on related accounts. Every returned event will refer to
             this account. For example, for a `Transfer` event, this will be the
@@ -345,7 +345,7 @@ paths:
         - in: query
           name: type
           schema:
-            $ref: '#/components/schemas/ConsensusEventType'
+            allOf: [$ref: '#/components/schemas/ConsensusEventType']
           description: A filter on the event type.
           example: *event_type_1
       responses:
@@ -383,7 +383,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            $ref: '#/components/schemas/Ed25519PubKeyType'
+            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -406,7 +406,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            $ref: '#/components/schemas/Ed25519PubKeyType'
+            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
           description: |
             The entity ID of the controlling entity of the nodes to return.
       responses:
@@ -427,7 +427,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            $ref: '#/components/schemas/Ed25519PubKeyType'
+            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
           description: |
             The entity ID of the entity controlling the node to return.
           example: *entity_id_1
@@ -435,7 +435,7 @@ paths:
           name: node_id
           required: true
           schema:
-            $ref: '#/components/schemas/Ed25519PubKeyType'
+            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
           description: The node ID of the node to return.
       responses:
         '200':
@@ -472,7 +472,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            $ref: '#/components/schemas/Ed25519PubKeyType'
+            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -494,42 +494,42 @@ paths:
         - in: query
           name: minAvailable
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the minimum available account balance.
         - in: query
           name: maxAvailable
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the maximum available account balance.
         - in: query
           name: minEscrow
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the minimum active escrow account balance.
         - in: query
           name: maxEscrow
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the maximum active escrow account balance.
         - in: query
           name: minDebonding
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the minimum debonding account balance.
         - in: query
           name: maxDebonding
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the maximum debonding account balance.
         - in: query
           name: minTotalBalance
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the minimum total account balance.
         - in: query
           name: maxTotalBalance
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: A filter on the maximum total account balance.
       responses:
         '200':
@@ -549,7 +549,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the account to return.
       responses:
         '200':
@@ -570,7 +570,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -591,7 +591,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the account that is being delegated to.
       responses:
         '200':
@@ -612,7 +612,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -633,7 +633,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the that is being delegated to.
       responses:
         '200':
@@ -689,12 +689,12 @@ paths:
         - in: query
           name: submitter
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: Filter on the submitter of the proposal.
         - in: query
           name: state
           schema:
-            $ref: '#/components/schemas/ProposalState'
+            allOf: [$ref: '#/components/schemas/ProposalState']
           description: Filter on the state of the proposal.
           example: *proposal_state_1
       responses:
@@ -920,7 +920,7 @@ paths:
         - in: query
           name: type
           schema:
-            $ref: '#/components/schemas/RuntimeEventType'
+            allOf: [$ref: '#/components/schemas/RuntimeEventType']
           description: A filter on the event type.
         - in: query
           name: rel
@@ -1004,7 +1004,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the token contract.
       responses:
         '200':
@@ -1028,7 +1028,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the token contract for which to return the holders.
       responses:
         '200':
@@ -1052,7 +1052,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the token contract for which to return the NFT instances.
       responses:
         '200':
@@ -1073,13 +1073,13 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the token contract of the NFT instance.
         - in: path
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/BigIntType'
+            allOf: [$ref: '#/components/schemas/BigIntType']
           description: The ID of the NFT instance.
       responses:
         '200':
@@ -1099,7 +1099,7 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the account to return.
       responses:
         '200':
@@ -1122,12 +1122,12 @@ paths:
           name: address
           required: true
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: The staking address of the owner of the NFT instances.
         - in: query
           name: token_address
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            allOf: [$ref: '#/components/schemas/StakingAddressType']
           description: Only return NFT instances from the token contract at the given staking address.
       responses:
         '200':
@@ -1166,7 +1166,7 @@ paths:
           name: layer
           required: true
           schema:
-            $ref: '#/components/schemas/Layer'
+            allOf: [$ref: '#/components/schemas/Layer']
           description: |
             The layer for which to return the transaction volume timeline.
       responses:
@@ -1192,7 +1192,7 @@ paths:
           name: layer
           required: true
           schema:
-            $ref: '#/components/schemas/Layer'
+            allOf: [$ref: '#/components/schemas/Layer']
           description: |
             The layer for which to return the active accounts timeline.
       responses:
@@ -1304,7 +1304,7 @@ components:
             blocks:
               type: array
               items:
-                $ref: '#/components/schemas/Block'
+                allOf: [$ref: '#/components/schemas/Block']
       description: |
         A list of consensus blocks.
 
@@ -1350,10 +1350,10 @@ components:
       required: [amount, shares, validator, delegator]
       properties:
         amount:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The amount of tokens delegated in base units.
         shares:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1375,7 +1375,7 @@ components:
             delegations:
               type: array
               items:
-                $ref: '#/components/schemas/Delegation'
+                allOf: [$ref: '#/components/schemas/Delegation']
           description: |
             A list of delegations.
 
@@ -1384,10 +1384,10 @@ components:
       required: [amount, shares, validator, delegator, debond_end]
       properties:
         amount:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The amount of tokens delegated in base units.
         shares:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1413,7 +1413,7 @@ components:
             debonding_delegations:
               type: array
               items:
-                $ref: '#/components/schemas/DebondingDelegation'
+                allOf: [$ref: '#/components/schemas/DebondingDelegation']
           description: |
             A list of debonding delegations.
 
@@ -1447,7 +1447,7 @@ components:
             transactions:
               type: array
               items:
-                $ref: '#/components/schemas/Transaction'
+                allOf: [$ref: '#/components/schemas/Transaction']
           description: |
             A list of consensus transactions.
 
@@ -1486,13 +1486,13 @@ components:
           description: The nonce used with this transaction, to prevent replay.
           example: 0
         fee:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: |
             The fee that this transaction's sender committed
             to pay to execute it.
           example: 1000
         method:
-          $ref: '#/components/schemas/ConsensusTxMethod'
+          allOf: [$ref: '#/components/schemas/ConsensusTxMethod']
           description: The method that was called.
         body:
           type: string
@@ -1505,7 +1505,7 @@ components:
           type: boolean
           description: Whether this transaction successfully executed.
         error:
-          $ref: '#/components/schemas/TxError'
+          allOf: [$ref: '#/components/schemas/TxError']
           description: Error details of a failed transaction.
       description: |
         A consensus transaction.
@@ -1537,7 +1537,7 @@ components:
         revert_params:
           type: array
           items:
-            $ref: '#/components/schemas/EvmAbiParam'
+            allOf: [$ref: '#/components/schemas/EvmAbiParam']
           description: |
             The error parameters, as decoded using the contract abi. Present only when
             - the error originated from within a smart contract (e.g. via `revert` in Solidity), and 
@@ -1579,7 +1579,7 @@ components:
             events:
               type: array
               items:
-                $ref: '#/components/schemas/ConsensusEvent'
+                allOf: [$ref: '#/components/schemas/ConsensusEvent']
           description: |
             A list of consensus events.
 
@@ -1608,8 +1608,8 @@ components:
             Absent if the event did not originate from a transaction.
           example: *tx_hash_1
         type:
+          allOf: [$ref: '#/components/schemas/ConsensusEventType']
           description: The type of the event.
-          $ref: '#/components/schemas/ConsensusEventType'
         body:
           type: object
           description: |
@@ -1629,7 +1629,7 @@ components:
             entities:
               type: array
               items:
-                $ref: '#/components/schemas/Entity'
+                allOf: [$ref: '#/components/schemas/Entity']
           description: |
             A list of entities registered at the consensus layer.
 
@@ -1663,7 +1663,7 @@ components:
             validators:
               type: array
               items:
-                $ref: '#/components/schemas/Validator'
+                allOf: [$ref: '#/components/schemas/Validator']
           description: |
             A list of validators registered at the consensus layer.
 
@@ -1727,7 +1727,7 @@ components:
           description: The public key identifying this Validator's node.
           example: *node_id_1
         escrow:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The amount staked.
         active:
           type: boolean
@@ -1742,7 +1742,7 @@ components:
           format: uint64
           description: Commission rate.
         current_commission_bound:
-          $ref: '#/components/schemas/ValidatorCommissionBound'
+          allOf: [$ref: '#/components/schemas/ValidatorCommissionBound']
       description: |
         An validator registered at the consensus layer.
 
@@ -1758,7 +1758,7 @@ components:
             nodes:
               type: array
               items:
-                $ref: '#/components/schemas/Node'
+                allOf: [$ref: '#/components/schemas/Node']
           description: |
             A list of nodes registered at the consensus layer.
 
@@ -1813,7 +1813,7 @@ components:
             accounts:
               type: array
               items:
-                $ref: '#/components/schemas/Account'
+                allOf: [$ref: '#/components/schemas/Account']
           description: |
             A list of consensus layer accounts.
 
@@ -1872,7 +1872,7 @@ components:
       required: [balance, token_symbol, token_decimals]
       properties:
         balance:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: Number of tokens held, in base units.
         token_symbol:
           type: string
@@ -1889,7 +1889,7 @@ components:
       required: [balance, token_contract_addr, token_contract_addr_eth, token_decimals, token_type]
       properties:
         balance:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: Number of tokens held, in base units.
         token_contract_addr:
           type: string
@@ -1921,7 +1921,7 @@ components:
             holders:
               type: array
               items:
-                $ref: '#/components/schemas/BareTokenHolder'
+                allOf: [$ref: '#/components/schemas/BareTokenHolder']
           description: |
             A list of token holders for a specific (implied) runtime and token.
 
@@ -1940,7 +1940,7 @@ components:
           description: The Ethereum address of the same account holder, if meaningfully defined.
           example: *eth_address_1
         balance:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: Number of tokens held, in base units.
 
 
@@ -1958,21 +1958,21 @@ components:
           description: A nonce used to prevent replay.
           example: 0
         available:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The available balance, in base units.
         escrow:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The active escrow balance, in base units.
         debonding:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The debonding escrow balance, in base units.
         delegations_balance:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: |
             The delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
         debonding_delegations_balance:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: |
             The debonding delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
@@ -1980,7 +1980,7 @@ components:
         allowances:
           type: array
           items:
-            $ref: '#/components/schemas/Allowance'
+            allOf: [$ref: '#/components/schemas/Allowance']
           description: The allowances made by this account.
       description: |
         A consensus layer account.
@@ -1994,7 +1994,7 @@ components:
           description: The allowed account.
           example: *staking_address_2
         amount:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The amount allowed for the allowed account.
 
     EpochList:
@@ -2006,7 +2006,7 @@ components:
             epochs:
               type: array
               items:
-                $ref: '#/components/schemas/Epoch'
+                allOf: [$ref: '#/components/schemas/Epoch']
           description: |
             A list of consensus epochs.
 
@@ -2042,7 +2042,7 @@ components:
             proposals:
               type: array
               items:
-                $ref: '#/components/schemas/Proposal'
+                allOf: [$ref: '#/components/schemas/Proposal']
           description: |
             A list of governance proposals.
 
@@ -2083,7 +2083,7 @@ components:
         state:
           $ref: '#/components/schemas/ProposalState'
         deposit:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The deposit attached to this proposal.
         handler:
           type: string
@@ -2123,7 +2123,7 @@ components:
           description: The epoch at which voting for this proposal will close.
           example: *epoch_2
         invalid_votes:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: |
             The number of invalid votes for this proposal, after tallying.
       description: |
@@ -2143,7 +2143,7 @@ components:
             votes:
               type: array
               items:
-                $ref: '#/components/schemas/ProposalVote'
+                allOf: [$ref: '#/components/schemas/ProposalVote']
               description: The list of votes for the proposal.
           description: |
             A list of votes for a governance proposal.
@@ -2170,7 +2170,7 @@ components:
             blocks:
               type: array
               items:
-                $ref: '#/components/schemas/RuntimeBlock'
+                allOf: [$ref: '#/components/schemas/RuntimeBlock']
           description: |
             A list of consensus blocks.
 
@@ -2219,7 +2219,7 @@ components:
             events:
               type: array
               items:
-                $ref: '#/components/schemas/RuntimeEvent'
+                allOf: [$ref: '#/components/schemas/RuntimeEvent']
           description: |
             A list of runtime events.
 
@@ -2257,8 +2257,8 @@ components:
             The second-granular consensus time of this event's block.
           example: *iso_timestamp_1
         type:
+          allOf: [$ref: '#/components/schemas/RuntimeEventType']
           description: The type of the event.
-          $ref: '#/components/schemas/RuntimeEventType'
         body:
           type: object
           description: |
@@ -2278,12 +2278,12 @@ components:
         evm_log_params:
           type: array
           items:
-            $ref: '#/components/schemas/EvmAbiParam'
+            allOf: [$ref: '#/components/schemas/EvmAbiParam']
           description: |
             The decoded `evm.log` event data.
             Absent if the event type is not `evm.log`.
         evm_token:
-          $ref: '#/components/schemas/EvmEventToken'
+          allOf: [$ref: '#/components/schemas/EvmEventToken']
       description: An event emitted by the runtime layer
 
     RuntimeEventType:
@@ -2377,7 +2377,7 @@ components:
           format: uint64
           example: 153852
         verification:
-          $ref: '#/components/schemas/RuntimeEvmContractVerification'
+          allOf: [$ref: '#/components/schemas/RuntimeEvmContractVerification']
           description: |
             Additional information obtained from contract verification. Only available for smart
             contracts that have been verified successfully by Sourcify.
@@ -2406,7 +2406,7 @@ components:
             transactions:
               type: array
               items:
-                $ref: '#/components/schemas/RuntimeTransaction'
+                allOf: [$ref: '#/components/schemas/RuntimeTransaction']
           description: |
             A list of runtime transactions.
 
@@ -2442,7 +2442,7 @@ components:
             Absent for non-Ethereum-format transactions.
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
         sender_0:
-          $ref: '#/components/schemas/AddressType'
+          allOf: [$ref: '#/components/schemas/AddressType']
           description: |
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
@@ -2517,7 +2517,7 @@ components:
             Note: Other transactions with method "evm.Call", and possibly "evm.Create", may also be (or include) native token transfers. The heuristic will be `false` for those.
           example: true
         to:
-          $ref: '#/components/schemas/AddressType'
+          allOf: [$ref: '#/components/schemas/AddressType']
           description: |
             A reasonable "to" Oasis address associated with this transaction,
             if applicable. The meaning varies based on the transaction method. Some notable examples:
@@ -2542,12 +2542,12 @@ components:
             Usually in native denomination, ParaTime units. As a string.
           example: "100000001666393459"
         encryption_envelope:
+          allOf: [$ref: '#/components/schemas/RuntimeTransactionEncryptionEnvelope']
           description: |
             The data relevant to the encrypted transaction. Only present for encrypted
             transactions in confidential EVM runtimes like Sapphire.
             Note: The term "envelope" in this context refers to the [Oasis-style encryption envelopes](https://github.com/oasisprotocol/oasis-sdk/blob/c36a7ee194abf4ca28fdac0edbefe3843b39bf69/runtime-sdk/src/types/callformat.rs)
             which differ slightly from [digital envelopes](hhttps://en.wikipedia.org/wiki/Hybrid_cryptosystem#Envelope_encryption).
-          $ref: '#/components/schemas/RuntimeTransactionEncryptionEnvelope'
         success:
           type: boolean
           description: |
@@ -2562,12 +2562,12 @@ components:
         evm_fn_params:
           type: array
           items:
-            $ref: '#/components/schemas/EvmAbiParam'
+            allOf: [$ref: '#/components/schemas/EvmAbiParam']
           description: |
             The decoded parameters with which the smart contract function was called.
             Only present for `evm.log` transaction calls to contracts that have been verified.
         error:
-          $ref: '#/components/schemas/TxError'
+          allOf: [$ref: '#/components/schemas/TxError']
           description: Error details of a failed transaction.
       description: |
         A runtime transaction.
@@ -2577,7 +2577,7 @@ components:
       required: [format]
       properties:
         format:
-          $ref: '#/components/schemas/CallFormat'
+          allOf: [$ref: '#/components/schemas/CallFormat']
           description: The format of the encrypted evm transaction envelope.
         public_key:
           type: string
@@ -2620,10 +2620,10 @@ components:
           items:
             $ref: '#/components/schemas/RuntimeSdkBalance'
         evm_contract:
+          allOf: [$ref: '#/components/schemas/RuntimeEvmContract']
           description: |
             Data on the EVM smart contract associated with this account address. Only present for accounts
             that represent a smart contract on EVM.
-          $ref: '#/components/schemas/RuntimeEvmContract'
         evm_balances:
           description: |
             The balances of this account in each runtime, as managed by EVM smart contracts (notably, ERC-20).
@@ -2677,7 +2677,7 @@ components:
             evm_tokens:
               type: array
               items:
-                $ref: '#/components/schemas/EvmToken'
+                allOf: [$ref: '#/components/schemas/EvmToken']
               description: A list of L2 EVM tokens (ERC-20, ERC-721, ...).
           description: A list of tokens in a runtime.
 
@@ -2709,14 +2709,14 @@ components:
             Affects display only. Often equals 18, to match ETH.
           example: 18
         type:
-          $ref: '#/components/schemas/EvmTokenType'
+          allOf: [$ref: '#/components/schemas/EvmTokenType']
           description: |
             The heuristically determined interface that the token contract implements.
             A less specialized variant of the token might be detected; for example, an
             ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
             detected or is not supported, this field will be null/absent.
         total_supply:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The total number of base units available.
         num_transfers:
           type: integer
@@ -2746,7 +2746,7 @@ components:
             evm_nfts:
               type: array
               items:
-                $ref: '#/components/schemas/EvmNft'
+                allOf: [$ref: '#/components/schemas/EvmNft']
               description: A list of L2 EVM NFT (ERC-721, ...) instances.
           description: A list of NFT instances.
 
@@ -2760,10 +2760,10 @@ components:
         token:
           $ref: '#/components/schemas/EvmToken'
         id:
-          $ref: '#/components/schemas/BigIntType'
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The instance ID of this NFT within the collection represented by `token`.
         owner:
-          $ref: '#/components/schemas/AddressType'
+          allOf: [$ref: '#/components/schemas/AddressType']
           description: The Oasis address of this NFT instance's owner.
           example: "oasis1qpclnnm0wu44pn43mt6vv3me59kl8zk9ty7qyj03"
         owner_eth:
@@ -2801,11 +2801,11 @@ components:
       required: [total_sent, total_received, num_txns]
       properties:
         total_sent:
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The total number of tokens sent, in base units.
-          $ref: '#/components/schemas/BigIntType'
         total_received:
+          allOf: [$ref: '#/components/schemas/BigIntType']
           description: The total number of tokens received, in base units.
-          $ref: '#/components/schemas/BigIntType'
         num_txns:
           description: The total number of transactions this account was involved with.
           type: integer
@@ -2822,7 +2822,7 @@ components:
         windows:
           type: array
           items:
-            $ref: '#/components/schemas/TxVolume'
+            allOf: [$ref: '#/components/schemas/TxVolume']
           description: The list of daily transaction volumes.
       description: |
         A list of daily transaction volumes.
@@ -2852,7 +2852,7 @@ components:
         windows:
           type: array
           items:
-            $ref: '#/components/schemas/ActiveAccounts'
+            allOf: [$ref: '#/components/schemas/ActiveAccounts']
           description: The list of daily unique active account windows.
       description: |
         A list of daily unique active account windows.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -231,7 +231,7 @@ paths:
         - in: query
           name: sender
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: A filter on transaction sender.
         - in: query
           name: rel
@@ -242,13 +242,13 @@ paths:
         - in: query
           name: minFee
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on minimum transaction fee, inclusive.
           example: "1000"
         - in: query
           name: maxFee
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on maximum transaction fee, inclusive.
           example: "100000000000000000000000"
         - in: query
@@ -337,7 +337,7 @@ paths:
         - in: query
           name: rel
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: |
             A filter on related accounts. Every returned event will refer to
             this account. For example, for a `Transfer` event, this will be the
@@ -383,7 +383,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
+            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -406,7 +406,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
+            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
           description: |
             The entity ID of the controlling entity of the nodes to return.
       responses:
@@ -427,7 +427,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
+            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
           description: |
             The entity ID of the entity controlling the node to return.
           example: *entity_id_1
@@ -435,7 +435,7 @@ paths:
           name: node_id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
+            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
           description: The node ID of the node to return.
       responses:
         '200':
@@ -472,7 +472,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKeyType']
+            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -494,42 +494,42 @@ paths:
         - in: query
           name: minAvailable
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the minimum available account balance.
         - in: query
           name: maxAvailable
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the maximum available account balance.
         - in: query
           name: minEscrow
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the minimum active escrow account balance.
         - in: query
           name: maxEscrow
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the maximum active escrow account balance.
         - in: query
           name: minDebonding
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the minimum debonding account balance.
         - in: query
           name: maxDebonding
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the maximum debonding account balance.
         - in: query
           name: minTotalBalance
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the minimum total account balance.
         - in: query
           name: maxTotalBalance
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: A filter on the maximum total account balance.
       responses:
         '200':
@@ -549,7 +549,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the account to return.
       responses:
         '200':
@@ -570,7 +570,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -591,7 +591,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the account that is being delegated to.
       responses:
         '200':
@@ -612,7 +612,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -633,7 +633,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the that is being delegated to.
       responses:
         '200':
@@ -689,7 +689,7 @@ paths:
         - in: query
           name: submitter
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: Filter on the submitter of the proposal.
         - in: query
           name: state
@@ -833,7 +833,7 @@ paths:
         - in: query
           name: rel
           schema:
-            $ref: '#/components/schemas/StakingAddressType'
+            $ref: '#/components/schemas/StakingAddress'
           # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
           description: |
             A filter on related accounts. Every returned transaction will refer to
@@ -1004,7 +1004,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the token contract.
       responses:
         '200':
@@ -1028,7 +1028,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the token contract for which to return the holders.
       responses:
         '200':
@@ -1052,7 +1052,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the token contract for which to return the NFT instances.
       responses:
         '200':
@@ -1073,13 +1073,13 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the token contract of the NFT instance.
         - in: path
           name: id
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/BigIntType']
+            allOf: [$ref: '#/components/schemas/BigInt']
           description: The ID of the NFT instance.
       responses:
         '200':
@@ -1099,7 +1099,7 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the account to return.
       responses:
         '200':
@@ -1122,12 +1122,12 @@ paths:
           name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The staking address of the owner of the NFT instances.
         - in: query
           name: token_address
           schema:
-            allOf: [$ref: '#/components/schemas/StakingAddressType']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: Only return NFT instances from the token contract at the given staking address.
       responses:
         '200':
@@ -1219,27 +1219,26 @@ components:
       # https://github.com/oasisprotocol/nexus/blob/v0.0.16/api/v1/types/util.go#L49
       enum: [emerald, sapphire, cipher]
 
-    StakingAddressType:
+    StakingAddress:
       type: string
       pattern: '^oasis1[a-z0-9]{40}$'
       example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
       x-go-type: staking.Address
       x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
       description: An Oasis-style (bech32) address.
-    BigIntType:
+    BigInt:
       type: string
       pattern: '^-?[0-9]+$'
       format: bigint  # Annotation is not used by Nexus's Go codegen; might be helpful to client generators to recognize this type.
       example: "1234567890123456789012"
       x-go-type: common.BigInt
       x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
-    AddressType:
+    Address:
       type: string
       pattern: '^oasis1[a-z0-9]{40}$'
       example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
-      x-go-type: Address
       description: An Oasis-style (bech32) address.
-    Ed25519PubKeyType:
+    Ed25519PubKey:
       type: string
       format: byte  # means base64-encoded raw bytes
       example: "lbxs4hlud9XNloIOdhJPaCahd7HtiY8QATCgGnFfCM0="
@@ -1350,10 +1349,10 @@ components:
       required: [amount, shares, validator, delegator]
       properties:
         amount:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The amount of tokens delegated in base units.
         shares:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1384,10 +1383,10 @@ components:
       required: [amount, shares, validator, delegator, debond_end]
       properties:
         amount:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The amount of tokens delegated in base units.
         shares:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1486,7 +1485,7 @@ components:
           description: The nonce used with this transaction, to prevent replay.
           example: 0
         fee:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: |
             The fee that this transaction's sender committed
             to pay to execute it.
@@ -1727,7 +1726,7 @@ components:
           description: The public key identifying this Validator's node.
           example: *node_id_1
         escrow:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The amount staked.
         active:
           type: boolean
@@ -1872,7 +1871,7 @@ components:
       required: [balance, token_symbol, token_decimals]
       properties:
         balance:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: Number of tokens held, in base units.
         token_symbol:
           type: string
@@ -1889,7 +1888,7 @@ components:
       required: [balance, token_contract_addr, token_contract_addr_eth, token_decimals, token_type]
       properties:
         balance:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: Number of tokens held, in base units.
         token_contract_addr:
           type: string
@@ -1940,7 +1939,7 @@ components:
           description: The Ethereum address of the same account holder, if meaningfully defined.
           example: *eth_address_1
         balance:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: Number of tokens held, in base units.
 
 
@@ -1958,21 +1957,21 @@ components:
           description: A nonce used to prevent replay.
           example: 0
         available:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The available balance, in base units.
         escrow:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The active escrow balance, in base units.
         debonding:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The debonding escrow balance, in base units.
         delegations_balance:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: |
             The delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
         debonding_delegations_balance:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: |
             The debonding delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
@@ -1994,7 +1993,7 @@ components:
           description: The allowed account.
           example: *staking_address_2
         amount:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The amount allowed for the allowed account.
 
     EpochList:
@@ -2083,7 +2082,7 @@ components:
         state:
           $ref: '#/components/schemas/ProposalState'
         deposit:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The deposit attached to this proposal.
         handler:
           type: string
@@ -2123,7 +2122,7 @@ components:
           description: The epoch at which voting for this proposal will close.
           example: *epoch_2
         invalid_votes:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: |
             The number of invalid votes for this proposal, after tallying.
       description: |
@@ -2442,7 +2441,7 @@ components:
             Absent for non-Ethereum-format transactions.
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
         sender_0:
-          allOf: [$ref: '#/components/schemas/AddressType']
+          allOf: [$ref: '#/components/schemas/Address']
           description: |
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
@@ -2517,7 +2516,7 @@ components:
             Note: Other transactions with method "evm.Call", and possibly "evm.Create", may also be (or include) native token transfers. The heuristic will be `false` for those.
           example: true
         to:
-          allOf: [$ref: '#/components/schemas/AddressType']
+          allOf: [$ref: '#/components/schemas/Address']
           description: |
             A reasonable "to" Oasis address associated with this transaction,
             if applicable. The meaning varies based on the transaction method. Some notable examples:
@@ -2716,7 +2715,7 @@ components:
             ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
             detected or is not supported, this field will be null/absent.
         total_supply:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The total number of base units available.
         num_transfers:
           type: integer
@@ -2760,10 +2759,10 @@ components:
         token:
           $ref: '#/components/schemas/EvmToken'
         id:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The instance ID of this NFT within the collection represented by `token`.
         owner:
-          allOf: [$ref: '#/components/schemas/AddressType']
+          allOf: [$ref: '#/components/schemas/Address']
           description: The Oasis address of this NFT instance's owner.
           example: "oasis1qpclnnm0wu44pn43mt6vv3me59kl8zk9ty7qyj03"
         owner_eth:
@@ -2801,10 +2800,10 @@ components:
       required: [total_sent, total_received, num_txns]
       properties:
         total_sent:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The total number of tokens sent, in base units.
         total_received:
-          allOf: [$ref: '#/components/schemas/BigIntType']
+          allOf: [$ref: '#/components/schemas/BigInt']
           description: The total number of tokens received, in base units.
         num_txns:
           description: The total number of transactions this account was involved with.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -126,33 +126,6 @@ x-err-responses:
       $ref: '#/components/responses/HumanReadableError'
       description: A server error occurred.
 
-x-type-annotations:
-  big-int: &BigIntType
-    type: string
-    pattern: '^-?[0-9]+$'
-    format: bigint  # Annotation is not used by Nexus's Go codegen; might be helpful to client generators to recognize this type.
-    example: "1234567890123456789012"
-    x-go-type: common.BigInt
-    x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
-  address: &AddressType
-    type: string
-    pattern: '^oasis1[a-z0-9]{40}$'
-    example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
-    x-go-type: Address
-    description: An Oasis-style (bech32) address.
-  pubkey: &Ed25519PubKeyType
-    type: string
-    format: byte  # means base64-encoded raw bytes
-    example: "lbxs4hlud9XNloIOdhJPaCahd7HtiY8QATCgGnFfCM0="
-    x-go-type: signature.PublicKey
-    x-go-type-import: { name: signature, path: "github.com/oasisprotocol/oasis-core/go/common/crypto/signature" }
-    description: A base64-encoded ed25519 public key.
-  call-format: &CallFormat
-    type: string
-    example: "encrypted/x25519-deoxysii"
-    x-go-type: common.CallFormat
-    x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
-
 paths:
   /:
     get:
@@ -269,13 +242,13 @@ paths:
         - in: query
           name: minFee
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on minimum transaction fee, inclusive.
           example: "1000"
         - in: query
           name: maxFee
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on maximum transaction fee, inclusive.
           example: "100000000000000000000000"
         - in: query
@@ -410,7 +383,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            <<: *Ed25519PubKeyType
+            $ref: '#/components/schemas/Ed25519PubKeyType'
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -433,7 +406,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            <<: *Ed25519PubKeyType
+            $ref: '#/components/schemas/Ed25519PubKeyType'
           description: |
             The entity ID of the controlling entity of the nodes to return.
       responses:
@@ -454,7 +427,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            <<: *Ed25519PubKeyType
+            $ref: '#/components/schemas/Ed25519PubKeyType'
           description: |
             The entity ID of the entity controlling the node to return.
           example: *entity_id_1
@@ -462,7 +435,7 @@ paths:
           name: node_id
           required: true
           schema:
-            <<: *Ed25519PubKeyType
+            $ref: '#/components/schemas/Ed25519PubKeyType'
           description: The node ID of the node to return.
       responses:
         '200':
@@ -499,7 +472,7 @@ paths:
           name: entity_id
           required: true
           schema:
-            <<: *Ed25519PubKeyType
+            $ref: '#/components/schemas/Ed25519PubKeyType'
           description: The entity ID of the entity to return.
       responses:
         '200':
@@ -521,42 +494,42 @@ paths:
         - in: query
           name: minAvailable
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the minimum available account balance.
         - in: query
           name: maxAvailable
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the maximum available account balance.
         - in: query
           name: minEscrow
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the minimum active escrow account balance.
         - in: query
           name: maxEscrow
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the maximum active escrow account balance.
         - in: query
           name: minDebonding
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the minimum debonding account balance.
         - in: query
           name: maxDebonding
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the maximum debonding account balance.
         - in: query
           name: minTotalBalance
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the minimum total account balance.
         - in: query
           name: maxTotalBalance
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: A filter on the maximum total account balance.
       responses:
         '200':
@@ -1106,7 +1079,7 @@ paths:
           name: id
           required: true
           schema:
-            <<: *BigIntType
+            $ref: '#/components/schemas/BigIntType'
           description: The ID of the NFT instance.
       responses:
         '200':
@@ -1234,14 +1207,6 @@ paths:
 
 components:
   schemas:
-    StakingAddressType:
-      type: string
-      pattern: '^oasis1[a-z0-9]{40}$'
-      example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
-      x-go-type: staking.Address
-      x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
-      description: An Oasis-style (bech32) address.
-
     Layer:
       type: string
       # NOTE: Change IsValid() in util.go if you change this.
@@ -1253,6 +1218,39 @@ components:
       # NOTE: Change IsValid() in util.go if you change this.
       # https://github.com/oasisprotocol/nexus/blob/v0.0.16/api/v1/types/util.go#L49
       enum: [emerald, sapphire, cipher]
+
+    StakingAddressType:
+      type: string
+      pattern: '^oasis1[a-z0-9]{40}$'
+      example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
+      x-go-type: staking.Address
+      x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
+      description: An Oasis-style (bech32) address.
+    BigIntType:
+      type: string
+      pattern: '^-?[0-9]+$'
+      format: bigint  # Annotation is not used by Nexus's Go codegen; might be helpful to client generators to recognize this type.
+      example: "1234567890123456789012"
+      x-go-type: common.BigInt
+      x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
+    AddressType:
+      type: string
+      pattern: '^oasis1[a-z0-9]{40}$'
+      example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
+      x-go-type: Address
+      description: An Oasis-style (bech32) address.
+    Ed25519PubKeyType:
+      type: string
+      format: byte  # means base64-encoded raw bytes
+      example: "lbxs4hlud9XNloIOdhJPaCahd7HtiY8QATCgGnFfCM0="
+      x-go-type: signature.PublicKey
+      x-go-type-import: { name: signature, path: "github.com/oasisprotocol/oasis-core/go/common/crypto/signature" }
+      description: A base64-encoded ed25519 public key.
+    CallFormat:
+      type: string
+      example: "encrypted/x25519-deoxysii"
+      x-go-type: common.CallFormat
+      x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
 
     List:
       type: object
@@ -1352,10 +1350,10 @@ components:
       required: [amount, shares, validator, delegator]
       properties:
         amount:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The amount of tokens delegated in base units.
         shares:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1386,10 +1384,10 @@ components:
       required: [amount, shares, validator, delegator, debond_end]
       properties:
         amount:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The amount of tokens delegated in base units.
         shares:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The shares of tokens delegated.
         validator:
           type: string
@@ -1488,7 +1486,7 @@ components:
           description: The nonce used with this transaction, to prevent replay.
           example: 0
         fee:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: |
             The fee that this transaction's sender committed
             to pay to execute it.
@@ -1729,7 +1727,7 @@ components:
           description: The public key identifying this Validator's node.
           example: *node_id_1
         escrow:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The amount staked.
         active:
           type: boolean
@@ -1874,7 +1872,7 @@ components:
       required: [balance, token_symbol, token_decimals]
       properties:
         balance:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: Number of tokens held, in base units.
         token_symbol:
           type: string
@@ -1891,7 +1889,7 @@ components:
       required: [balance, token_contract_addr, token_contract_addr_eth, token_decimals, token_type]
       properties:
         balance:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: Number of tokens held, in base units.
         token_contract_addr:
           type: string
@@ -1942,7 +1940,7 @@ components:
           description: The Ethereum address of the same account holder, if meaningfully defined.
           example: *eth_address_1
         balance:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: Number of tokens held, in base units.
 
 
@@ -1960,21 +1958,21 @@ components:
           description: A nonce used to prevent replay.
           example: 0
         available:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The available balance, in base units.
         escrow:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The active escrow balance, in base units.
         debonding:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The debonding escrow balance, in base units.
         delegations_balance:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: |
             The delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
         debonding_delegations_balance:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: |
             The debonding delegations balance, in base units.
             For efficiency, this field is omitted when listing multiple-accounts.
@@ -1996,7 +1994,7 @@ components:
           description: The allowed account.
           example: *staking_address_2
         amount:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The amount allowed for the allowed account.
 
     EpochList:
@@ -2085,7 +2083,7 @@ components:
         state:
           $ref: '#/components/schemas/ProposalState'
         deposit:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The deposit attached to this proposal.
         handler:
           type: string
@@ -2125,7 +2123,7 @@ components:
           description: The epoch at which voting for this proposal will close.
           example: *epoch_2
         invalid_votes:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: |
             The number of invalid votes for this proposal, after tallying.
       description: |
@@ -2444,7 +2442,7 @@ components:
             Absent for non-Ethereum-format transactions.
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
         sender_0:
-          <<: *AddressType
+          $ref: '#/components/schemas/AddressType'
           description: |
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
@@ -2519,7 +2517,7 @@ components:
             Note: Other transactions with method "evm.Call", and possibly "evm.Create", may also be (or include) native token transfers. The heuristic will be `false` for those.
           example: true
         to:
-          <<: *AddressType
+          $ref: '#/components/schemas/AddressType'
           description: |
             A reasonable "to" Oasis address associated with this transaction,
             if applicable. The meaning varies based on the transaction method. Some notable examples:
@@ -2579,7 +2577,7 @@ components:
       required: [format]
       properties:
         format:
-          <<: *CallFormat
+          $ref: '#/components/schemas/CallFormat'
           description: The format of the encrypted evm transaction envelope.
         public_key:
           type: string
@@ -2718,7 +2716,7 @@ components:
             ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
             detected or is not supported, this field will be null/absent.
         total_supply:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The total number of base units available.
         num_transfers:
           type: integer
@@ -2762,10 +2760,10 @@ components:
         token:
           $ref: '#/components/schemas/EvmToken'
         id:
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
           description: The instance ID of this NFT within the collection represented by `token`.
         owner:
-          <<: *AddressType
+          $ref: '#/components/schemas/AddressType'
           description: The Oasis address of this NFT instance's owner.
           example: "oasis1qpclnnm0wu44pn43mt6vv3me59kl8zk9ty7qyj03"
         owner_eth:
@@ -2804,10 +2802,10 @@ components:
       properties:
         total_sent:
           description: The total number of tokens sent, in base units.
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
         total_received:
           description: The total number of tokens received, in base units.
-          <<: *BigIntType
+          $ref: '#/components/schemas/BigIntType'
         num_txns:
           description: The total number of transactions this account was involved with.
           type: integer

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -134,13 +134,6 @@ x-type-annotations:
     example: "1234567890123456789012"
     x-go-type: common.BigInt
     x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
-  staking-address: &StakingAddressType
-    type: string
-    pattern: '^oasis1[a-z0-9]{40}$'
-    example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
-    x-go-type: staking.Address
-    x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
-    description: An Oasis-style (bech32) address.
   address: &AddressType
     type: string
     pattern: '^oasis1[a-z0-9]{40}$'
@@ -265,7 +258,7 @@ paths:
         - in: query
           name: sender
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: A filter on transaction sender.
         - in: query
           name: rel
@@ -371,7 +364,7 @@ paths:
         - in: query
           name: rel
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: |
             A filter on related accounts. Every returned event will refer to
             this account. For example, for a `Transfer` event, this will be the
@@ -583,7 +576,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the account to return.
       responses:
         '200':
@@ -604,7 +597,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -625,7 +618,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the account that is being delegated to.
       responses:
         '200':
@@ -646,7 +639,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the account that delegated.
       responses:
         '200':
@@ -667,7 +660,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the that is being delegated to.
       responses:
         '200':
@@ -723,7 +716,7 @@ paths:
         - in: query
           name: submitter
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: Filter on the submitter of the proposal.
         - in: query
           name: state
@@ -867,7 +860,7 @@ paths:
         - in: query
           name: rel
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
           description: |
             A filter on related accounts. Every returned transaction will refer to
@@ -1038,7 +1031,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the token contract.
       responses:
         '200':
@@ -1062,7 +1055,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the token contract for which to return the holders.
       responses:
         '200':
@@ -1086,7 +1079,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the token contract for which to return the NFT instances.
       responses:
         '200':
@@ -1107,7 +1100,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the token contract of the NFT instance.
         - in: path
           name: id
@@ -1133,7 +1126,7 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the account to return.
       responses:
         '200':
@@ -1156,12 +1149,12 @@ paths:
           name: address
           required: true
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: The staking address of the owner of the NFT instances.
         - in: query
           name: token_address
           schema:
-            <<: *StakingAddressType
+            $ref: '#/components/schemas/StakingAddressType'
           description: Only return NFT instances from the token contract at the given staking address.
       responses:
         '200':
@@ -1241,6 +1234,14 @@ paths:
 
 components:
   schemas:
+    StakingAddressType:
+      type: string
+      pattern: '^oasis1[a-z0-9]{40}$'
+      example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
+      x-go-type: staking.Address
+      x-go-type-import: { name: staking, path: "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api" }
+      description: An Oasis-style (bech32) address.
+
     Layer:
       type: string
       # NOTE: Change IsValid() in util.go if you change this.

--- a/api/v1/types/util.go
+++ b/api/v1/types/util.go
@@ -9,8 +9,6 @@ const (
 	Erc20Approval = "Approval"
 )
 
-type Address string
-
 func (c ConsensusEventType) IsValid() bool {
 	switch c {
 	case ConsensusEventTypeStakingTransfer,


### PR DESCRIPTION
This PR removes YAML references in favor of openapi types and `$ref`-style references for all reusable types, notably `Address` and `BigInt`. It was prompted by https://github.com/oasisprotocol/explorer/issues/711

It also wraps all `$ref` references into `allOf`; this is a [workaround](https://github.com/OAI/OpenAPI-Specification/issues/1514#issuecomment-1386613645) (thank you @lukaw3d) for the fact `$ref` on its own [does not allow sibling attributes](https://swagger.io/docs/specification/using-ref/) like a custom description.

---

**OUTDATED** description follows, from before the workaround was known.

I'm on the fence whether to actually merge this PR:
- GOOD: Nexus still compiles with the new openapi, requiring no changes.
- BAD: When I compared the autogenerated Go code, I noticed all code comments for variables of type `Address` and `BigInt` were gone.
    - This is because `$ref` does not allow a custom description. That's part of the spec: https://swagger.io/docs/specification/using-ref/
    - GOOD: On the other hand, our HTML documentation generator ignores that part of openapi spec and helpfully still includes the docstrings in `v1.html`.

In my mind, losing per-field descriptions is a deal breaker. But since we're not losing them in the human-oriented HTML, maybe that's enough.

@lukaw3d please evaluate the pros and cons on the frontend side.