### PR TITLE
[api] shorten query

### DIFF
--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1403,13 +1403,19 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 		// TODO: That's a little odd to do in the database layer. Move this farther
 		// out if we have the energy.
 		if fromPreimageContextIdentifier != nil && fromPreimageContextVersion != nil {
-			e.Body["from_eth"] = EthChecksumAddrFromPreimage(*fromPreimageContextIdentifier, *fromPreimageContextVersion, fromPreimageData)
+			if from_eth := EthChecksumAddrFromPreimage(*fromPreimageContextIdentifier, *fromPreimageContextVersion, fromPreimageData); from_eth != nil {
+				e.Body["from_eth"] = from_eth
+			}
 		}
 		if toPreimageContextIdentifier != nil && toPreimageContextVersion != nil {
-			e.Body["to_eth"] = EthChecksumAddrFromPreimage(*toPreimageContextIdentifier, *toPreimageContextVersion, toPreimageData)
+			if to_eth := EthChecksumAddrFromPreimage(*toPreimageContextIdentifier, *toPreimageContextVersion, toPreimageData); to_eth != nil {
+				e.Body["to_eth"] = to_eth
+			}
 		}
 		if ownerPreimageContextIdentifier != nil && ownerPreimageContextVersion != nil {
-			e.Body["owner_eth"] = EthChecksumAddrFromPreimage(*ownerPreimageContextIdentifier, *ownerPreimageContextVersion, ownerPreimageData)
+			if owner_eth := EthChecksumAddrFromPreimage(*ownerPreimageContextIdentifier, *ownerPreimageContextVersion, ownerPreimageData); owner_eth != nil {
+				e.Body["owner_eth"] = owner_eth
+			}
 		}
 		es.Events = append(es.Events, e)
 	}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -411,17 +411,11 @@ const (
 			preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
 			preimages.context_version = 0
 		LEFT JOIN chain.address_preimages AS pre_from ON
-			evs.body->>'from' = pre_from.address AND
-			pre_from.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre_from.context_version = 0
+			evs.body->>'from' = pre_from.address
 		LEFT JOIN chain.address_preimages AS pre_to ON
-			evs.body->>'to' = pre_to.address AND
-			pre_to.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre_to.context_version = 0
+			evs.body->>'to' = pre_to.address
 		LEFT JOIN chain.address_preimages AS pre_owner ON
-			evs.body->>'owner' = pre_owner.address AND
-			pre_owner.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND
-			pre_owner.context_version = 0
+			evs.body->>'owner' = pre_owner.address
 		LEFT JOIN chain.evm_tokens as tokens ON
 			(evs.runtime=tokens.runtime) AND
 			(preimages.address=tokens.token_address) AND


### PR DESCRIPTION
Per https://github.com/oasisprotocol/nexus/pull/653#discussion_r1516723205, this PR shortens the query since the address context/identifier are checked later on anyway. If the check fails, the corresponding address field is nil as expected, so there is no change to api behavior.