### PR TITLE
analyzer/runtime: limit total_{received,sent} to native denomination

### DIFF
--- a/.changelog/679.bugfix.1.md
+++ b/.changelog/679.bugfix.1.md
@@ -1,0 +1,5 @@
+analyzer/runtime: limit total\_{received,sent} to native denomination
+
+Previously, those metrics tracked the sum of all SDK denominations. This bug
+did not impact Sapphire, Emerald, or Cipher; they each only have one SDK
+denomination, i.e. the native one.

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -477,11 +477,12 @@ var (
     ON CONFLICT (runtime, address) DO UPDATE
       SET total_received = accounts.total_received + $3`
 
+	// $3 should be the symbol of the _native_ token.
 	RuntimeAccountTotalReceivedRecompute = `
     WITH agg AS (
       SELECT runtime, receiver, sum(amount) AS total_received
       FROM chain.runtime_transfers
-      WHERE runtime = $1::runtime AND round <= $2::bigint AND receiver IS NOT NULL
+      WHERE runtime = $1::runtime AND round <= $2::bigint AND receiver IS NOT NULL AND symbol = $3
       GROUP BY 1, 2
     )
     INSERT INTO chain.runtime_accounts as accts (runtime, address, total_received)

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -61,12 +61,14 @@ func (m *processor) queueMint(batch *storage.QueryBatch, round uint64, e account
 			m.StringifyDenomination(e.Amount.Denomination),
 			e.Amount.Amount.String(),
 		)
-		batch.Queue(
-			queries.RuntimeAccountTotalReceivedUpsert,
-			m.runtime,
-			e.Owner.String(),
-			e.Amount.Amount.String(),
-		)
+		if e.Amount.Denomination.IsNative() {
+			batch.Queue(
+				queries.RuntimeAccountTotalReceivedUpsert,
+				m.runtime,
+				e.Owner.String(),
+				e.Amount.Amount.String(),
+			)
+		}
 	}
 }
 
@@ -89,12 +91,14 @@ func (m *processor) queueBurn(batch *storage.QueryBatch, round uint64, e account
 			m.StringifyDenomination(e.Amount.Denomination),
 			(&big.Int{}).Neg(e.Amount.Amount.ToBigInt()).String(),
 		)
-		batch.Queue(
-			queries.RuntimeAccountTotalSentUpsert,
-			m.runtime,
-			e.Owner.String(),
-			e.Amount.Amount.String(),
-		)
+		if e.Amount.Denomination.IsNative() {
+			batch.Queue(
+				queries.RuntimeAccountTotalSentUpsert,
+				m.runtime,
+				e.Owner.String(),
+				e.Amount.Amount.String(),
+			)
+		}
 	}
 }
 

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -152,7 +152,7 @@ func (m *processor) FinalizeFastSync(ctx context.Context, lastFastSyncHeight int
 	batch.Queue(queries.RuntimeAccountTotalSentRecompute, m.runtime, lastFastSyncHeight)
 
 	m.logger.Info("recomputing total_received for every account")
-	batch.Queue(queries.RuntimeAccountTotalReceivedRecompute, m.runtime, lastFastSyncHeight)
+	batch.Queue(queries.RuntimeAccountTotalReceivedRecompute, m.runtime, lastFastSyncHeight, m.nativeTokenSymbol())
 
 	m.logger.Info("recomputing gas_for_calling for every contract")
 	batch.Queue(queries.RuntimeAccountGasForCallingRecompute, m.runtime, lastFastSyncHeight)

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2841,10 +2841,10 @@ components:
       properties:
         total_sent:
           allOf: [$ref: '#/components/schemas/TextBigInt']
-          description: The total number of tokens sent, in base units.
+          description: The total amount of native tokens sent, in base units.
         total_received:
           allOf: [$ref: '#/components/schemas/TextBigInt']
-          description: The total number of tokens received, in base units.
+          description: The total amount of native tokens received, in base units.
         num_txns:
           description: The total number of transactions this account was involved with.
           type: integer

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -14,7 +14,7 @@ staged_fragments="$(git diff --cached --name-only -- .changelog/*.md)"
 # Re-wraps file $1 to 80 characters per line, using prettier, in-place.
 rewrap() {
   # Suppress the output of prettier, as it's overly verbose. Show only on errors.
-  prettier --no-config --no-editorconfig --prose-wrap always --print-width 80 --write "$f" >/tmp/prettier.out \
+  prettier --no-config --no-editorconfig --prose-wrap always --print-width 78 --write "$f" >/tmp/prettier.out \
     || { cat /tmp/prettier.out; exit 1; }
 }
 


### PR DESCRIPTION
pontusx is the first runtime where this makes a difference because it uses two separate SDK denominations. Before this PR, their stats got conflated in the total_received and total_sent metrics (i.e. the metric was a sum of the two SDK tokens, EUROe and TEST).

This PR is a no-op for other existing runtimes because the only SDK denomination they use is the native denomination.