### PR TITLE
[consensus] add height/timestamp to governance votes

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -1008,6 +1008,7 @@ func (m *processor) queueVotes(batch *storage.QueryBatch, data *governanceData) 
 			vote.ID,
 			vote.Submitter.String(),
 			vote.Vote,
+			data.Height,
 		)
 	}
 

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -415,10 +415,11 @@ var (
       WHERE id = $1`
 
 	ConsensusVoteUpsert = `
-    INSERT INTO chain.votes (proposal, voter, vote)
-      VALUES ($1, $2, $3)
+    INSERT INTO chain.votes (proposal, voter, vote, height)
+      VALUES ($1, $2, $3, $4)
     ON CONFLICT (proposal, voter) DO UPDATE SET
-	    vote = excluded.vote;`
+	    vote = excluded.vote,
+      height = excluded.height;`
 
 	RuntimeBlockInsert = `
     INSERT INTO chain.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2178,6 +2178,16 @@ components:
           type: string
           description: The vote cast.
           example: 'yes'
+        height:
+          type: integer
+          format: int64
+          description: The block height at which this vote was recorded.
+          example: *block_height_1
+        timestamp:
+          type: string
+          format: date-time
+          description: The second-granular consensus time of the block in which this vote was cast.
+          example: *iso_timestamp_1
 
     RuntimeBlockList:
       allOf:

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1054,6 +1054,8 @@ func (c *StorageClient) ProposalVotes(ctx context.Context, proposalID uint64, p 
 		if err := res.rows.Scan(
 			&v.Address,
 			&v.Vote,
+			&v.Height,
+			&v.Timestamp,
 		); err != nil {
 			return nil, wrapError(err)
 		}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -246,10 +246,11 @@ const (
 			WHERE id = $1::bigint`
 
 	ProposalVotes = `
-		SELECT voter, vote
-			FROM chain.votes
+		SELECT votes.voter, votes.vote, votes.height, blocks.time
+			FROM chain.votes as votes
+			LEFT JOIN chain.blocks as blocks ON votes.height = blocks.height
 			WHERE proposal = $1::bigint
-		ORDER BY proposal DESC
+		ORDER BY height DESC, voter ASC
 		LIMIT $2::bigint
 		OFFSET $3::bigint`
 

--- a/storage/migrations/11_governance_votes.up.sql
+++ b/storage/migrations/11_governance_votes.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE chain.votes
+    ADD COLUMN height UINT63; -- Can be NULL; when the vote comes from a genesis file, height is unknown.
+
+COMMIT;

--- a/tests/e2e_regression/damask/expected/votes.body
+++ b/tests/e2e_regression/damask/expected/votes.body
@@ -4,6 +4,162 @@
   "total_count": 90,
   "votes": [
     {
+      "address": "oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp3rhyfjagkj65cnn6lt8ej305gh3kamsvzspluq",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp4f47plgld98n5g2ltalalnndnzz96euv9n89lz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp4rp7adhegfktyg4aq3w6jelqumx6klfv5t7kvv",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp53ud2pcmm73mlf4qywnrr245222mvlz5a2e5ty",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp60saapdcrhe5zp3c3zk52r4dcfkr2uyuc5qjxp",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp6fzgx9zhamsk6c77cwzjeme06xwswffvhk6js2",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp9xlxurlcx3k5h3pkays56mp48zfv9nmcf982kn",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpavd66xsezz8s4wjw2fyycxw8jm2nlpnuejlg2g",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpaygvzwd5ffh2f5p4qdqylymgqcvl7sp5gxyrl3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpg763ex50jp0e34lsu789smlzqvcv7025v7m7yx",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpgl52u29wy4hjla89f46ntkn2qsa6zpdvhv6s6n",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpjuke27se2wnmvx6e8uc4l5h44yjp9h7g2clqfq",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpl883gp995zs9n6a279tqsavnaxxf0rzcdlauwu",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qppctxzn8djkqfvrxugak9v7dp25vddq7sxqhkry",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qppjm5sxqwps4dpyekdvz530sjmq3e5eusp7hdan",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpqz8g88kvw49m402k8m2r6nv4p62vsdkv5d0u6r",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qps7mh7usg7u4t35ujr0l8dxjs2ly2swhu9v0mr0",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qps9drw07z0gmh5z2pn7zwl3z53ate2yvqf3uzq5",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpsnzv8qz4fu3lwps2tc3eg5pnryzl4h7cqxruzf",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qptk3ydjxuq3eenqwljdy45uxdye5tfg4sqar0fz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpwrq93z8s9ytu2hfjtqggc9edgwfadzevs3trvm",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpxpnxxk4qcgl7n55tx0yuqmrcw5cy2u5vzjq5u4",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq2kqzr4q942x44st97n66nmmyh7dhsuvsqyc22u",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq4f2h225gv6g8w8w23fm740aze9lke4qun72n59",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq7vyz4ewrdh00yujw0mgkf459et306xmvh2h3zg",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqf6wmc0ax3mykd028ltgtqr49h3qffcm50gwag3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qql4alk30frfa6xua42eu7tynkqf9vd5ug95yqpn",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqlq8jplttrmw982rrhp0svl8054xqevecks5yqr",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqm6l2msa0lhp080wmd0xrudzpusqjp4puuusup5",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqnmppt4j5d2yl584euhn6g2cw9gewdswga9frg4",
+      "vote": "yes"
+    },
+    {
       "address": "oasis1qqqn56k79st0zy4060m0wvmec76vd3pl6czmg90a",
       "vote": "yes"
     },
@@ -16,19 +172,7 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qqyynj90zkvyhja33w4ltgej45pr48f45ymmnsrx",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qqx820g2geqzeyeyfnm5hgz72eaj9emajgqmscy0",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qqf6wmc0ax3mykd028ltgtqr49h3qffcm50gwag3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qq2kqzr4q942x44st97n66nmmyh7dhsuvsqyc22u",
+      "address": "oasis1qqs5wnxvsk009swtt7ehm5fslxve96kczszwt47s",
       "vote": "yes"
     },
     {
@@ -36,199 +180,87 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt",
+      "address": "oasis1qqx820g2geqzeyeyfnm5hgz72eaj9emajgqmscy0",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqs5wnxvsk009swtt7ehm5fslxve96kczszwt47s",
+      "address": "oasis1qqyynj90zkvyhja33w4ltgej45pr48f45ymmnsrx",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
+      "address": "oasis1qr0jwz65c29l044a204e3cllvumdg8cmsgt2k3ql",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqnmppt4j5d2yl584euhn6g2cw9gewdswga9frg4",
+      "address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq4f2h225gv6g8w8w23fm740aze9lke4qun72n59",
+      "address": "oasis1qr9wccuk6pqcr5ld8t2uf599e4ch5348hqeq53x4",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz",
+      "address": "oasis1qr9zuf3n8g3znm786st3sldfw677pk3a6v85w9ds",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
+      "address": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqm6l2msa0lhp080wmd0xrudzpusqjp4puuusup5",
+      "address": "oasis1qrcmmvgf7qt8pmy543dmz0muwcm752kleund8rwr",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq7vyz4ewrdh00yujw0mgkf459et306xmvh2h3zg",
+      "address": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqlq8jplttrmw982rrhp0svl8054xqevecks5yqr",
+      "address": "oasis1qresj0vhmwawll6fe2vw2nlapkp6nj6etcx7a32h",
       "vote": "yes"
     },
     {
-      "address": "oasis1qql4alk30frfa6xua42eu7tynkqf9vd5ug95yqpn",
+      "address": "oasis1qrflth3g7k0ymkut2zrca3ktagw6g882yvqmgzdv",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpqz8g88kvw49m402k8m2r6nv4p62vsdkv5d0u6r",
+      "address": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k",
       "vote": "yes"
     },
     {
-      "address": "oasis1qppjm5sxqwps4dpyekdvz530sjmq3e5eusp7hdan",
+      "address": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm",
       "vote": "yes"
     },
     {
-      "address": "oasis1qppctxzn8djkqfvrxugak9v7dp25vddq7sxqhkry",
+      "address": "oasis1qrs8zlh0mj37ug0jzlcykz808ylw93xwkvknm7yc",
       "vote": "yes"
     },
     {
-      "address": "oasis1qp9xlxurlcx3k5h3pkays56mp48zfv9nmcf982kn",
+      "address": "oasis1qrtq873ddwnnjqyv66ezdc9ql2a07l37d5vae9k0",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpxpnxxk4qcgl7n55tx0yuqmrcw5cy2u5vzjq5u4",
+      "address": "oasis1qrugz89g5esmhs0ezer0plsfvmcgctge35n32vmr",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpg763ex50jp0e34lsu789smlzqvcv7025v7m7yx",
+      "address": "oasis1qryc94hn6hucev6ex79ceheve2pjesenc50svvvp",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpgl52u29wy4hjla89f46ntkn2qsa6zpdvhv6s6n",
+      "address": "oasis1qryreqam7w0slj7rhz70g9xvt9rct2024cepgqjj",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57",
+      "address": "oasis1qrzkqzvlw9xgyxhhqps746ssyhn5lkqrmcgz8amq",
       "vote": "yes"
     },
     {
-      "address": "oasis1qptk3ydjxuq3eenqwljdy45uxdye5tfg4sqar0fz",
+      "address": "oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpwrq93z8s9ytu2hfjtqggc9edgwfadzevs3trvm",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qps9drw07z0gmh5z2pn7zwl3z53ate2yvqf3uzq5",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpsnzv8qz4fu3lwps2tc3eg5pnryzl4h7cqxruzf",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qps7mh7usg7u4t35ujr0l8dxjs2ly2swhu9v0mr0",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp3rhyfjagkj65cnn6lt8ej305gh3kamsvzspluq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpjuke27se2wnmvx6e8uc4l5h44yjp9h7g2clqfq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp53ud2pcmm73mlf4qywnrr245222mvlz5a2e5ty",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp4rp7adhegfktyg4aq3w6jelqumx6klfv5t7kvv",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp4f47plgld98n5g2ltalalnndnzz96euv9n89lz",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp6fzgx9zhamsk6c77cwzjeme06xwswffvhk6js2",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp60saapdcrhe5zp3c3zk52r4dcfkr2uyuc5qjxp",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpaygvzwd5ffh2f5p4qdqylymgqcvl7sp5gxyrl3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpavd66xsezz8s4wjw2fyycxw8jm2nlpnuejlg2g",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpl883gp995zs9n6a279tqsavnaxxf0rzcdlauwu",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzp84num6xgspdst65yv7yqegln6ndcxmuuq8s9w",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzp8e4ldf9zq27jle847nawll5jwwa9x75y6spaz",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzzytegg6jc7hxu6y8feuzkgmr75ms7hc54mz85p",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzzwkrjmyrzey46hyste5xszue3ggy90ag7k3687",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzrjsupecrjmvyfmg0aqz75sek4x7dn4ggchqx28",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzrehfnnntdaeshy5f6kfa8v3p35yu7mluaapmgc",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz8vfnkcc48grazt83gstfm6yjwyptalny8cywtp",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz86vltcdhjurzuvzfhkku4yaf7vf2umdvpwmtlv",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz8u0zqhcmgxalnjgwj6m0sg6wuy2vrsgyna2z7t",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzgq240adkyxhm6598ex2jvgs7lyx5wmtg7cszmk",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd",
+      "address": "oasis1qz0tqva49ysnjk2p7xe83qfp86khxwms8sc2wf6e",
       "vote": "yes"
     },
     {
@@ -240,51 +272,7 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qztpm422n7v98f4s7ja0wt5jey7fy3xpg5ye2vtl",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzt4fvcc6cw9af69tek9p3mfjwn3a5e5vcyrw7ac",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzv7a0gkxwpfelv985fvkl24k7jh3arfwy84zw7q",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz0tqva49ysnjk2p7xe83qfp86khxwms8sc2wf6e",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzc687uuywnel4eqtdn6x3t9hkdvf6sf2gtv4ye9",
-      "vote": "yes"
-    },
-    {
       "address": "oasis1qz65awwegd9pr8msfxkg7hpwyjemm2qdlysyc8jq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzmwdlxy7cltmwt99u9pwqt3g0rdwgsqyvcqymmt",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzm74el4utw4jssrl95ujq87g3ks3xfmjytvtaaa",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzugextrcdueshq63w7l9x4xglnusznsgqa95w7e",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzaracvtpgp87frlk9jshdcu8aczpsrz8y94jjg4",
       "vote": "yes"
     },
     {
@@ -292,75 +280,87 @@
       "vote": "yes"
     },
     {
+      "address": "oasis1qz86vltcdhjurzuvzfhkku4yaf7vf2umdvpwmtlv",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qz8u0zqhcmgxalnjgwj6m0sg6wuy2vrsgyna2z7t",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qz8vfnkcc48grazt83gstfm6yjwyptalny8cywtp",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzaracvtpgp87frlk9jshdcu8aczpsrz8y94jjg4",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzc687uuywnel4eqtdn6x3t9hkdvf6sf2gtv4ye9",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzgq240adkyxhm6598ex2jvgs7lyx5wmtg7cszmk",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6",
+      "vote": "yes"
+    },
+    {
       "address": "oasis1qzl8w5ka9y3p8a8gqlemqk98hzc33sn0tuezyc8l",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrzkqzvlw9xgyxhhqps746ssyhn5lkqrmcgz8amq",
+      "address": "oasis1qzm74el4utw4jssrl95ujq87g3ks3xfmjytvtaaa",
       "vote": "yes"
     },
     {
-      "address": "oasis1qryreqam7w0slj7rhz70g9xvt9rct2024cepgqjj",
+      "address": "oasis1qzmwdlxy7cltmwt99u9pwqt3g0rdwgsqyvcqymmt",
       "vote": "yes"
     },
     {
-      "address": "oasis1qryc94hn6hucev6ex79ceheve2pjesenc50svvvp",
+      "address": "oasis1qzp84num6xgspdst65yv7yqegln6ndcxmuuq8s9w",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr9zuf3n8g3znm786st3sldfw677pk3a6v85w9ds",
+      "address": "oasis1qzp8e4ldf9zq27jle847nawll5jwwa9x75y6spaz",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr9wccuk6pqcr5ld8t2uf599e4ch5348hqeq53x4",
+      "address": "oasis1qzrehfnnntdaeshy5f6kfa8v3p35yu7mluaapmgc",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k",
+      "address": "oasis1qzrjsupecrjmvyfmg0aqz75sek4x7dn4ggchqx28",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrflth3g7k0ymkut2zrca3ktagw6g882yvqmgzdv",
+      "address": "oasis1qzt4fvcc6cw9af69tek9p3mfjwn3a5e5vcyrw7ac",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrtq873ddwnnjqyv66ezdc9ql2a07l37d5vae9k0",
+      "address": "oasis1qztpm422n7v98f4s7ja0wt5jey7fy3xpg5ye2vtl",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz",
+      "address": "oasis1qzugextrcdueshq63w7l9x4xglnusznsgqa95w7e",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr0jwz65c29l044a204e3cllvumdg8cmsgt2k3ql",
+      "address": "oasis1qzv7a0gkxwpfelv985fvkl24k7jh3arfwy84zw7q",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrs8zlh0mj37ug0jzlcykz808ylw93xwkvknm7yc",
+      "address": "oasis1qzzwkrjmyrzey46hyste5xszue3ggy90ag7k3687",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrcmmvgf7qt8pmy543dmz0muwcm752kleund8rwr",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qresj0vhmwawll6fe2vw2nlapkp6nj6etcx7a32h",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrugz89g5esmhs0ezer0plsfvmcgctge35n32vmr",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at",
+      "address": "oasis1qzzytegg6jc7hxu6y8feuzkgmr75ms7hc54mz85p",
       "vote": "yes"
     }
   ]

--- a/tests/e2e_regression/eden/expected/votes.body
+++ b/tests/e2e_regression/eden/expected/votes.body
@@ -4,6 +4,162 @@
   "total_count": 90,
   "votes": [
     {
+      "address": "oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp3rhyfjagkj65cnn6lt8ej305gh3kamsvzspluq",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp4f47plgld98n5g2ltalalnndnzz96euv9n89lz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp4rp7adhegfktyg4aq3w6jelqumx6klfv5t7kvv",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp53ud2pcmm73mlf4qywnrr245222mvlz5a2e5ty",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp60saapdcrhe5zp3c3zk52r4dcfkr2uyuc5qjxp",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp6fzgx9zhamsk6c77cwzjeme06xwswffvhk6js2",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qp9xlxurlcx3k5h3pkays56mp48zfv9nmcf982kn",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpavd66xsezz8s4wjw2fyycxw8jm2nlpnuejlg2g",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpaygvzwd5ffh2f5p4qdqylymgqcvl7sp5gxyrl3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpg763ex50jp0e34lsu789smlzqvcv7025v7m7yx",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpgl52u29wy4hjla89f46ntkn2qsa6zpdvhv6s6n",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpjuke27se2wnmvx6e8uc4l5h44yjp9h7g2clqfq",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpl883gp995zs9n6a279tqsavnaxxf0rzcdlauwu",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qppctxzn8djkqfvrxugak9v7dp25vddq7sxqhkry",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qppjm5sxqwps4dpyekdvz530sjmq3e5eusp7hdan",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpqz8g88kvw49m402k8m2r6nv4p62vsdkv5d0u6r",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qps7mh7usg7u4t35ujr0l8dxjs2ly2swhu9v0mr0",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qps9drw07z0gmh5z2pn7zwl3z53ate2yvqf3uzq5",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpsnzv8qz4fu3lwps2tc3eg5pnryzl4h7cqxruzf",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qptk3ydjxuq3eenqwljdy45uxdye5tfg4sqar0fz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpwrq93z8s9ytu2hfjtqggc9edgwfadzevs3trvm",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qpxpnxxk4qcgl7n55tx0yuqmrcw5cy2u5vzjq5u4",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq2kqzr4q942x44st97n66nmmyh7dhsuvsqyc22u",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq4f2h225gv6g8w8w23fm740aze9lke4qun72n59",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qq7vyz4ewrdh00yujw0mgkf459et306xmvh2h3zg",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqf6wmc0ax3mykd028ltgtqr49h3qffcm50gwag3",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qql4alk30frfa6xua42eu7tynkqf9vd5ug95yqpn",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqlq8jplttrmw982rrhp0svl8054xqevecks5yqr",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqm6l2msa0lhp080wmd0xrudzpusqjp4puuusup5",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qqnmppt4j5d2yl584euhn6g2cw9gewdswga9frg4",
+      "vote": "yes"
+    },
+    {
       "address": "oasis1qqqn56k79st0zy4060m0wvmec76vd3pl6czmg90a",
       "vote": "yes"
     },
@@ -16,19 +172,7 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qqyynj90zkvyhja33w4ltgej45pr48f45ymmnsrx",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qqx820g2geqzeyeyfnm5hgz72eaj9emajgqmscy0",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qqf6wmc0ax3mykd028ltgtqr49h3qffcm50gwag3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qq2kqzr4q942x44st97n66nmmyh7dhsuvsqyc22u",
+      "address": "oasis1qqs5wnxvsk009swtt7ehm5fslxve96kczszwt47s",
       "vote": "yes"
     },
     {
@@ -36,199 +180,87 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt",
+      "address": "oasis1qqx820g2geqzeyeyfnm5hgz72eaj9emajgqmscy0",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqs5wnxvsk009swtt7ehm5fslxve96kczszwt47s",
+      "address": "oasis1qqyynj90zkvyhja33w4ltgej45pr48f45ymmnsrx",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
+      "address": "oasis1qr0jwz65c29l044a204e3cllvumdg8cmsgt2k3ql",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqnmppt4j5d2yl584euhn6g2cw9gewdswga9frg4",
+      "address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq4f2h225gv6g8w8w23fm740aze9lke4qun72n59",
+      "address": "oasis1qr9wccuk6pqcr5ld8t2uf599e4ch5348hqeq53x4",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqewwznmvwfvee0dyq9g48acy0wcw890g549pukz",
+      "address": "oasis1qr9zuf3n8g3znm786st3sldfw677pk3a6v85w9ds",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
+      "address": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqm6l2msa0lhp080wmd0xrudzpusqjp4puuusup5",
+      "address": "oasis1qrcmmvgf7qt8pmy543dmz0muwcm752kleund8rwr",
       "vote": "yes"
     },
     {
-      "address": "oasis1qq7vyz4ewrdh00yujw0mgkf459et306xmvh2h3zg",
+      "address": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz",
       "vote": "yes"
     },
     {
-      "address": "oasis1qqlq8jplttrmw982rrhp0svl8054xqevecks5yqr",
+      "address": "oasis1qresj0vhmwawll6fe2vw2nlapkp6nj6etcx7a32h",
       "vote": "yes"
     },
     {
-      "address": "oasis1qql4alk30frfa6xua42eu7tynkqf9vd5ug95yqpn",
+      "address": "oasis1qrflth3g7k0ymkut2zrca3ktagw6g882yvqmgzdv",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpqz8g88kvw49m402k8m2r6nv4p62vsdkv5d0u6r",
+      "address": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k",
       "vote": "yes"
     },
     {
-      "address": "oasis1qppjm5sxqwps4dpyekdvz530sjmq3e5eusp7hdan",
+      "address": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm",
       "vote": "yes"
     },
     {
-      "address": "oasis1qppctxzn8djkqfvrxugak9v7dp25vddq7sxqhkry",
+      "address": "oasis1qrs8zlh0mj37ug0jzlcykz808ylw93xwkvknm7yc",
       "vote": "yes"
     },
     {
-      "address": "oasis1qp9xlxurlcx3k5h3pkays56mp48zfv9nmcf982kn",
+      "address": "oasis1qrtq873ddwnnjqyv66ezdc9ql2a07l37d5vae9k0",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpxpnxxk4qcgl7n55tx0yuqmrcw5cy2u5vzjq5u4",
+      "address": "oasis1qrugz89g5esmhs0ezer0plsfvmcgctge35n32vmr",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpg763ex50jp0e34lsu789smlzqvcv7025v7m7yx",
+      "address": "oasis1qryc94hn6hucev6ex79ceheve2pjesenc50svvvp",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpgl52u29wy4hjla89f46ntkn2qsa6zpdvhv6s6n",
+      "address": "oasis1qryreqam7w0slj7rhz70g9xvt9rct2024cepgqjj",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpfcsun7zju6ku7d2mdh54j9nsmxvj76uqk35w57",
+      "address": "oasis1qrzkqzvlw9xgyxhhqps746ssyhn5lkqrmcgz8amq",
       "vote": "yes"
     },
     {
-      "address": "oasis1qptk3ydjxuq3eenqwljdy45uxdye5tfg4sqar0fz",
+      "address": "oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt",
       "vote": "yes"
     },
     {
-      "address": "oasis1qpwrq93z8s9ytu2hfjtqggc9edgwfadzevs3trvm",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qps9drw07z0gmh5z2pn7zwl3z53ate2yvqf3uzq5",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpsnzv8qz4fu3lwps2tc3eg5pnryzl4h7cqxruzf",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qps7mh7usg7u4t35ujr0l8dxjs2ly2swhu9v0mr0",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp3rhyfjagkj65cnn6lt8ej305gh3kamsvzspluq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp334gzlzrap6k2ch6wc9vxxplw9sg3v9cfvvgsy",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpjuke27se2wnmvx6e8uc4l5h44yjp9h7g2clqfq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp53ud2pcmm73mlf4qywnrr245222mvlz5a2e5ty",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp4rp7adhegfktyg4aq3w6jelqumx6klfv5t7kvv",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp4f47plgld98n5g2ltalalnndnzz96euv9n89lz",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp6fzgx9zhamsk6c77cwzjeme06xwswffvhk6js2",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qp60saapdcrhe5zp3c3zk52r4dcfkr2uyuc5qjxp",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpaygvzwd5ffh2f5p4qdqylymgqcvl7sp5gxyrl3",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpavd66xsezz8s4wjw2fyycxw8jm2nlpnuejlg2g",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qpl883gp995zs9n6a279tqsavnaxxf0rzcdlauwu",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzp84num6xgspdst65yv7yqegln6ndcxmuuq8s9w",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzp8e4ldf9zq27jle847nawll5jwwa9x75y6spaz",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzzytegg6jc7hxu6y8feuzkgmr75ms7hc54mz85p",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzzwkrjmyrzey46hyste5xszue3ggy90ag7k3687",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzrjsupecrjmvyfmg0aqz75sek4x7dn4ggchqx28",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzrehfnnntdaeshy5f6kfa8v3p35yu7mluaapmgc",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz8vfnkcc48grazt83gstfm6yjwyptalny8cywtp",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz86vltcdhjurzuvzfhkku4yaf7vf2umdvpwmtlv",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz8u0zqhcmgxalnjgwj6m0sg6wuy2vrsgyna2z7t",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzgq240adkyxhm6598ex2jvgs7lyx5wmtg7cszmk",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd",
+      "address": "oasis1qz0tqva49ysnjk2p7xe83qfp86khxwms8sc2wf6e",
       "vote": "yes"
     },
     {
@@ -240,51 +272,7 @@
       "vote": "yes"
     },
     {
-      "address": "oasis1qztpm422n7v98f4s7ja0wt5jey7fy3xpg5ye2vtl",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzt4fvcc6cw9af69tek9p3mfjwn3a5e5vcyrw7ac",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzv7a0gkxwpfelv985fvkl24k7jh3arfwy84zw7q",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz0tqva49ysnjk2p7xe83qfp86khxwms8sc2wf6e",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzc687uuywnel4eqtdn6x3t9hkdvf6sf2gtv4ye9",
-      "vote": "yes"
-    },
-    {
       "address": "oasis1qz65awwegd9pr8msfxkg7hpwyjemm2qdlysyc8jq",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzmwdlxy7cltmwt99u9pwqt3g0rdwgsqyvcqymmt",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzm74el4utw4jssrl95ujq87g3ks3xfmjytvtaaa",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzugextrcdueshq63w7l9x4xglnusznsgqa95w7e",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qzaracvtpgp87frlk9jshdcu8aczpsrz8y94jjg4",
       "vote": "yes"
     },
     {
@@ -292,75 +280,87 @@
       "vote": "yes"
     },
     {
+      "address": "oasis1qz86vltcdhjurzuvzfhkku4yaf7vf2umdvpwmtlv",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qz8u0zqhcmgxalnjgwj6m0sg6wuy2vrsgyna2z7t",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qz8vfnkcc48grazt83gstfm6yjwyptalny8cywtp",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzaracvtpgp87frlk9jshdcu8aczpsrz8y94jjg4",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzc687uuywnel4eqtdn6x3t9hkdvf6sf2gtv4ye9",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzf03q57jdgdwp2w7y6a8yww6mak9khuag9qt0kd",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzgq240adkyxhm6598ex2jvgs7lyx5wmtg7cszmk",
+      "vote": "yes"
+    },
+    {
+      "address": "oasis1qzk6qlmgnq40cq2n3jfkw3307feqngt4gvksfml6",
+      "vote": "yes"
+    },
+    {
       "address": "oasis1qzl8w5ka9y3p8a8gqlemqk98hzc33sn0tuezyc8l",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrzkqzvlw9xgyxhhqps746ssyhn5lkqrmcgz8amq",
+      "address": "oasis1qzm74el4utw4jssrl95ujq87g3ks3xfmjytvtaaa",
       "vote": "yes"
     },
     {
-      "address": "oasis1qryreqam7w0slj7rhz70g9xvt9rct2024cepgqjj",
+      "address": "oasis1qzmwdlxy7cltmwt99u9pwqt3g0rdwgsqyvcqymmt",
       "vote": "yes"
     },
     {
-      "address": "oasis1qryc94hn6hucev6ex79ceheve2pjesenc50svvvp",
+      "address": "oasis1qzp84num6xgspdst65yv7yqegln6ndcxmuuq8s9w",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr9zuf3n8g3znm786st3sldfw677pk3a6v85w9ds",
+      "address": "oasis1qzp8e4ldf9zq27jle847nawll5jwwa9x75y6spaz",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr9wccuk6pqcr5ld8t2uf599e4ch5348hqeq53x4",
+      "address": "oasis1qzrehfnnntdaeshy5f6kfa8v3p35yu7mluaapmgc",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrgxl0ylc7lvkj0akv6s32rj4k98nr0f7smf6m4k",
+      "address": "oasis1qzrjsupecrjmvyfmg0aqz75sek4x7dn4ggchqx28",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrflth3g7k0ymkut2zrca3ktagw6g882yvqmgzdv",
+      "address": "oasis1qzt4fvcc6cw9af69tek9p3mfjwn3a5e5vcyrw7ac",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrtq873ddwnnjqyv66ezdc9ql2a07l37d5vae9k0",
+      "address": "oasis1qztpm422n7v98f4s7ja0wt5jey7fy3xpg5ye2vtl",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrdx0n7lgheek24t24vejdks9uqmfldtmgdv7jzz",
+      "address": "oasis1qzugextrcdueshq63w7l9x4xglnusznsgqa95w7e",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr0jwz65c29l044a204e3cllvumdg8cmsgt2k3ql",
+      "address": "oasis1qzv7a0gkxwpfelv985fvkl24k7jh3arfwy84zw7q",
       "vote": "yes"
     },
     {
-      "address": "oasis1qrs8zlh0mj37ug0jzlcykz808ylw93xwkvknm7yc",
+      "address": "oasis1qzzwkrjmyrzey46hyste5xszue3ggy90ag7k3687",
       "vote": "yes"
     },
     {
-      "address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrcmmvgf7qt8pmy543dmz0muwcm752kleund8rwr",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qresj0vhmwawll6fe2vw2nlapkp6nj6etcx7a32h",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrmexg6kh67xvnp7k42sx482nja5760stcrcdkhm",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qrugz89g5esmhs0ezer0plsfvmcgctge35n32vmr",
-      "vote": "yes"
-    },
-    {
-      "address": "oasis1qram2p9w3yxm4px5nth8n7ugggk5rr6ay5d284at",
+      "address": "oasis1qzzytegg6jc7hxu6y8feuzkgmr75ms7hc54mz85p",
       "vote": "yes"
     }
   ]


### PR DESCRIPTION
Resolves https://app.clickup.com/t/8693prg5a

This PR adds two additional fields, `height` and `timestamp`, to the `ProposalVote` object in the api. 

As Mitja pointed out in the ticket, the "api fields will be optional because the votes might have been observed via the genesis doc rather than via events, in which case the voting height [is not available](https://github.com/oasisprotocol/nexus/blob/f6af89d1101fd6c983ade51755a44dee0b6d0597/analyzer/consensus/genesis.go#L571-L572)."

This is the case for the e2e_regression tests, which query for a proposal that was observed via genesis doc. 

Testing: e2e_regression tests, also I inserted some fake round data into the `votes` table and the resulting query looks like 
```
» curl "http://localhost:8008/v1/consensus/proposals/2/votes" | jq                                 andrewlow@Beleriand
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11956    0 11956    0     0   249k      0 --:--:-- --:--:-- --:--:--  277k
{
  "is_total_count_clipped": false,
  "proposal_id": 2,
  "total_count": 90,
  "votes": [
    {
      "address": "oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6",
      "height": 16818000,
      "timestamp": "2023-11-29T03:31:10-08:00",
      "vote": "yes"
    },
    {
      "address": "oasis1qp0xuvw2a93w4yp8jwthfz93gxy87u7hes9eu2ev",
      "height": 16818000,
      "timestamp": "2023-11-29T03:31:10-08:00",
      "vote": "yes"
    },
```