### PR TITLE
statecheck: Use BigInt, not uint64, for balances

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -34,6 +34,10 @@ func (b BigInt) Times(other BigInt) BigInt {
 	return BigInt{result}
 }
 
+func (b BigInt) IsZero() bool {
+	return b.Sign() == 0
+}
+
 func (b BigInt) MarshalText() ([]byte, error) {
 	return b.Int.MarshalText()
 }

--- a/tests/statecheck/consensus_test.go
+++ b/tests/statecheck/consensus_test.go
@@ -560,7 +560,7 @@ func validateAccounts(t *testing.T, genesis *stakingAPI.Genesis, target *postgre
 		hasBalance := !acct.General.Balance.IsZero() ||
 			!acct.Escrow.Active.Balance.IsZero() ||
 			!acct.Escrow.Debonding.Balance.IsZero()
-		if !hasBalance { // nexus doesn't have to know about this acct
+		if !hasBalance && acct.General.Nonce == 0 { // nexus doesn't have to know about this acct
 			continue
 		}
 

--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -122,9 +122,9 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 		_, ok := expectedAccts[actualAddr]
 		if !ok {
 			// If the account is not expected (missing from oasis-node) it should have a zero balance.
-			if a.Balance.Int64() != 0 {
+			if !a.Balance.IsZero() {
 				notExpectedFound++
-				t.Logf("Unexpected address '%s' found, reported balance (Nexus): %d", a.Address, a.Balance.Int64())
+				t.Logf("Unexpected address '%s' found, reported balance (Nexus): %s", a.Address, a.Balance)
 				t.Fail()
 			} else {
 				allBalances++
@@ -160,7 +160,7 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 			for denom, amount := range balances.Balances {
 				if stringifyDenomination(denom, sdkPT) == nativeTokenSymbol(sdkPT) {
 					t.Logf("Balance: %s", amount)
-					if amount.ToBigInt().Int64() > 0 {
+					if !amount.IsZero() {
 						expectedNotFoundNonZero++
 					}
 				}


### PR DESCRIPTION
Consensus statecheck was failing in part because it was unable to pull large (>uint64) balances from the db into internal uin64 variables:
```
      Error:          Received unexpected error:
                      can't scan into dest[1]: cannot scan 70039999999999963480000000 into *uint64
```

**This PR:**
- fixes that bug in statecheck/consensus
- avoids some less critical unneccessary BigInt->uint64 conversions in statecheck/runtime
- tightens the test a little; we now do NOT ignore accounts with 0 balance but non-0 nonce
- (no-op: renames some cryptically-named variables)

**Testing:** Deployed a statecheck manually, verified in the output that type errors were gone.