### PR TITLE
openapi: new linting tool, fix lint errors

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -65,17 +65,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          VERSION=v4.30.5
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_amd64 -q -O ./yq
+          chmod +x ./yq
+
+          VERSION=0.9.9
+          wget https://github.com/daveshanley/vacuum/releases/download/v${VERSION}/vacuum_${VERSION}_linux_x86_64.tar.gz -q -O- | tar -xzv
       - name: Normalize YAML
         run: |
-          VERSION=v4.30.5 BINARY=yq_linux_amd64
-          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O ./yq
-          chmod +x ./yq
           # OpenAPI parser fails to parse YAML templates (*, <<:). Expand them out here.
           <api/spec/v1.yaml ./yq --output-format json | ./yq --output-format yaml --input-format json >api/spec/v1-normalized.yaml
       - name: Validate OpenAPI definition
-        uses: char0n/swagger-editor-validate@v1
-        with:
-          definition-file: api/spec/v1-normalized.yaml
+        run: |
+          ./vacuum lint --ruleset .vacuum.yaml --errors api/spec/v1-normalized.yaml
 
   validate-migrations:
     runs-on: ubuntu-20.04

--- a/.vacuum.yaml
+++ b/.vacuum.yaml
@@ -1,0 +1,7 @@
+# Config for vacuum, the openapi spec linter.
+
+extends: [[spectral:oas, recommended]]
+rules:
+  # This rule requires an operationId attribute for every endpoint.
+  # However, openapi spec says it's an optional attribute.
+  operation-operationId: false

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -118,13 +118,10 @@ x-err-responses:
   common-errors: &common_error_responses
     '400':
       $ref: '#/components/responses/HumanReadableError'
-      description: Invalid request.
     '404':
       $ref: '#/components/responses/NotFoundError'
-      description: The requested resource was not found.
     '500':
       $ref: '#/components/responses/HumanReadableError'
-      description: A server error occurred.
 
 paths:
   /:
@@ -1707,7 +1704,7 @@ components:
 
     Validator:
       type: object
-      required: [entity_address, entity_id, name, node_id, escrow, active, status, current_rate, current_commission_bound]
+      required: [entity_address, entity_id, node_id, escrow, active, status, current_rate, current_commission_bound]
       properties:
         entity_address:
             type: string
@@ -1845,7 +1842,7 @@ components:
       required: [context, address_data]
       properties:
         context:
-          $ref: "#/components/schemas/AddressDerivationContext"
+          allOf: [$ref: "#/components/schemas/AddressDerivationContext"]
           description: |
             The method by which the Oasis address was derived from `address_data`.
           example: "oasis-runtime-sdk/address: secp256k1eth"
@@ -2596,7 +2593,7 @@ components:
 
     RuntimeAccount:
       type: object
-      required: [address, runtime, balances, evm_balances, stats]
+      required: [address, balances, evm_balances, stats]
       properties:
         address:
           type: string
@@ -2748,7 +2745,6 @@ components:
       type: object
       required:
         - token
-        - contract_addr
         - id
       properties:
         token:


### PR DESCRIPTION
Our existing OpenAPI validation CI action is [failing with HTTP 500](https://github.com/oasisprotocol/nexus/actions/runs/8009264534/job/21877527647?pr=633) when trying to download Chrome for Puppeteer.

It's a ridiculous enough dependency that it spurred this PR, which brings a substitute openapi validation tool, `vacuum`.
Unlike the old tool, the new one supports linting, and the PR fixes the few linting errors we had.

