### PR TITLE
Fast CI on "assemble release" PRs

### DIFF
--- a/.changelog/660.internal.md
+++ b/.changelog/660.internal.md
@@ -1,0 +1,5 @@
+Fast CI on "assemble release" PRs
+
+The special PRs that just assemble the changelog fragments to prepare
+a release no longer need to undergo full CI, allowing us to cut
+releases quickly if needed.

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -10,7 +10,6 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
-      - ".github/**"
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
@@ -19,7 +18,6 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
-      - ".github/**"
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -7,11 +7,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore: # Do not trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
     branches:
       - main
+    paths-ignore: # Do not trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -10,6 +10,7 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
+      - ".github/**"
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
@@ -18,6 +19,7 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
+      - ".github/**"
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -10,7 +10,6 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
-      - ".github/**"
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
@@ -19,7 +18,6 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
-      - ".github/**"
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -7,11 +7,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore: # Do not trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
     branches:
       - main
+    paths-ignore: # Do not trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -10,6 +10,7 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
+      - ".github/**"
   # Or when a pull request event occurs for a pull request against one of the
   # matched branches.
   pull_request:
@@ -18,6 +19,7 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
+      - ".github/**"
 
 # Cancel in-progress jobs on same branch.
 concurrency:

--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -12,7 +12,6 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
-      - ".github/**"
   workflow_dispatch:  # manual; for debugging workflow before merging branch into `main`
 
 jobs:

--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -1,10 +1,17 @@
-# NOTE: This name appears in GitHub's Checks API and in workflow's status badge.
-name: docker-nexus
+name: docker-nexus # This name appears in GitHub's Checks API and in workflow's status badge.
+
+# THIS WORKFLOW:
+#   Builds and pushes a Docker image at the current commit.
+#   This image is only offered for manual testing/debugging of a given PR/commit.
+#   It is not a dependency of any automated process.
 
 on:
   push:
     branches:
       - main
+    paths-ignore: # Do not trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
   workflow_dispatch:  # manual; for debugging workflow before merging branch into `main`
 
 jobs:

--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -12,6 +12,7 @@ on:
     paths-ignore: # Do not trigger if _only_ these files were changed.
       - .changelog/*.md
       - CHANGELOG.md
+      - ".github/**"
   workflow_dispatch:  # manual; for debugging workflow before merging branch into `main`
 
 jobs:

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,58 @@
+name: mock # This name appears in GitHub's Checks API and in workflow's status badge.
+
+# THIS WORKFLOW:
+#   Is special, and only a workaround for limitations in Github's CI config.
+#   When a PR touches only changelog .md files, most CI workflows do not run.
+#   However, our branch protection rules still require that the jobs in those
+#   workflows _pass_; them being skipped is not good enough for Github.
+#
+#   This workflow creates mock success statuses for all the jobs that would 
+#   otherwise run in regular CI workflows, and triggers exactly when the regular
+#   CI workflows don't.
+
+on:
+  # A push occurs to one of the matched branches.
+  push:
+    branches:
+      - main
+    paths: # Trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
+  # Or when a pull request event occurs for a pull request against one of the
+  # matched branches.
+  pull_request:
+    branches:
+      - main
+    paths: # Trigger if _only_ these files were changed.
+      - .changelog/*.md
+      - CHANGELOG.md
+
+jobs:
+  build-go:
+    name: build-go
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  lint-go:
+    name: lint-go
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  validate-openapi:
+    name: validate-openapi
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  validate-migrations:
+    name: validate-migrations
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  test-e2e-localnet:
+    name: test-e2e-localnet
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  test-e2e-regression-damask:
+    name: test-e2e-regression-damask
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]
+  test-e2e-regression-eden:
+    name: test-e2e-regression-eden
+    runs-on: ubuntu-20.04
+    steps: [{name: "fake success", run: "exit 0"}]


### PR DESCRIPTION
With the new release flow (#584), we cut every release by creating a special PR that assembles the changelog fragments.
This makes it so that that PR doesn't need to undergo full CI, allowing us to cut releases quickly if needed.

Testing: Ran CI with and without including `.github/**` in the ignore list.