### PR TITLE
[api] remove nullable tags

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1594,14 +1594,12 @@ components:
         tx_index:
           type: integer
           format: int32
-          nullable: true
           description: |
             0-based index of this event's originating transaction within its block.
             Absent if the event did not originate from a transaction.
           example: 5
         tx_hash:
           type: string
-          nullable: true
           description: |
             Hash of this event's originating transaction.
             Absent if the event did not originate from a transaction.
@@ -1853,7 +1851,6 @@ components:
           example: "oasis-runtime-sdk/address: secp256k1eth"
         context_version:
           type: integer
-          nullable: true
           default: 0
           description: Version of the `context`.
         address_data:
@@ -2239,7 +2236,6 @@ components:
             Absent if the event did not originate from a transaction.
         tx_hash:
           type: string
-          nullable: true
           description: |
             Hash of this event's originating transaction.
             Absent if the event did not originate from a transaction.
@@ -2268,7 +2264,6 @@ components:
             OR `evm > Event`.
         evm_log_name:
           type: string
-          nullable: true
           description: |
             If the event type is `evm.log`, this field describes the human-readable type of 
             evm event, e.g. `Transfer`. 

--- a/tests/e2e_regression/expected/emerald_events.body
+++ b/tests/e2e_regression/expected/emerald_events.body
@@ -9,10 +9,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -24,10 +22,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -39,10 +35,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -54,10 +48,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -69,10 +61,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -84,10 +74,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -99,10 +87,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -114,10 +100,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -129,10 +113,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -144,10 +126,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -159,10 +139,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060339,
       "timestamp": "2023-12-12T10:06:44Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -175,7 +153,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "8a5b6cd62141f380e4b481a48814fea9c40f7f382cd819d9d49e021af76ca6d8",
-      "evm_log_name": null,
       "round": 8060338,
       "timestamp": "2023-12-12T10:06:38Z",
       "tx_hash": "ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d",
@@ -187,7 +164,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "8a5b6cd62141f380e4b481a48814fea9c40f7f382cd819d9d49e021af76ca6d8",
-      "evm_log_name": null,
       "round": 8060338,
       "timestamp": "2023-12-12T10:06:38Z",
       "tx_hash": "ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d",
@@ -203,10 +179,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060338,
       "timestamp": "2023-12-12T10:06:38Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -218,10 +192,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -233,10 +205,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -248,10 +218,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -263,10 +231,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -278,10 +244,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -293,10 +257,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -308,10 +270,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -323,10 +283,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -338,10 +296,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -353,10 +309,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -368,10 +322,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060337,
       "timestamp": "2023-12-12T10:06:32Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -384,7 +336,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "547aa2944a8be90f55f37c34afab8b9b8e08be5ff998f8a401efedaa2f77793e",
-      "evm_log_name": null,
       "round": 8060336,
       "timestamp": "2023-12-12T10:06:26Z",
       "tx_hash": "a0c8251ab648e04b9aade29d96d94f8abd5d6f71456da12bbbfb34844cf028e7",
@@ -396,7 +347,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "547aa2944a8be90f55f37c34afab8b9b8e08be5ff998f8a401efedaa2f77793e",
-      "evm_log_name": null,
       "round": 8060336,
       "timestamp": "2023-12-12T10:06:26Z",
       "tx_hash": "a0c8251ab648e04b9aade29d96d94f8abd5d6f71456da12bbbfb34844cf028e7",
@@ -412,10 +362,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060336,
       "timestamp": "2023-12-12T10:06:26Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -427,10 +375,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -442,10 +388,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -457,10 +401,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -472,10 +414,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -487,10 +427,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -502,10 +440,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -517,10 +453,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -532,10 +466,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -547,10 +479,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -562,10 +492,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -577,10 +505,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060335,
       "timestamp": "2023-12-12T10:06:21Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -593,7 +519,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "f3f39a596bc8d93e220d51f5304bf0265e7ce94e9968960be43030642cf31d7d",
-      "evm_log_name": null,
       "round": 8060334,
       "timestamp": "2023-12-12T10:06:15Z",
       "tx_hash": "165ad5f1bda6ff87876e3a0dbb9f8578da6cb2472120a359e5fbd6d9af6c51bb",
@@ -605,7 +530,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "f3f39a596bc8d93e220d51f5304bf0265e7ce94e9968960be43030642cf31d7d",
-      "evm_log_name": null,
       "round": 8060334,
       "timestamp": "2023-12-12T10:06:15Z",
       "tx_hash": "165ad5f1bda6ff87876e3a0dbb9f8578da6cb2472120a359e5fbd6d9af6c51bb",
@@ -621,10 +545,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060334,
       "timestamp": "2023-12-12T10:06:15Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -635,10 +557,8 @@
         },
         "owner": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.mint"
     },
     {
@@ -650,10 +570,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -665,10 +583,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -680,10 +596,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -695,10 +609,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -710,10 +622,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -725,10 +635,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -740,10 +648,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -755,10 +661,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -770,10 +674,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -785,10 +687,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -800,10 +700,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -816,10 +714,8 @@
         "nonce": 201377,
         "to": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd"
       },
-      "evm_log_name": null,
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
-      "tx_hash": null,
       "type": "consensus_accounts.deposit"
     },
     {
@@ -832,7 +728,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "aca7d562c32924a98d3d3a5c3a33d4b34f7471ee8e4604ade5cf54f64ff32817",
-      "evm_log_name": null,
       "round": 8060332,
       "timestamp": "2023-12-12T10:06:03Z",
       "tx_hash": "78709473a80f616194adcbea98823894628a916b2502ba9b9c8b8128c73fff7d",
@@ -844,7 +739,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "aca7d562c32924a98d3d3a5c3a33d4b34f7471ee8e4604ade5cf54f64ff32817",
-      "evm_log_name": null,
       "round": 8060332,
       "timestamp": "2023-12-12T10:06:03Z",
       "tx_hash": "78709473a80f616194adcbea98823894628a916b2502ba9b9c8b8128c73fff7d",
@@ -855,7 +749,6 @@
       "body": {
         "amount": 61294
       },
-      "evm_log_name": null,
       "round": 8060332,
       "timestamp": "2023-12-12T10:06:03Z",
       "tx_hash": "73cba102c282b9a64b03828a2eb2ef85af5006a9d3c3d8bed55d00fd2576da78",
@@ -871,10 +764,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060332,
       "timestamp": "2023-12-12T10:06:03Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -886,10 +777,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -901,10 +790,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -916,10 +803,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -931,10 +816,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -946,10 +829,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -961,10 +842,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -976,10 +855,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -991,10 +868,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1006,10 +881,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1021,10 +894,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1036,10 +907,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060331,
       "timestamp": "2023-12-12T10:05:57Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1052,7 +921,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "759dca8bbf142aef388bde551a9425fb655e2d0d4dc0f8f718ffec1489a9c3cd",
-      "evm_log_name": null,
       "round": 8060330,
       "timestamp": "2023-12-12T10:05:51Z",
       "tx_hash": "e0dbb7feb3a08b43a0e3c1561d229344edeeb750774f54f2b3974c4cedb49fd9",
@@ -1064,7 +932,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "759dca8bbf142aef388bde551a9425fb655e2d0d4dc0f8f718ffec1489a9c3cd",
-      "evm_log_name": null,
       "round": 8060330,
       "timestamp": "2023-12-12T10:05:51Z",
       "tx_hash": "e0dbb7feb3a08b43a0e3c1561d229344edeeb750774f54f2b3974c4cedb49fd9",
@@ -1081,7 +948,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "8c24652f1b27f107c64aa4abfa9d794a6a2c0b9e5236caa99ea2f53b2e5dbc83",
-      "evm_log_name": null,
       "round": 8060330,
       "timestamp": "2023-12-12T10:05:51Z",
       "tx_hash": "a2ca8bc1aa18335747b8d194764c779c4f432ef31d154c8e9cc00e8bbd6fc48d",
@@ -1093,7 +959,6 @@
         "amount": 22144
       },
       "eth_tx_hash": "8c24652f1b27f107c64aa4abfa9d794a6a2c0b9e5236caa99ea2f53b2e5dbc83",
-      "evm_log_name": null,
       "round": 8060330,
       "timestamp": "2023-12-12T10:05:51Z",
       "tx_hash": "a2ca8bc1aa18335747b8d194764c779c4f432ef31d154c8e9cc00e8bbd6fc48d",
@@ -1109,10 +974,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060330,
       "timestamp": "2023-12-12T10:05:51Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1124,10 +987,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1139,10 +1000,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1154,10 +1013,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1169,10 +1026,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1184,10 +1039,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1199,10 +1052,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1214,10 +1065,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1229,10 +1078,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1244,10 +1091,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1259,10 +1104,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1274,10 +1117,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060329,
       "timestamp": "2023-12-12T10:05:46Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1290,7 +1131,6 @@
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "c5f0d68d7ed2280fccb2c3181a598e954fa4d003caea6b1d54b86c11540afe15",
-      "evm_log_name": null,
       "round": 8060328,
       "timestamp": "2023-12-12T10:05:40Z",
       "tx_hash": "9ee113d29da2cafb8bb08fa1307f83db880c4f4e42993750466966decd229ffe",
@@ -1302,7 +1142,6 @@
         "amount": 22136
       },
       "eth_tx_hash": "c5f0d68d7ed2280fccb2c3181a598e954fa4d003caea6b1d54b86c11540afe15",
-      "evm_log_name": null,
       "round": 8060328,
       "timestamp": "2023-12-12T10:05:40Z",
       "tx_hash": "9ee113d29da2cafb8bb08fa1307f83db880c4f4e42993750466966decd229ffe",
@@ -1318,10 +1157,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060328,
       "timestamp": "2023-12-12T10:05:40Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1333,10 +1170,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1348,10 +1183,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1363,10 +1196,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1378,10 +1209,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1393,10 +1222,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1408,10 +1235,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1423,10 +1248,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1438,10 +1261,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz22xm9vyg0uqxncc667m4j4p5mrsj455c743lfn"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1453,10 +1274,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1468,10 +1287,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     },
     {
@@ -1483,10 +1300,8 @@
         "from": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
         "to": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6"
       },
-      "evm_log_name": null,
       "round": 8060327,
       "timestamp": "2023-12-12T10:05:34Z",
-      "tx_hash": null,
       "type": "accounts.transfer"
     }
   ],


### PR DESCRIPTION
From https://github.com/oasisprotocol/nexus/pull/640#discussion_r1488734482

per @mitjat 's comment:
> I was surprised by all these explicit nulls, so I did some digging. These fields would be simply missing if they were tagged as json:"...,omitempty". The JSON tags are generated by oapi-codegen. And the reason that the tag does not get generated (it [normally does](https://github.com/deepmap/oapi-codegen/blob/v1.16.2/pkg/codegen/codegen_test.go#L126-L128)) is that the evm_log_name field is marked nullable in our openapi spec. Which, [per openapi](https://swagger.io/docs/specification/data-models/data-types/#null), means "this variable can contain an explicit null value".

> Looking at our openapi spec, we have 5 instances of nullable: true, and I don't think any of them are justified. What we want as the behavior is to simply omit those fields when they are null.

This PR removes the `nullable` tags in our openapi spec. The only ones that might require further confirmation are the `event.{tx_index/tx_hash}`. For non-tx events, these fields will no longer exist and we should double check that the Explorer doesn't make assumptions otherwise.