### PR TITLE
analyzer/consensus: enumerate all tx body types

### DIFF
--- a/.changelog/661.bugfix.md
+++ b/.changelog/661.bugfix.md
@@ -1,0 +1,1 @@
+analyzer/consensus: add all known consensus tx body types; add serde helpers

--- a/analyzer/consensus/consensus_test.go
+++ b/analyzer/consensus/consensus_test.go
@@ -78,7 +78,7 @@ func TestMalformedTxBody(t *testing.T) {
 	parsed, err := unpackTxBody(&tx)
 	require.Nil(t, parsed)
 	require.NotNil(t, err)
-	require.Equal(t, "unable to cbor-decode consensus tx body: cbor: invalid additional information 30 for type tag, body: deadbeef", err.Error())
+	require.Equal(t, "unable to cbor-decode consensus tx body: cbor: invalid additional information 30 for type tag, method: staking.Allow, body: deadbeef", err.Error())
 }
 
 func TestMalformedTxMethod(t *testing.T) {
@@ -97,5 +97,5 @@ func TestMalformedTxMethod(t *testing.T) {
 	parsed, err := unpackTxBody(&tx)
 	require.Nil(t, parsed)
 	require.NotNil(t, err)
-	require.Equal(t, "unknown tx method: not_a_valid_method", err.Error())
+	require.Equal(t, "unable to cbor-decode consensus tx body: unknown tx method, method: not_a_valid_method, body: deadbeef", err.Error())
 }

--- a/analyzer/consensus/convert_tx.go
+++ b/analyzer/consensus/convert_tx.go
@@ -1,0 +1,115 @@
+// Package consensus implements an analyzer for the consensus layer.
+package consensus
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/entity"
+
+	beaconCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/beacon/api"
+	governanceCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/governance/api"
+	keymanagerCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/keymanager/api"
+	registryCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/registry/api"
+	roothashCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/roothash/api"
+	stakingCobalt "github.com/oasisprotocol/nexus/coreapi/v21.1.1/staking/api"
+
+	beacon "github.com/oasisprotocol/nexus/coreapi/v22.2.11/beacon/api"
+	"github.com/oasisprotocol/nexus/coreapi/v22.2.11/common/node"
+	governance "github.com/oasisprotocol/nexus/coreapi/v22.2.11/governance/api"
+	keymanager "github.com/oasisprotocol/nexus/coreapi/v22.2.11/keymanager/api"
+	registry "github.com/oasisprotocol/nexus/coreapi/v22.2.11/registry/api"
+	roothash "github.com/oasisprotocol/nexus/coreapi/v22.2.11/roothash/api"
+	staking "github.com/oasisprotocol/nexus/coreapi/v22.2.11/staking/api"
+
+	beaconEden "github.com/oasisprotocol/nexus/coreapi/v23.0/beacon/api"
+	consensusEden "github.com/oasisprotocol/nexus/coreapi/v23.0/consensus/api"
+	governanceEden "github.com/oasisprotocol/nexus/coreapi/v23.0/governance/api"
+	keymanagerEden "github.com/oasisprotocol/nexus/coreapi/v23.0/keymanager/api"
+	registryEden "github.com/oasisprotocol/nexus/coreapi/v23.0/registry/api"
+	roothashEden "github.com/oasisprotocol/nexus/coreapi/v23.0/roothash/api"
+	stakingEden "github.com/oasisprotocol/nexus/coreapi/v23.0/staking/api"
+)
+
+var bodyTypeForTxMethodCobalt = map[string]interface{}{
+	"beacon.PVSSCommit":                beaconCobalt.PVSSCommit{},
+	"beacon.PVSSReveal":                beaconCobalt.PVSSReveal{},
+	"governance.SubmitProposal":        governanceCobalt.ProposalContent{},
+	"governance.CastVote":              governanceCobalt.ProposalVote{},
+	"keymanager.UpdatePolicy":          keymanagerCobalt.SignedPolicySGX{},
+	"registry.RegisterEntity":          entity.SignedEntity{},  // We didn't vendor the entity Cobalt package because it's identical
+	"registry.RegisterNode":            node.MultiSignedNode{}, // We didn't vendor the node Cobalt package because it's identical
+	"registry.UnfreezeNode":            registryCobalt.UnfreezeNode{},
+	"registry.RegisterRuntime":         registryCobalt.Runtime{},
+	"roothash.ExecutorCommit":          roothashCobalt.ExecutorCommit{},
+	"roothash.ExecutorProposerTimeout": roothashCobalt.ExecutorProposerTimeoutRequest{},
+	"roothash.Evidence":                roothashCobalt.Evidence{},
+	"staking.Transfer":                 stakingCobalt.Transfer{},
+	"staking.Burn":                     stakingCobalt.Burn{},
+	"staking.AddEscrow":                stakingCobalt.Escrow{},
+	"staking.ReclaimEscrow":            stakingCobalt.ReclaimEscrow{},
+	"staking.AmendCommissionSchedule":  stakingCobalt.AmendCommissionSchedule{},
+	"staking.Allow":                    stakingCobalt.Allow{},
+	"staking.Withdraw":                 stakingCobalt.Withdraw{},
+}
+
+var bodyTypeForTxMethodDamask = map[string]interface{}{
+	"beacon.VRFProve":                  beacon.VRFProve{},
+	"governance.SubmitProposal":        governance.ProposalContent{},
+	"governance.CastVote":              governance.ProposalVote{},
+	"keymanager.UpdatePolicy":          keymanager.SignedPolicySGX{},
+	"registry.RegisterEntity":          entity.SignedEntity{}, // We didn't vendor the entityDamask package because it's identical
+	"registry.DeregisterEntity":        registry.DeregisterEntity{},
+	"registry.RegisterNode":            node.MultiSignedNode{}, // We didn't vendor the node Damask package because it's identical
+	"registry.UnfreezeNode":            registry.UnfreezeNode{},
+	"registry.RegisterRuntime":         registry.Runtime{},
+	"registry.ProveFreshness":          registry.Runtime{}, // not sure when the proveFreshness tx body changed; so we keep the old one here.
+	"roothash.ExecutorCommit":          roothash.ExecutorCommit{},
+	"roothash.ExecutorProposerTimeout": roothash.ExecutorProposerTimeoutRequest{},
+	"roothash.Evidence":                roothash.Evidence{},
+	"roothash.SubmitMsg":               roothash.SubmitMsg{},
+	"staking.Transfer":                 staking.Transfer{},
+	"staking.Burn":                     staking.Burn{},
+	"staking.AddEscrow":                staking.Escrow{},
+	"staking.ReclaimEscrow":            staking.ReclaimEscrow{},
+	"staking.AmendCommissionSchedule":  staking.AmendCommissionSchedule{},
+	"staking.Allow":                    staking.Allow{},
+	"staking.Withdraw":                 staking.Withdraw{},
+}
+
+var bodyTypeForTxMethodEden = map[string]interface{}{
+	"beacon.VRFProve":                   beaconEden.VRFProve{},
+	"consensus.Meta":                    consensusEden.BlockMetadata{},
+	"governance.SubmitProposal":         governanceEden.ProposalContent{},
+	"governance.CastVote":               governanceEden.ProposalVote{},
+	"keymanager.PublishMasterSecret":    keymanagerEden.SignedEncryptedMasterSecret{},
+	"keymanager.PublishEphemeralSecret": keymanagerEden.SignedEncryptedEphemeralSecret{},
+	"keymanager.UpdatePolicy":           keymanagerEden.SignedPolicySGX{},
+	"registry.RegisterEntity":           entity.SignedEntity{},
+	"registry.DeregisterEntity":         registryEden.DeregisterEntity{},
+	"registry.RegisterNode":             node.MultiSignedNode{},
+	"registry.UnfreezeNode":             registryEden.UnfreezeNode{},
+	"registry.RegisterRuntime":          registryEden.Runtime{},
+	"registry.ProveFreshness":           freshnessProofEden{},
+	"roothash.ExecutorCommit":           roothashEden.ExecutorCommit{},
+	"roothash.Evidence":                 roothashEden.Evidence{},
+	"roothash.SubmitMsg":                roothashEden.SubmitMsg{},
+	"staking.Transfer":                  stakingEden.Transfer{},
+	"staking.Burn":                      stakingEden.Burn{},
+	"staking.AddEscrow":                 stakingEden.Escrow{},
+	"staking.ReclaimEscrow":             stakingEden.ReclaimEscrow{},
+	"staking.AmendCommissionSchedule":   stakingEden.AmendCommissionSchedule{},
+	"staking.Allow":                     stakingEden.Allow{},
+	"staking.Withdraw":                  stakingEden.Withdraw{},
+}
+
+type freshnessProofEden struct {
+	Blob []byte `json:"blob"`
+}
+
+func (f *freshnessProofEden) UnmarshalCBOR(data []byte) error {
+	var blob []byte
+	if err := cbor.Unmarshal(data, &blob); err != nil {
+		return err
+	}
+	f.Blob = blob
+	return nil
+}

--- a/coreapi/v23.0/keymanager/api/secret.go
+++ b/coreapi/v23.0/keymanager/api/secret.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/oasisprotocol/curve25519-voi/primitives/x25519"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -29,6 +32,22 @@ type EncryptedSecret struct {
 
 	// Ciphertexts is the map of REK encrypted secrets.
 	Ciphertexts map[x25519.PublicKey][]byte `json:"ciphertexts"`
+}
+
+// XXX: Nexus-specific addition/hack.
+// We implement MarshalJSON here because the the encoding/json library
+// does not recognize the x25519.PublicKey type as a valid map key.
+func (es *EncryptedSecret) MarshalJSON() ([]byte, error) {
+	ciphertexts := make(map[string][]byte)
+	for pubkey, ciphertext := range es.Ciphertexts {
+		ciphertexts[base64.StdEncoding.EncodeToString(pubkey[:])] = ciphertext
+	}
+	esJSON := make(map[string]interface{})
+	esJSON["checksum"] = es.Checksum
+	esJSON["pub_key"] = es.PubKey
+	esJSON["ciphertexts"] = ciphertexts
+
+	return json.Marshal(esJSON)
 }
 
 // SanityCheck performs a sanity check on the encrypted secret.


### PR DESCRIPTION
@mitjat reported that the testnet deployment was generating lots of error logs about being unable to cbor-decode the consensus tx body. Further investigation revealed that there was a change to the `roothash.ExecutorCommit.Commits.Header` struct between damask/eden that was not backwards-compatible but this change slipped through the cracks in #655 . 

The first commit of this PR fixes the known problem. The second commit adds adds all the types just in case. It's verbose but might be easier to maintain in the future.

Todo: test on production testnet [x] also production mainnet [x]

Todo: investigate why it didn't fail on the eden test range, which should have used the latest eden type of roothash.ExecutorCommit edit*: our eden test range doesn't have any of that type of tx