### PR TITLE
Tweak ci-lint workflow

### DIFF
--- a/.changelog/662.process.md
+++ b/.changelog/662.process.md
@@ -1,0 +1,6 @@
+Tweak ci-lint workflow
+
+- limit towncrier check to pull_request event to fix an issue with failing
+  workflow for merge commits triggered by push event
+- enable gitlint
+- prevent dependabot issues related to gitlint and towncrier checks

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -54,6 +54,9 @@ jobs:
           towncrier check --compare-with origin/${BASE_BRANCH}
         env:
           BASE_BRANCH: ${{ github.base_ref }}
+        if: |
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]'
       - name: Lint Change Log fragments
         run: |
           make lint-changelog

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -39,6 +39,9 @@ jobs:
         with:
           python-version: '3.x'
         # Needed for Towncrier fork to work with 3.12 and above
+      - name: Install gitlint
+        run: |
+          python -m pip install gitlint
       - name: Install setuptools
         run: |
           python -m pip install setuptools
@@ -57,6 +60,11 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.actor != 'dependabot[bot]'
+      - name: Lint git commits
+        run: |
+          make lint-git
+        # Always run this step so that all linting errors can be seen at once, but skip for dependabot
+        if: always() && github.actor != 'dependabot[bot]'
       - name: Lint Change Log fragments
         run: |
           make lint-changelog

--- a/Makefile
+++ b/Makefile
@@ -128,12 +128,15 @@ fmt:
 	@goimports -w -local github.com/oasisprotocol/nexus .
 
 # Lint code, commits and documentation.
-lint-targets := lint-go lint-go-mod-tidy lint-changelog
+lint-targets := lint-go lint-go-mod-tidy lint-changelog lint-git
 
 lint-go: codegen-go
 	@$(ECHO) "$(CYAN)*** Running Go linters...$(OFF)"
 	@env -u GOPATH golangci-lint run
 
+lint-git:
+	@$(CHECK_GITLINT)
+	
 lint-changelog:
 	@$(CHECK_CHANGELOG_FRAGMENTS)
 


### PR DESCRIPTION
- prevent issues with dependabot PRs
- limit towncrier check to pull_request event to fix an issue with failing workflow for merge commits (push event)
- enable gitlint