### PR TITLE
[api] return evm addresses in event body when available

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2279,11 +2279,13 @@ components:
         body:
           type: object
           description: |
-            The decoded event contents. This spec does not encode the many possible types;
-            instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
+            The decoded event contents, possibly augmented with additional address info.
+            This spec does not encode the many possible types; instead, see [the Go API](https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules).
             This object will conform to one of the `*Event` types two levels down
             the hierarchy (e.g. `MintEvent` from `accounts > Event > MintEvent`),
-            OR `evm > Event`.
+            OR `evm > Event`. For object fields that specify an oasis-style address, Nexus
+            may add a field specifying the corresponding evm-style address. Currently, 
+            the only such possible fields are `from_eth`, `to_eth`, and `owner_eth`.
         evm_log_name:
           type: string
           description: |

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2284,7 +2284,7 @@ components:
             This object will conform to one of the `*Event` types two levels down
             the hierarchy (e.g. `MintEvent` from `accounts > Event > MintEvent`),
             OR `evm > Event`. For object fields that specify an oasis-style address, Nexus
-            may add a field specifying the corresponding evm-style address. Currently, 
+            will add a field specifying the corresponding Ethereum address, if known. Currently, 
             the only such possible fields are `from_eth`, `to_eth`, and `owner_eth`.
         evm_log_name:
           type: string

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1407,7 +1407,6 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 		}
 		if toPreimageContextIdentifier != nil && toPreimageContextVersion != nil {
 			e.Body["to_eth"] = EthChecksumAddrFromPreimage(*toPreimageContextIdentifier, *toPreimageContextVersion, toPreimageData)
-			c.logger.Info("reached to block")
 		}
 		if ownerPreimageContextIdentifier != nil && ownerPreimageContextVersion != nil {
 			e.Body["owner_eth"] = EthChecksumAddrFromPreimage(*ownerPreimageContextIdentifier, *ownerPreimageContextVersion, ownerPreimageData)

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1359,6 +1359,15 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 		var e RuntimeEvent
 		var et apiTypes.EvmEventToken
 		var tokenType sql.NullInt32
+		var fromPreimageContextIdentifier *string
+		var fromPreimageContextVersion *int
+		var fromPreimageData []byte
+		var toPreimageContextIdentifier *string
+		var toPreimageContextVersion *int
+		var toPreimageData []byte
+		var ownerPreimageContextIdentifier *string
+		var ownerPreimageContextVersion *int
+		var ownerPreimageData []byte
 		if err := res.rows.Scan(
 			&e.Round,
 			&e.TxIndex,
@@ -1372,6 +1381,15 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 			&et.Symbol,
 			&tokenType,
 			&et.Decimals,
+			&fromPreimageContextIdentifier,
+			&fromPreimageContextVersion,
+			&fromPreimageData,
+			&toPreimageContextIdentifier,
+			&toPreimageContextVersion,
+			&toPreimageData,
+			&ownerPreimageContextIdentifier,
+			&ownerPreimageContextVersion,
+			&ownerPreimageData,
 		); err != nil {
 			return nil, wrapError(err)
 		}
@@ -1380,6 +1398,19 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 		}
 		if et != (apiTypes.EvmEventToken{}) {
 			e.EvmToken = &et
+		}
+		// Render Ethereum-compatible address preimages.
+		// TODO: That's a little odd to do in the database layer. Move this farther
+		// out if we have the energy.
+		if fromPreimageContextIdentifier != nil && fromPreimageContextVersion != nil {
+			e.Body["from_eth"] = EthChecksumAddrFromPreimage(*fromPreimageContextIdentifier, *fromPreimageContextVersion, fromPreimageData)
+		}
+		if toPreimageContextIdentifier != nil && toPreimageContextVersion != nil {
+			e.Body["to_eth"] = EthChecksumAddrFromPreimage(*toPreimageContextIdentifier, *toPreimageContextVersion, toPreimageData)
+			c.logger.Info("reached to block")
+		}
+		if ownerPreimageContextIdentifier != nil && ownerPreimageContextVersion != nil {
+			e.Body["owner_eth"] = EthChecksumAddrFromPreimage(*ownerPreimageContextIdentifier, *ownerPreimageContextVersion, ownerPreimageData)
 		}
 		es.Events = append(es.Events, e)
 	}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -392,7 +392,16 @@ const (
 			evs.evm_log_params,
 			tokens.symbol,
 			tokens.token_type,
-			tokens.decimals
+			tokens.decimals,
+			pre1.context_identifier AS from_preimage_context_identifier,
+			pre1.context_version AS from_preimage_context_version,
+			pre1.address_data AS from_preimage_address_data,
+			pre2.context_identifier AS to_preimage_context_identifier,
+			pre2.context_version AS to_preimage_context_version,
+			pre2.address_data AS to_preimage_address_data,
+			pre3.context_identifier AS owner_preimage_context_identifier,
+			pre3.context_version AS owner_preimage_context_version,
+			pre3.address_data AS owner_preimage_address_data
 		FROM chain.runtime_events as evs
 		-- Look up the oasis-style address derived from evs.body.address.
 		-- The derivation is just a keccak hash and we could theoretically compute it instead of looking it up,
@@ -401,6 +410,18 @@ const (
 			DECODE(evs.body ->> 'address', 'base64')=preimages.address_data AND
 			preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
 			preimages.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre1 ON
+			evs.body->>'from' = pre1.address AND
+			pre1.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre1.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre2 ON
+			evs.body->>'to' = pre2.address AND
+			pre2.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre2.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre3 ON
+			evs.body->>'owner' = pre3.address AND
+			pre3.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre3.context_version = 0
 		LEFT JOIN chain.evm_tokens as tokens ON
 			(evs.runtime=tokens.runtime) AND
 			(preimages.address=tokens.token_address) AND

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -393,15 +393,15 @@ const (
 			tokens.symbol,
 			tokens.token_type,
 			tokens.decimals,
-			pre1.context_identifier AS from_preimage_context_identifier,
-			pre1.context_version AS from_preimage_context_version,
-			pre1.address_data AS from_preimage_address_data,
-			pre2.context_identifier AS to_preimage_context_identifier,
-			pre2.context_version AS to_preimage_context_version,
-			pre2.address_data AS to_preimage_address_data,
-			pre3.context_identifier AS owner_preimage_context_identifier,
-			pre3.context_version AS owner_preimage_context_version,
-			pre3.address_data AS owner_preimage_address_data
+			pre_from.context_identifier AS from_preimage_context_identifier,
+			pre_from.context_version AS from_preimage_context_version,
+			pre_from.address_data AS from_preimage_address_data,
+			pre_to.context_identifier AS to_preimage_context_identifier,
+			pre_to.context_version AS to_preimage_context_version,
+			pre_to.address_data AS to_preimage_address_data,
+			pre_owner.context_identifier AS owner_preimage_context_identifier,
+			pre_owner.context_version AS owner_preimage_context_version,
+			pre_owner.address_data AS owner_preimage_address_data
 		FROM chain.runtime_events as evs
 		-- Look up the oasis-style address derived from evs.body.address.
 		-- The derivation is just a keccak hash and we could theoretically compute it instead of looking it up,
@@ -410,18 +410,18 @@ const (
 			DECODE(evs.body ->> 'address', 'base64')=preimages.address_data AND
 			preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
 			preimages.context_version = 0
-		LEFT JOIN chain.address_preimages AS pre1 ON
-			evs.body->>'from' = pre1.address AND
-			pre1.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre1.context_version = 0
-		LEFT JOIN chain.address_preimages AS pre2 ON
-			evs.body->>'to' = pre2.address AND
-			pre2.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre2.context_version = 0
-		LEFT JOIN chain.address_preimages AS pre3 ON
-			evs.body->>'owner' = pre3.address AND
-			pre3.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre3.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre_from ON
+			evs.body->>'from' = pre_from.address AND
+			pre_from.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre_from.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre_to ON
+			evs.body->>'to' = pre_to.address AND
+			pre_to.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre_to.context_version = 0
+		LEFT JOIN chain.address_preimages AS pre_owner ON
+			evs.body->>'owner' = pre_owner.address AND
+			pre_owner.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
+			pre_owner.context_version = 0
 		LEFT JOIN chain.evm_tokens as tokens ON
 			(evs.runtime=tokens.runtime) AND
 			(preimages.address=tokens.token_address) AND

--- a/tests/e2e_regression/eden/expected/emerald_events.body
+++ b/tests/e2e_regression/eden/expected/emerald_events.body
@@ -150,6 +150,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "8a5b6cd62141f380e4b481a48814fea9c40f7f382cd819d9d49e021af76ca6d8",
@@ -333,6 +334,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "547aa2944a8be90f55f37c34afab8b9b8e08be5ff998f8a401efedaa2f77793e",
@@ -516,6 +518,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "f3f39a596bc8d93e220d51f5304bf0265e7ce94e9968960be43030642cf31d7d",
@@ -555,7 +558,8 @@
           "Amount": "100000000000000000",
           "Denomination": ""
         },
-        "owner": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd"
+        "owner": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+        "owner_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8"
       },
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
@@ -712,7 +716,8 @@
         },
         "from": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
         "nonce": 201377,
-        "to": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd"
+        "to": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+        "to_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8"
       },
       "round": 8060333,
       "timestamp": "2023-12-12T10:06:09Z",
@@ -725,6 +730,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "aca7d562c32924a98d3d3a5c3a33d4b34f7471ee8e4604ade5cf54f64ff32817",
@@ -918,6 +924,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "759dca8bbf142aef388bde551a9425fb655e2d0d4dc0f8f718ffec1489a9c3cd",
@@ -945,6 +952,7 @@
           "Denomination": ""
         },
         "from": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+        "from_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "8c24652f1b27f107c64aa4abfa9d794a6a2c0b9e5236caa99ea2f53b2e5dbc83",
@@ -1128,6 +1136,7 @@
           "Denomination": ""
         },
         "from": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+        "from_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
         "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4"
       },
       "eth_tx_hash": "c5f0d68d7ed2280fccb2c3181a598e954fa4d003caea6b1d54b86c11540afe15",


### PR DESCRIPTION
Part of https://app.clickup.com/t/8693up8ft

This PR updates the events query to augment the body of non-`evm.log` events with evm-style addresses when available. 

Todo:
- `evm.log` events always use evm-style addresses; is there a demand for returning the oasis-style address for those events as well? edit: not yet; will hold off here

Testing: Only manual and e2e_regression tests for now as this is an api-only change. Performance benchmarks on production showed that the new query is slower but still within acceptable bounds. 

Note: 
- The current impl does not scale well as the number of event body fields that can hold an oasis-style address increases, although I don't think it will increase much, if at all. An alternative impl would be to extract all oasis-style addresses from events and do a subsequent db query to fetch the mappings to the eth-style addresses, and then update the event body(s) accordingly. I tried this originally but it got messy quickly, but in theory it should avoid the aforementioned scaling issue and avoid query bloat. 

Sample result:
```
» curl "http://localhost:8008/v1/sapphire/events?type=consensus_accounts.deposit&limit=2" | jq                andrewlow@Beleriand
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   739  100   739    0     0  43727      0 --:--:-- --:--:-- --:--:-- 61583
{
  "events": [
    {
      "body": {
        "amount": {
          "Amount": "100000000000000000",
          "Denomination": ""
        },
        "from": "oasis1qry5d5zxs58w9deu5ara5zaamhkzqtg99s00ls90",
        "nonce": 27405,
        "to": "oasis1qquzek9y9guk6plys32s7zvf4g2f8rvn9slu8uye",
        "to_eth": "0x8b0b51A92B0FD6d7A9595f057EdF3D85C76E571c"
      },
      "round": 158613,
      "timestamp": "2023-02-21T09:06:32-08:00",
      "type": "consensus_accounts.deposit"
    },
    {
      "body": {
        "amount": {
          "Amount": "100000000000000000",
          "Denomination": ""
        },
        "from": "oasis1qry5d5zxs58w9deu5ara5zaamhkzqtg99s00ls90",
        "nonce": 27404,
        "to": "oasis1qquzek9y9guk6plys32s7zvf4g2f8rvn9slu8uye",
        "to_eth": "0x8b0b51A92B0FD6d7A9595f057EdF3D85C76E571c"
      },
      "round": 158606,
      "timestamp": "2023-02-21T09:03:36-08:00",
      "type": "consensus_accounts.deposit"
    }
  ],
  "is_total_count_clipped": false,
  "total_count": 57
}
```