### PR TITLE
[analyzer] return default message if no revert reason specified

### DIFF
--- a/analyzer/evmabibackfill/evm_abi_backfill_test.go
+++ b/analyzer/evmabibackfill/evm_abi_backfill_test.go
@@ -1,0 +1,221 @@
+package evmabibackfill
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/nexus/analyzer/evmabi"
+	"github.com/oasisprotocol/nexus/common"
+	"github.com/oasisprotocol/nexus/log"
+)
+
+// TODO: Update WROSE source and add tests for more txs, mismatched txs, and custom errors
+
+type mockParsedEvent struct {
+	Name *string
+	Args []*abiEncodedArg
+	Sig  *ethCommon.Hash
+}
+
+type mockParsedTxCall struct {
+	Name *string
+	Args []*abiEncodedArg
+}
+
+func unmarshalEvmEvent(t *testing.T, body []byte) *abiEncodedEvent {
+	var ev evm.Event
+	err := json.Unmarshal(body, &ev)
+	require.Nil(t, err)
+	return &abiEncodedEvent{
+		Round:     0,
+		TxIndex:   nil,
+		EventBody: ev,
+	}
+}
+
+func unmarshalEvmTx(t *testing.T, body string, error_message *string) *abiEncodedTx {
+	txData, err := base64.StdEncoding.DecodeString(body)
+	require.Nil(t, err)
+	return &abiEncodedTx{
+		TxHash:         "", // not relevant for current unit tests
+		TxData:         txData,
+		TxRevertReason: error_message,
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	abi := evmabi.WROSE
+	p := &processor{
+		runtime: common.RuntimeSapphire,
+		target:  nil,
+		logger:  log.NewDefaultLogger("testing"),
+	}
+	ev := unmarshalEvmEvent(t, []byte(`{"data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADCopscuTr4A=", "topics": ["3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=", "AAAAAAAAAAAAAAAAw3+DQaxuSpRTgwK81NSc8IUtMMA=", "AAAAAAAAAAAAAAAAWZiaj7/4vj0d6v/ytGtmtjrLeX4="], "address": "i8KwMLKZlk7vteHgs2mRNS5W0tM="}`))
+	expected := mockParsedEvent{
+		Name: common.Ptr("Transfer"),
+		Sig:  common.Ptr(ethCommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")),
+		Args: []*abiEncodedArg{
+			{
+				Name:    "src",
+				EvmType: "address",
+				Value:   ethCommon.HexToAddress("0xc37F8341Ac6e4a94538302bCd4d49Cf0852D30C0"),
+			},
+			{
+				Name:    "dst",
+				EvmType: "address",
+				Value:   ethCommon.HexToAddress("0x59989A8fBff8be3d1deAFFF2b46B66B63ACB797e"),
+			},
+			{
+				Name:    "wad",
+				EvmType: "uint256",
+				Value:   "876558921078386560",
+			},
+		},
+	}
+	name, args, sig, err := p.parseEvent(ev, *abi)
+	require.Nil(t, err)
+	verifyEvent(t, &expected, name, args, sig)
+}
+
+func TestParseUnknownEvent(t *testing.T) {
+	abi := evmabi.WROSE
+	p := &processor{
+		runtime: common.RuntimeSapphire,
+		target:  nil,
+		logger:  log.NewDefaultLogger("testing"),
+	}
+	// Non-WROSE event; it doesn't fit the `abi` and should fail to parse.
+	rawEv := []byte(`{"data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "topics": ["8nnmofXjIMypETVnbZy25EyooIwLiDQrzbEUT2URtWg=", "AAAAAAAAAAAAAAAArk2RKpUohmFUB3UShFG6FIKuqKc=", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI="], "address": "jZzJ7hGq+GWRPe7JOe6y3Hg4q3s="}`)
+	ev := unmarshalEvmEvent(t, rawEv)
+
+	name, args, sig, err := p.parseEvent(ev, *abi)
+	require.NotNil(t, err)
+	require.Nil(t, name)
+	require.Nil(t, args)
+	require.Nil(t, sig)
+}
+
+func TestParseTransactionCall(t *testing.T) {
+	abi := evmabi.WROSE
+	p := &processor{
+		runtime: common.RuntimeSapphire,
+		target:  nil,
+		logger:  log.NewDefaultLogger("testing"),
+	}
+	txs := []*abiEncodedTx{
+		unmarshalEvmTx(t, "Lhp9TQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKcV46p6RigAA", nil),
+		unmarshalEvmTx(t, "qQWcuwAAAAAAAAAAAAAAAOY8J3oxo9tm0HXYxapOlEKOuxjxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", nil),
+		unmarshalEvmTx(t, "0OMNsA==", nil),
+	}
+
+	expected := []mockParsedTxCall{
+		{
+			Name: common.Ptr("withdraw"),
+			Args: []*abiEncodedArg{
+				{
+					Name:    "wad",
+					EvmType: "uint256",
+					Value:   "770545888011536171008",
+				},
+			},
+		},
+		{
+			Name: common.Ptr("transfer"),
+			Args: []*abiEncodedArg{
+				{
+					Name:    "dst",
+					EvmType: "address",
+					Value:   ethCommon.HexToAddress("0xE63c277a31A3dB66D075D8C5aA4E94428Ebb18F1"),
+				},
+				{
+					Name:    "wad",
+					EvmType: "uint256",
+					Value:   "0",
+				},
+			},
+		},
+		{
+			Name: common.Ptr("deposit"),
+			Args: []*abiEncodedArg{},
+		},
+	}
+	for i, tx := range txs {
+		name, args, err := p.parseTxCall(tx, *abi)
+		require.Nil(t, err)
+		verifyTxCall(t, &expected[i], name, args)
+	}
+}
+
+func TestParseTxErrorPlaintext(t *testing.T) {
+	abi := evmabi.WROSE
+	p := &processor{
+		runtime: common.RuntimeSapphire,
+		target:  nil,
+		logger:  log.NewDefaultLogger("testing"),
+	}
+	errMsg := "reverted: plaintext error message"
+	emptyErrMsg := "reverted: "
+	txs := []*abiEncodedTx{
+		unmarshalEvmTx(t, "", &errMsg),
+		unmarshalEvmTx(t, "", &emptyErrMsg),
+	}
+
+	for _, tx := range txs {
+		parsedMsg, args, err := p.parseTxErr(tx, *abi)
+		require.Nil(t, err)
+		require.Nil(t, parsedMsg)
+		require.Nil(t, args)
+	}
+}
+
+func verifyEvent(t *testing.T, expected *mockParsedEvent, name *string, args []*abiEncodedArg, sig *ethCommon.Hash) {
+	if expected.Name != nil {
+		require.NotNil(t, name)
+		require.Equal(t, *expected.Name, *name)
+	} else {
+		require.Nil(t, name)
+	}
+	if expected.Args != nil {
+		require.NotNil(t, args)
+		require.Equal(t, len(expected.Args), len(args))
+		for i, ea := range expected.Args {
+			require.Equal(t, ea.Name, args[i].Name)
+			require.Equal(t, ea.EvmType, args[i].EvmType)
+			require.Equal(t, ea.Value, args[i].Value)
+		}
+	} else {
+		require.Nil(t, args)
+	}
+	if expected.Sig != nil {
+		require.NotNil(t, sig)
+		require.Equal(t, *expected.Sig, *sig)
+	} else {
+		require.Nil(t, sig)
+	}
+}
+
+func verifyTxCall(t *testing.T, expected *mockParsedTxCall, name *string, args []*abiEncodedArg) {
+	if expected.Name != nil {
+		require.NotNil(t, name)
+		require.Equal(t, *expected.Name, *name)
+	} else {
+		require.Nil(t, name)
+	}
+	if expected.Args != nil {
+		require.NotNil(t, args)
+		require.Equal(t, len(expected.Args), len(args))
+		for i, ea := range expected.Args {
+			require.Equal(t, ea.Name, args[i].Name)
+			require.Equal(t, ea.EvmType, args[i].EvmType)
+			require.Equal(t, ea.Value, args[i].Value)
+		}
+	} else {
+		require.Nil(t, args)
+	}
+}

--- a/analyzer/runtime/abiparse/abiparse.go
+++ b/analyzer/runtime/abiparse/abiparse.go
@@ -107,6 +107,9 @@ func ParseEvent(topics [][]byte, data []byte, contractABI *abi.ABI) (*abi.Event,
 
 	for i, in := range event.Inputs {
 		if in.Indexed {
+			if nextTopicIndex == len(topicsEC) {
+				return nil, nil, fmt.Errorf("number of indexed inputs exceeds number of event topics")
+			}
 			switch in.Type.T {
 			case abi.StringTy, abi.SliceTy, abi.ArrayTy, abi.TupleTy, abi.BytesTy:
 				// https://docs.soliditylang.org/en/latest/abi-spec.html

--- a/analyzer/runtime/extract_test.go
+++ b/analyzer/runtime/extract_test.go
@@ -76,9 +76,10 @@ func TestUnknownError(t *testing.T) {
 }
 
 func TestEmptyError(t *testing.T) {
-	input := &mockError{module: "evm", code: 8, message: "reverted: "}
-	msg := tryParseErrorMessage(input.module, input.code, input.message)
-	require.Nil(t, msg, "tryParseErrorMessage extracted a message when it should not have")
+	emptyErr := mockError{module: "evm", code: 8, message: "reverted: "}
+	msg := tryParseErrorMessage(emptyErr.module, emptyErr.code, emptyErr.message)
+	require.NotNil(t, msg, "failed to extract default error message")
+	require.Equal(t, DefaultTxRevertErrMsg, *msg, "tryParseErrorMessage extracted a message that differed from the expected default error message")
 }
 
 func TestExtractSuccessfulEncryptedTx(t *testing.T) {


### PR DESCRIPTION
Per discussion on slack, we want to return a more human-friendly default error message if no transaction revert reason is provided. 

Note:
* This PR only handles the case where the error message is `reverted: `. It does not handle the case where the error message is entirely empty, since this should never occur (staging mainnet has no instances of a failed tx with a rawErrMessage of `""`)

Testing:
* Unfortunately our e2e_regression test ranges don't include a suitable failed tx with an empty revert message. Tested manually on the [originally reported transaction](https://explorer.oasis.io/testnet/sapphire/tx/0x872d95e14bd497f35209539341958346a4e20ddf66d1ef2f282251294aa5d3d0):

```
~/oasis/oasis-block-indexer(andrew7234/default-runtime-tx-err*) » curl "http://localhost:8008/v1/sapphire/transactions/872d95e14bd497f35209539341958346a4e20ddf66d1ef2f282251294aa5d3d0" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2249    0  2249    0     0   107k      0 --:--:-- --:--:-- --:--:--  244k
{
  "is_total_count_clipped": false,
  "total_count": 1,
  "transactions": [
    {
      "amount": "0",
      "body": {
        "address": "llRjnKXeSEg9muiB+exn7IR/G3o=",
        "data": "OALN1QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAAAAAAAAAAAAAAAACx/yhbXkLNKgq/Z+RVLPWmmG7bpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY2DMN3FAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAElByb29mLW9mLUF1dGhvcml0eQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC5RbWNvMUI4QWFHVEttSnJrVjNYdEp6c3FWRmFKR3B6UjhhU056RnJ4TTNjZDhzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAALH/KFteQs0qCr9n5FUs9aaYbtukAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAnt9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdkYW9zaWduAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACe30AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQWwftSr0/smPCfeMrrBKn85WcjfkOPC3e+9HVm6wUnY6SgZ0fyq9gfBtfb5qL61LIeq7lH3lqj6k5Tu24NFaPzQcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuUW1aNm41Nkg5THhQcnVDUWRlRVJVazFpdVZvNzRrRWFuZFpxdnk2dGp1cFNQMwAAAAAAAAAAAAAAAAAAAAAAAA==",
        "value": ""
      },
      "charged_fee": "30870585000000000",
      "error": {
        "code": 8,
        "message": "reverted without a message",
        "module": "evm"
      },
      "eth_hash": "872d95e14bd497f35209539341958346a4e20ddf66d1ef2f282251294aa5d3d0",
      "fee": "10100250000000000000",
      "gas_limit": 10050000,
      "gas_used": 30717,
      "hash": "7b8f21f8f233412855758ae5a8a5f5032649b0dffa578a69b4516bc762e82ccb",
      "index": 0,
      "method": "evm.Call",
      "nonce_0": 10,
      "round": 5029734,
      "sender_0": "oasis1qqmkkw69a56lqsrqqhvetknlup3gcl6885g8lqjm",
      "sender_0_eth": "0x1e59ce931B4CFea3fe4B875411e280e173cB7A9C",
      "size": 1197,
      "success": false,
      "timestamp": "2024-02-23T05:46:50-05:00",
      "to": "oasis1qqd94y2hqwl48t4sh7ck2f72y8g06f42fvz82lmp",
      "to_eth": "0x9654639cA5De48483D9Ae881f9ec67eC847f1b7A"
    }
  ]
}
```