### PR TITLE
tests: restructure e2e_regression

### DIFF
--- a/.changelog/665.internal.md
+++ b/.changelog/665.internal.md
@@ -1,0 +1,1 @@
+tests: restructure e2e_regression

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -156,7 +156,7 @@ jobs:
           make postgres
       - name: Run e2e regression tests
         run : |
-          make test-e2e-regression-eden
+          make E2E_REGRESSION_SUITES=eden test-e2e-regression
       - uses: actions/upload-artifact@v3
         with:
           name: Actual nexus api responses
@@ -187,7 +187,7 @@ jobs:
           make postgres
       - name: Run e2e regression tests
         run : |
-          make test-e2e-regression-damask
+          make E2E_REGRESSION_SUITES=damask test-e2e-regression
       - uses: actions/upload-artifact@v3
         with:
           name: Actual nexus api responses

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ensure-consistent-config-for-e2e-regression:
 # Run the api tests locally, assuming the environment is set up with an oasis-node that is
 # accessible as specified in the config file.
 test-e2e-regression: nexus ensure-consistent-config-for-e2e-regression
-	for suite in $(e2e_regression_suites); do ./tests/e2e_regression/run.sh $$suite; done
+	for suite in $(e2e_regression_suites); do ./tests/e2e_regression/run.sh -a $$suite; done
 
 # Accept the outputs of the e2e tests as the new expected outputs.
 accept-e2e-regression:

--- a/Makefile
+++ b/Makefile
@@ -60,19 +60,21 @@ test-e2e: export OASIS_INDEXER_E2E = true
 test-e2e:
 	@$(GO) test -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -v ./tests/e2e
 
-e2e_regression_suites := eden damask
+# To run specific suites, do e.g.
+# make E2E_REGRESSION_SUITES='suite1 suite2' test-e2e-regression
+E2E_REGRESSION_SUITES := eden damask
 
 ensure-consistent-config-for-e2e-regression:
-	for suite in $(e2e_regression_suites); do ./tests/e2e_regression/ensure_consistent_config.sh $$suite; done
+	for suite in $(E2E_REGRESSION_SUITES); do ./tests/e2e_regression/ensure_consistent_config.sh $$suite; done
 
 # Run the api tests locally, assuming the environment is set up with an oasis-node that is
 # accessible as specified in the config file.
 test-e2e-regression: nexus ensure-consistent-config-for-e2e-regression
-	for suite in $(e2e_regression_suites); do ./tests/e2e_regression/run.sh -a $$suite; done
+	for suite in $(E2E_REGRESSION_SUITES); do ./tests/e2e_regression/run.sh -a $$suite; done
 
 # Accept the outputs of the e2e tests as the new expected outputs.
 accept-e2e-regression:
-	for suite in $(e2e_regression_suites); do ./tests/e2e_regression/accept.sh $$suite; done
+	for suite in $(E2E_REGRESSION_SUITES); do ./tests/e2e_regression/accept.sh $$suite; done
 
 # Format code.
 fmt:

--- a/tests/e2e_regression/accept.sh
+++ b/tests/e2e_regression/accept.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+E2E_REGRESSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# Read arg
+suite="${1:-}"
+TEST_DIR="$E2E_REGRESSION_DIR/$suite"
+if [[ -z "$suite" || ! -e "$TEST_DIR/e2e_config_1.yml" ]]; then
+  echo >&2 "Usage: $0 <suite>"
+  exit 1
+fi
+
+[[ -d "$TEST_DIR/actual" ]] || {
+  echo "Note: No actual outputs found for suite $suite. Nothing to accept."
+  exit 0
+}
+# Delete all old expected files first, in case any test cases were renamed or removed.
+rm -rf "$TEST_DIR/expected"
+# Copy the actual outputs to the expected outputs.
+cp -r  "$TEST_DIR/"{actual,expected}
+# The result of the "spec" test is a special case. It should always match the
+# current openAPI spec file, so we symlink it to avoid having to update the expected
+# output every time the spec changes.
+rm -f "$TEST_DIR/expected/spec.body"
+ln -s  ../../../../api/spec/v1.yaml "$TEST_DIR/expected/spec.body"

--- a/tests/e2e_regression/common_test_cases.sh
+++ b/tests/e2e_regression/common_test_cases.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This file holds the test cases for the e2e_regression tests defined in run.sh. Tests
-# are grouped into suites, which often overlap.
+# This file holds common test cases for the e2e_regression tests.
 #
 # Each test case is a pair of (name, SQL query or URL).
 # For SQL queries, the regression-tested output is the result of the query against the indexer DB.
@@ -75,41 +74,4 @@ commonTestCases=(
   'emerald_contract_account       /v1/emerald/accounts/oasis1qz2rynvcmrkwd57v00298uc2vtzgatde3cjpy72f'
   'emerald_status                 /v1/emerald/status'
   'emerald_tx_volume              /v1/emerald/stats/tx_volume'
-)
-
-edenTestCases=(
-  "${commonTestCases[@]}"
-  'block                          /v1/consensus/blocks/16818000'
-  'entity                         /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
-  'entity_nodes                   /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes'
-  'node                           /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/6wbL5%2fOxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA='
-  'bad_node                       /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/NOTANODE'
-  'epoch                          /v1/consensus/epochs/28017'
-  'tx                             /v1/consensus/transactions/142d43e5194b738ab2223f8d0b42326fab06edd714a8cefc59a078b89b5de057'
-  'validator                      /v1/consensus/validators/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
-  'emerald_tx                     /v1/emerald/transactions/ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d'
-  'emerald_failed_tx              /v1/emerald/transactions/35fdc8261dd81be8187c858aa9a623085494baf0565d414f48562a856147c093'
-  'emerald_events_by_nft          /v1/emerald/events?contract_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx&nft_id=1'
-  'emerald_token_nfts             /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts'
-  'emerald_token_nft              /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts/2'
-  'emerald_account_nfts           /v1/emerald/accounts/oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l/nfts'
-  'emerald_account_nfts_token     /v1/emerald/accounts/oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l/nfts?token_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx'
-)
-
-damaskTestCases=(
-  "${commonTestCases[@]}"
-  'block                          /v1/consensus/blocks/8049500'
-  'entity                         /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As='
-  'entity_nodes                   /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes'
-  'node                           /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/LuIdtuiEPLBJefXVieVruy4kf04jjp5CBJFWVes0ZuE='
-  'bad_node                       /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/NOTANODE'
-  'epoch                          /v1/consensus/epochs/13403'
-  'tx                             /v1/consensus/transactions/f7a03e0912d355901ee794e5fec79a6b4c91363fc27d953596ee6de5c1492798'
-  'validator                      /v1/consensus/validators/HPeLbzc88IoYEP0TC4nqSxfxdPCPjduLeJqFvmxFye8='
-  'emerald_tx                     /v1/emerald/transactions/a6471a9c6f3307087586da9156f3c9876fbbaf4b23910cd9a2ac524a54d0aefe'
-  'emerald_failed_tx              /v1/emerald/transactions/a7e76442c52a3cb81f719bde26c9a6179bd3415f96740d91a93ee8f205b45150'
-  'emerald_token_nfts             /v1/emerald/evm_tokens/oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u/nfts'
-  'emerald_token_nft              /v1/emerald/evm_tokens/oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u/nfts/227'
-  'emerald_account_nfts           /v1/emerald/accounts/oasis1qq92lk7kpqmvllhjvhlc282zp6v2e2t2rqrwuq2u/nfts'
-  'emerald_account_nfts_token     /v1/emerald/accounts/oasis1qq92lk7kpqmvllhjvhlc282zp6v2e2t2rqrwuq2u/nfts?token_address=oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u'
 )

--- a/tests/e2e_regression/damask/test_cases.sh
+++ b/tests/e2e_regression/damask/test_cases.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This file holds the test cases for the e2e_regression tests.
+#
+# Each test case is a pair of (name, SQL query or URL).
+# For SQL queries, the regression-tested output is the result of the query against the indexer DB.
+# For URLs, the regression-tested output is the full HTTP response.
+
+source "$E2E_REGRESSION_DIR/common_test_cases.sh"
+
+testCases=(
+  "${commonTestCases[@]}"
+  'block                          /v1/consensus/blocks/8049500'
+  'entity                         /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As='
+  'entity_nodes                   /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes'
+  'node                           /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/LuIdtuiEPLBJefXVieVruy4kf04jjp5CBJFWVes0ZuE='
+  'bad_node                       /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/NOTANODE'
+  'epoch                          /v1/consensus/epochs/13403'
+  'tx                             /v1/consensus/transactions/f7a03e0912d355901ee794e5fec79a6b4c91363fc27d953596ee6de5c1492798'
+  'validator                      /v1/consensus/validators/HPeLbzc88IoYEP0TC4nqSxfxdPCPjduLeJqFvmxFye8='
+  'emerald_tx                     /v1/emerald/transactions/a6471a9c6f3307087586da9156f3c9876fbbaf4b23910cd9a2ac524a54d0aefe'
+  'emerald_failed_tx              /v1/emerald/transactions/a7e76442c52a3cb81f719bde26c9a6179bd3415f96740d91a93ee8f205b45150'
+  'emerald_token_nfts             /v1/emerald/evm_tokens/oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u/nfts'
+  'emerald_token_nft              /v1/emerald/evm_tokens/oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u/nfts/227'
+  'emerald_account_nfts           /v1/emerald/accounts/oasis1qq92lk7kpqmvllhjvhlc282zp6v2e2t2rqrwuq2u/nfts'
+  'emerald_account_nfts_token     /v1/emerald/accounts/oasis1qq92lk7kpqmvllhjvhlc282zp6v2e2t2rqrwuq2u/nfts?token_address=oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u'
+)

--- a/tests/e2e_regression/eden/test_cases.sh
+++ b/tests/e2e_regression/eden/test_cases.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This file holds the test cases for the e2e_regression tests.
+#
+# Each test case is a pair of (name, SQL query or URL).
+# For SQL queries, the regression-tested output is the result of the query against the indexer DB.
+# For URLs, the regression-tested output is the full HTTP response.
+
+source "$E2E_REGRESSION_DIR/common_test_cases.sh"
+
+testCases=(
+  "${commonTestCases[@]}"
+  'block                          /v1/consensus/blocks/16818000'
+  'entity                         /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
+  'entity_nodes                   /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes'
+  'node                           /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/6wbL5%2fOxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA='
+  'bad_node                       /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/NOTANODE'
+  'epoch                          /v1/consensus/epochs/28017'
+  'tx                             /v1/consensus/transactions/142d43e5194b738ab2223f8d0b42326fab06edd714a8cefc59a078b89b5de057'
+  'validator                      /v1/consensus/validators/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
+  'emerald_tx                     /v1/emerald/transactions/ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d'
+  'emerald_failed_tx              /v1/emerald/transactions/35fdc8261dd81be8187c858aa9a623085494baf0565d414f48562a856147c093'
+  'emerald_events_by_nft          /v1/emerald/events?contract_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx&nft_id=1'
+  'emerald_token_nfts             /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts'
+  'emerald_token_nft              /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts/2'
+  'emerald_account_nfts           /v1/emerald/accounts/oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l/nfts'
+  'emerald_account_nfts_token     /v1/emerald/accounts/oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l/nfts?token_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx'
+)

--- a/tests/e2e_regression/ensure_consistent_config.sh
+++ b/tests/e2e_regression/ensure_consistent_config.sh
@@ -18,9 +18,17 @@ shopt -s expand_aliases
 # A converter whose only dependency is python3, which is likely preinstalled
 alias yaml2json="python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))'" 
 
+E2E_REGRESSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# Read arg
+suite="${1:-}"
+TEST_DIR="$E2E_REGRESSION_DIR/$suite"
+if [[ -z "$suite" || ! -e "$TEST_DIR/e2e_config_1.yml" ]]; then
+  echo >&2 "Usage: $0 <suite>"
+  exit 1
+fi
+
 # Compare
-for range in $(find "$directory" -type d); do
-    cat "${range}/e2e_config_1.yml" | yaml2json | jq "$important_attrs" > /tmp/e2e_config_1.summary
-    cat "${range}/e2e_config_2.yml" | yaml2json | jq "$important_attrs" > /tmp/e2e_config_2.summary
-    diff /tmp/e2e_config_1.summary /tmp/e2e_config_2.summary || { echo "The two config files for e2e tests differ in key parameters! See diff above."; exit 1; }
-done
+cat "$TEST_DIR/e2e_config_1.yml" | yaml2json | jq "$important_attrs" > /tmp/e2e_config_1.summary
+cat "$TEST_DIR/e2e_config_2.yml" | yaml2json | jq "$important_attrs" > /tmp/e2e_config_2.summary
+diff /tmp/e2e_config_1.summary /tmp/e2e_config_2.summary || { echo "The two config files for e2e tests differ in key parameters! See diff above."; exit 1; }

--- a/tests/e2e_regression/run.sh
+++ b/tests/e2e_regression/run.sh
@@ -2,9 +2,11 @@
 
 # This script is a simple e2e regression test for Nexus.
 #
-# It runs
-#  - a fixed set of URLs against the HTTP API
-#  - a fixed set of SQL queries against the DB
+# It takes the name of a test suite, and
+#  - builds nexus (if -b is given) and indexes (if -a is given) the block
+#    range defined by the suite
+#  - runs a fixed set of URLs against the HTTP API
+#  - runs a fixed set of SQL queries against the DB
 # and saves the responses to files, then check that the responses match
 # the expected outputs (from a previous run).
 #


### PR DESCRIPTION
- run.sh now runs the analysis too. no replacement for compare only, run the whole test instead
- there's no longer a separate "fill cache" target. no replacement, run the whole test instead
- there are no longer separate makefile targets for individual suites. instead run `tests/e2e_regression/run.sh <suite>`
- there are no longer separate makefile targets for accepting individual suites. run `tests/e2e_regression/accept.sh <suite>`
- each suite now has its own test_cases.sh. they source a shared common_test_cases.sh with the overlapping tests
- the symlink-dereferenced "expected" output copy is now scoped by suite name
- CI mistakenly git-diff'd against the non-symlink-dereferenced "expected" output. the code around here is restructured to prevent the two `git diff` invocations from diverging
- run.sh no longer builds nexus. this should be fine, as the test-e2e-regression target depends on the nexus target
- ensure_consistent_config.sh now only runs for one suite at a time. use the new ensure-consistent-config-for-e2e-regression target to run it on all suites

the goal for most changes is to reduce the tasks for starting a new suite as close as possible to copying an existing suite's directory. the additional changes are:
1. add the new suite name to the makefile's `e2e_regression_suites` list
2. add a job for it in ci-test