### PR TITLE
analyzer/consensus: Skip nonexistent mainnet block 8048955

### DIFF
--- a/.changelog/677.bugfix.1.md
+++ b/.changelog/677.bugfix.1.md
@@ -1,0 +1,4 @@
+analyzer/consensus: Skip nonexistent mainnet block 8048955
+
+Nexus can now reindex the whole range of blocks without getting stuck on this
+block.

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -303,7 +303,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return consensus.NewAnalyzer(cfg.Source.ChainName, *fastRange, cfg.Analyzers.Consensus.BatchSize, analyzer.FastSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
+					return consensus.NewAnalyzer(*fastRange, cfg.Analyzers.Consensus.BatchSize, analyzer.FastSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
 				})
 			}
 		}
@@ -340,7 +340,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return consensus.NewAnalyzer(cfg.Source.ChainName, cfg.Analyzers.Consensus.SlowSyncRange(), cfg.Analyzers.Consensus.BatchSize, analyzer.SlowSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
+			return consensus.NewAnalyzer(cfg.Analyzers.Consensus.SlowSyncRange(), cfg.Analyzers.Consensus.BatchSize, analyzer.SlowSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -303,7 +303,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return consensus.NewAnalyzer(*fastRange, cfg.Analyzers.Consensus.BatchSize, analyzer.FastSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
+					return consensus.NewAnalyzer(cfg.Source.ChainName, *fastRange, cfg.Analyzers.Consensus.BatchSize, analyzer.FastSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
 				})
 			}
 		}
@@ -340,7 +340,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return consensus.NewAnalyzer(cfg.Analyzers.Consensus.SlowSyncRange(), cfg.Analyzers.Consensus.BatchSize, analyzer.SlowSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
+			return consensus.NewAnalyzer(cfg.Source.ChainName, cfg.Analyzers.Consensus.SlowSyncRange(), cfg.Analyzers.Consensus.BatchSize, analyzer.SlowSyncMode, *cfg.Source.History(), sourceClient, *cfg.Source.SDKNetwork(), dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {

--- a/config/history.go
+++ b/config/history.go
@@ -23,7 +23,8 @@ type Record struct {
 }
 
 type History struct {
-	Records []*Record `koanf:"records"`
+	Records       []*Record           `koanf:"records"`
+	MissingBlocks map[uint64]struct{} `koanf:"missing_blocks"`
 }
 
 func (h *History) CurrentRecord() *Record {
@@ -82,6 +83,8 @@ func (h *History) RecordForRuntimeRound(runtime common.Runtime, round uint64) (*
 
 var DefaultChains = map[common.ChainName]*History{
 	common.ChainNameMainnet: {
+		// Block does not exist due to mishap during upgrade to Damask.
+		MissingBlocks: map[uint64]struct{}{8048955: {}},
 		Records: []*Record{
 			{
 				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2023-11-29
@@ -135,6 +138,7 @@ var DefaultChains = map[common.ChainName]*History{
 		},
 	},
 	common.ChainNameTestnet: {
+		MissingBlocks: map[uint64]struct{}{},
 		Records: []*Record{
 			{
 				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2023-10-12


### PR DESCRIPTION
On Oasis mainnet, consensus block 8048955 does not exist: 8048954 is the last block of Cobalt, and 8048956 is the first block of Damask. This was an unintended side effect of the dump-restore Damask upgrade.

Nexus was unaware of this, and would get stuck on that block when reindexing the entire history. The only way to "unstick" it was (small) manual DB surgery. This PR hardcodes the block as an exception, and makes Nexus skip it.

**Testing:**
One-off manual test. Ran mainnet analysis with the following config:
```yaml
    consensus:
      from: 8_048_946  # Damask genesis was at 8_048_956; probe slightly into Cobalt
      to:   8_048_966
```
and verified that blocks are analyzed as expected.