### PR TITLE
analyzer: move some uncategorized code into new packages

### DIFF
--- a/.changelog/681.internal.md
+++ b/.changelog/681.internal.md
@@ -1,0 +1,1 @@
+analyzer: move some uncategorized code into new packages

--- a/analyzer/evmverifier/evmverifier.go
+++ b/analyzer/evmverifier/evmverifier.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oasisprotocol/nexus/analyzer/evmverifier/sourcify"
 	"github.com/oasisprotocol/nexus/analyzer/item"
 	"github.com/oasisprotocol/nexus/analyzer/queries"
-	uncategorized "github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	"github.com/oasisprotocol/nexus/analyzer/util/addresses"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/config"
 	"github.com/oasisprotocol/nexus/log"
@@ -137,7 +137,7 @@ func (p *processor) GetItems(ctx context.Context, limit uint64) ([]contract, err
 	// Find contracts that are verified in Sourcify and not yet verified in Nexus.
 	var items []contract
 	for ethAddr, sourcifyLevel := range sourcifyLevels {
-		oasisAddr, err := uncategorized.StringifyEthAddress(ethAddr.Bytes())
+		oasisAddr, err := addresses.FromEthAddress(ethAddr.Bytes())
 		if err != nil {
 			p.logger.Warn("failed to stringify eth address from sourcify", "err", err, "eth_address", ethAddr)
 			continue

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -29,6 +29,7 @@ import (
 	evm "github.com/oasisprotocol/nexus/analyzer/runtime/evm"
 	uncategorized "github.com/oasisprotocol/nexus/analyzer/uncategorized"
 	"github.com/oasisprotocol/nexus/analyzer/util"
+	"github.com/oasisprotocol/nexus/analyzer/util/addresses"
 	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
@@ -196,7 +197,7 @@ func extractAddressPreimage(as *sdkTypes.AddressSpec) (*AddressPreimageData, err
 }
 
 func registerAddressSpec(addressPreimages map[apiTypes.Address]*AddressPreimageData, as *sdkTypes.AddressSpec) (apiTypes.Address, error) {
-	addr, err := uncategorized.StringifyAddressSpec(as)
+	addr, err := addresses.FromAddressSpec(as)
 	if err != nil {
 		return "", err
 	}
@@ -213,7 +214,7 @@ func registerAddressSpec(addressPreimages map[apiTypes.Address]*AddressPreimageD
 }
 
 func registerEthAddress(addressPreimages map[apiTypes.Address]*AddressPreimageData, ethAddr []byte) (apiTypes.Address, error) {
-	addr, err := uncategorized.StringifyEthAddress(ethAddr)
+	addr, err := addresses.FromEthAddress(ethAddr)
 	if err != nil {
 		return "", err
 	}
@@ -230,7 +231,7 @@ func registerEthAddress(addressPreimages map[apiTypes.Address]*AddressPreimageDa
 }
 
 func registerRelatedSdkAddress(relatedAddresses map[apiTypes.Address]bool, sdkAddr *sdkTypes.Address) (apiTypes.Address, error) {
-	addr, err := uncategorized.StringifySdkAddress(sdkAddr)
+	addr, err := addresses.FromSdkAddress(sdkAddr)
 	if err != nil {
 		return "", err
 	}
@@ -413,7 +414,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					amount = body.Amount.Amount
 					if body.To != nil {
 						// This is the address of an account in the consensus layer only; we do not register it as a preimage.
-						if to, err = uncategorized.StringifySdkAddress(body.To); err != nil {
+						if to, err = addresses.FromSdkAddress(body.To); err != nil {
 							return fmt.Errorf("to: %w", err)
 						}
 					} else {
@@ -450,7 +451,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					blockTransactionData.Body = body
 					amount = body.Amount.Amount
 					// This is the address of an account in the consensus layer only; we do not register it as a preimage.
-					if to, err = uncategorized.StringifySdkAddress(&body.To); err != nil {
+					if to, err = addresses.FromSdkAddress(&body.To); err != nil {
 						return fmt.Errorf("to: %w", err)
 					}
 					blockTransactionData.RelatedAccountAddresses[to] = true

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -29,6 +29,7 @@ import (
 	uncategorized "github.com/oasisprotocol/nexus/analyzer/uncategorized"
 	"github.com/oasisprotocol/nexus/analyzer/util"
 	"github.com/oasisprotocol/nexus/analyzer/util/addresses"
+	"github.com/oasisprotocol/nexus/analyzer/util/eth"
 	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/log"
@@ -223,7 +224,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 		blockTransactionData.Index = txIndex
 		blockTransactionData.Hash = txr.Tx.Hash().Hex()
 		if len(txr.Tx.AuthProofs) == 1 && txr.Tx.AuthProofs[0].Module == "evm.ethereum.v0" {
-			ethHash := hex.EncodeToString(uncategorized.Keccak256(txr.Tx.Body))
+			ethHash := hex.EncodeToString(eth.Keccak256(txr.Tx.Body))
 			blockTransactionData.EthHash = &ethHash
 		}
 		blockTransactionData.Raw = cbor.Marshal(txr.Tx)
@@ -779,8 +780,8 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 			}
 			if err1 = VisitEVMEvent(event, &EVMEventHandler{
 				ERC20Transfer: func(fromECAddr ethCommon.Address, toECAddr ethCommon.Address, value *big.Int) error {
-					fromZero := bytes.Equal(fromECAddr.Bytes(), uncategorized.ZeroEthAddr)
-					toZero := bytes.Equal(toECAddr.Bytes(), uncategorized.ZeroEthAddr)
+					fromZero := bytes.Equal(fromECAddr.Bytes(), eth.ZeroEthAddr)
+					toZero := bytes.Equal(toECAddr.Bytes(), eth.ZeroEthAddr)
 					if !fromZero {
 						fromAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, fromECAddr.Bytes())
 						if err2 != nil {
@@ -833,14 +834,14 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					return nil
 				},
 				ERC20Approval: func(ownerECAddr ethCommon.Address, spenderECAddr ethCommon.Address, value *big.Int) error {
-					if !bytes.Equal(ownerECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(ownerECAddr.Bytes(), eth.ZeroEthAddr) {
 						ownerAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, ownerECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("owner: %w", err2)
 						}
 						eventData.RelatedAddresses[ownerAddr] = struct{}{}
 					}
-					if !bytes.Equal(spenderECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(spenderECAddr.Bytes(), eth.ZeroEthAddr) {
 						spenderAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, spenderECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("spender: %w", err2)
@@ -874,8 +875,8 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					return nil
 				},
 				ERC721Transfer: func(fromECAddr ethCommon.Address, toECAddr ethCommon.Address, tokenID *big.Int) error {
-					fromZero := bytes.Equal(fromECAddr.Bytes(), uncategorized.ZeroEthAddr)
-					toZero := bytes.Equal(toECAddr.Bytes(), uncategorized.ZeroEthAddr)
+					fromZero := bytes.Equal(fromECAddr.Bytes(), eth.ZeroEthAddr)
+					toZero := bytes.Equal(toECAddr.Bytes(), eth.ZeroEthAddr)
 					var fromAddr, toAddr apiTypes.Address
 					if !fromZero {
 						var err2 error
@@ -941,14 +942,14 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					return nil
 				},
 				ERC721Approval: func(ownerECAddr ethCommon.Address, approvedECAddr ethCommon.Address, tokenID *big.Int) error {
-					if !bytes.Equal(ownerECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(ownerECAddr.Bytes(), eth.ZeroEthAddr) {
 						ownerAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, ownerECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("owner: %w", err2)
 						}
 						eventData.RelatedAddresses[ownerAddr] = struct{}{}
 					}
-					if !bytes.Equal(approvedECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(approvedECAddr.Bytes(), eth.ZeroEthAddr) {
 						approvedAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, approvedECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("approved: %w", err2)
@@ -983,14 +984,14 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					return nil
 				},
 				ERC721ApprovalForAll: func(ownerECAddr ethCommon.Address, operatorECAddr ethCommon.Address, approved bool) error {
-					if !bytes.Equal(ownerECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(ownerECAddr.Bytes(), eth.ZeroEthAddr) {
 						ownerAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, ownerECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("owner: %w", err2)
 						}
 						eventData.RelatedAddresses[ownerAddr] = struct{}{}
 					}
-					if !bytes.Equal(operatorECAddr.Bytes(), uncategorized.ZeroEthAddr) {
+					if !bytes.Equal(operatorECAddr.Bytes(), eth.ZeroEthAddr) {
 						operatorAddr, err2 := addresses.RegisterRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, operatorECAddr.Bytes())
 						if err2 != nil {
 							return fmt.Errorf("operator: %w", err2)

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -369,7 +369,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 
 	// Insert events.
 	for _, eventData := range data.EventData {
-		eventRelatedAddresses := addresses.Extract(eventData.RelatedAddresses)
+		eventRelatedAddresses := addresses.SliceFromSet(eventData.RelatedAddresses)
 		batch.Queue(
 			queries.RuntimeEventInsert,
 			m.runtime,

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oasisprotocol/nexus/analyzer/queries"
 	evm "github.com/oasisprotocol/nexus/analyzer/runtime/evm"
 	"github.com/oasisprotocol/nexus/analyzer/runtime/static"
-	uncategorized "github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	"github.com/oasisprotocol/nexus/analyzer/util/addresses"
 	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/config"
@@ -369,7 +369,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 
 	// Insert events.
 	for _, eventData := range data.EventData {
-		eventRelatedAddresses := uncategorized.ExtractAddresses(eventData.RelatedAddresses)
+		eventRelatedAddresses := addresses.Extract(eventData.RelatedAddresses)
 		batch.Queue(
 			queries.RuntimeEventInsert,
 			m.runtime,

--- a/analyzer/util/addresses/addresses.go
+++ b/analyzer/util/addresses/addresses.go
@@ -44,7 +44,7 @@ func FromEthAddress(ethAddr []byte) (apiTypes.Address, error) {
 	return FromOCAddress(ocAddr)
 }
 
-func Extract(accounts map[apiTypes.Address]bool) []string {
+func Extract(accounts map[apiTypes.Address]struct{}) []string {
 	addrs := make([]string, len(accounts))
 	i := 0
 	for a := range accounts {

--- a/analyzer/util/addresses/addresses.go
+++ b/analyzer/util/addresses/addresses.go
@@ -1,4 +1,4 @@
-package common
+package addresses
 
 import (
 	"fmt"
@@ -17,7 +17,7 @@ import (
 // addr -> bech32 string oasis address
 // addrTextBytes -> bech32 []byte oasis address
 
-func StringifySdkAddress(sdkAddr *sdkTypes.Address) (apiTypes.Address, error) {
+func FromSdkAddress(sdkAddr *sdkTypes.Address) (apiTypes.Address, error) {
 	addrTextBytes, err := sdkAddr.MarshalText()
 	if err != nil {
 		return "", fmt.Errorf("address marshal text: %w", err)
@@ -25,26 +25,26 @@ func StringifySdkAddress(sdkAddr *sdkTypes.Address) (apiTypes.Address, error) {
 	return apiTypes.Address(addrTextBytes), nil
 }
 
-func StringifyAddressSpec(as *sdkTypes.AddressSpec) (apiTypes.Address, error) {
+func FromAddressSpec(as *sdkTypes.AddressSpec) (apiTypes.Address, error) {
 	sdkAddr, err := as.Address()
 	if err != nil {
 		return "", fmt.Errorf("derive address: %w", err)
 	}
-	return StringifySdkAddress(&sdkAddr)
+	return FromSdkAddress(&sdkAddr)
 }
 
-func StringifyOcAddress(ocAddr address.Address) (apiTypes.Address, error) {
+func FromOCAddress(ocAddr address.Address) (apiTypes.Address, error) {
 	sdkAddr := (sdkTypes.Address)(ocAddr)
-	return StringifySdkAddress(&sdkAddr)
+	return FromSdkAddress(&sdkAddr)
 }
 
-func StringifyEthAddress(ethAddr []byte) (apiTypes.Address, error) {
+func FromEthAddress(ethAddr []byte) (apiTypes.Address, error) {
 	ctx := sdkTypes.AddressV0Secp256k1EthContext
 	ocAddr := address.NewAddress(ctx, ethAddr)
-	return StringifyOcAddress(ocAddr)
+	return FromOCAddress(ocAddr)
 }
 
-func ExtractAddresses(accounts map[apiTypes.Address]bool) []string {
+func Extract(accounts map[apiTypes.Address]bool) []string {
 	addrs := make([]string, len(accounts))
 	i := 0
 	for a := range accounts {

--- a/analyzer/util/addresses/addresses.go
+++ b/analyzer/util/addresses/addresses.go
@@ -44,7 +44,7 @@ func FromEthAddress(ethAddr []byte) (apiTypes.Address, error) {
 	return FromOCAddress(ocAddr)
 }
 
-func Extract(accounts map[apiTypes.Address]struct{}) []string {
+func SliceFromSet(accounts map[apiTypes.Address]struct{}) []string {
 	addrs := make([]string, len(accounts))
 	i := 0
 	for a := range accounts {

--- a/analyzer/util/addresses/registration.go
+++ b/analyzer/util/addresses/registration.go
@@ -7,7 +7,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
-	"github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	"github.com/oasisprotocol/nexus/analyzer/util/eth"
 	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
 )
 
@@ -35,7 +35,7 @@ func extractAddressPreimage(as *sdkTypes.AddressSpec) (*PreimageData, error) {
 			// Use a scheme such that we can compute Secp256k1 addresses from Ethereum
 			// addresses as this makes things more interoperable.
 			untaggedPk, _ := spec.Secp256k1Eth.MarshalBinaryUncompressedUntagged()
-			data = common.SliceEthAddress(common.Keccak256(untaggedPk))
+			data = eth.SliceEthAddress(eth.Keccak256(untaggedPk))
 		case spec.Sr25519 != nil:
 			ctx = sdkTypes.AddressV0Sr25519Context
 			data, _ = spec.Sr25519.MarshalBinary()

--- a/analyzer/util/addresses/registration.go
+++ b/analyzer/util/addresses/registration.go
@@ -1,0 +1,124 @@
+package addresses
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
+	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	"github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	apiTypes "github.com/oasisprotocol/nexus/api/v1/types"
+)
+
+type PreimageData struct {
+	ContextIdentifier string
+	ContextVersion    int
+	Data              []byte
+}
+
+func extractAddressPreimage(as *sdkTypes.AddressSpec) (*PreimageData, error) {
+	// Adapted from oasis-sdk/client-sdk/go/types/transaction.go.
+	var (
+		ctx  address.Context
+		data []byte
+	)
+	switch {
+	case as.Signature != nil:
+		spec := as.Signature
+		switch {
+		case spec.Ed25519 != nil:
+			ctx = sdkTypes.AddressV0Ed25519Context
+			data, _ = spec.Ed25519.MarshalBinary()
+		case spec.Secp256k1Eth != nil:
+			ctx = sdkTypes.AddressV0Secp256k1EthContext
+			// Use a scheme such that we can compute Secp256k1 addresses from Ethereum
+			// addresses as this makes things more interoperable.
+			untaggedPk, _ := spec.Secp256k1Eth.MarshalBinaryUncompressedUntagged()
+			data = common.SliceEthAddress(common.Keccak256(untaggedPk))
+		case spec.Sr25519 != nil:
+			ctx = sdkTypes.AddressV0Sr25519Context
+			data, _ = spec.Sr25519.MarshalBinary()
+		default:
+			panic("address: unsupported public key type")
+		}
+	case as.Multisig != nil:
+		config := as.Multisig
+		ctx = sdkTypes.AddressV0MultisigContext
+		data = cbor.Marshal(config)
+	default:
+		return nil, fmt.Errorf("malformed AddressSpec")
+	}
+	return &PreimageData{
+		ContextIdentifier: ctx.Identifier,
+		ContextVersion:    int(ctx.Version),
+		Data:              data,
+	}, nil
+}
+
+func registerAddressSpec(addressPreimages map[apiTypes.Address]*PreimageData, as *sdkTypes.AddressSpec) (apiTypes.Address, error) {
+	addr, err := FromAddressSpec(as)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := addressPreimages[addr]; !ok {
+		preimageData, err1 := extractAddressPreimage(as)
+		if err1 != nil {
+			return "", fmt.Errorf("extract address preimage: %w", err1)
+		}
+		addressPreimages[addr] = preimageData
+	}
+
+	return addr, nil
+}
+
+func registerEthAddress(addressPreimages map[apiTypes.Address]*PreimageData, ethAddr []byte) (apiTypes.Address, error) {
+	addr, err := FromEthAddress(ethAddr)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := addressPreimages[addr]; !ok {
+		addressPreimages[addr] = &PreimageData{
+			ContextIdentifier: sdkTypes.AddressV0Secp256k1EthContext.Identifier,
+			ContextVersion:    int(sdkTypes.AddressV0Secp256k1EthContext.Version),
+			Data:              ethAddr,
+		}
+	}
+
+	return addr, nil
+}
+
+func RegisterRelatedSdkAddress(relatedAddresses map[apiTypes.Address]struct{}, sdkAddr *sdkTypes.Address) (apiTypes.Address, error) {
+	addr, err := FromSdkAddress(sdkAddr)
+	if err != nil {
+		return "", err
+	}
+
+	relatedAddresses[addr] = struct{}{}
+
+	return addr, nil
+}
+
+func RegisterRelatedAddressSpec(addressPreimages map[apiTypes.Address]*PreimageData, relatedAddresses map[apiTypes.Address]struct{}, as *sdkTypes.AddressSpec) (apiTypes.Address, error) {
+	addr, err := registerAddressSpec(addressPreimages, as)
+	if err != nil {
+		return "", err
+	}
+
+	relatedAddresses[addr] = struct{}{}
+
+	return addr, nil
+}
+
+func RegisterRelatedEthAddress(addressPreimages map[apiTypes.Address]*PreimageData, relatedAddresses map[apiTypes.Address]struct{}, ethAddr []byte) (apiTypes.Address, error) {
+	addr, err := registerEthAddress(addressPreimages, ethAddr)
+	if err != nil {
+		return "", err
+	}
+
+	relatedAddresses[addr] = struct{}{}
+
+	return addr, nil
+}

--- a/analyzer/util/eth/eth.go
+++ b/analyzer/util/eth/eth.go
@@ -1,4 +1,4 @@
-package common
+package eth
 
 import (
 	"golang.org/x/crypto/sha3"


### PR DESCRIPTION
uncategorized/addresses.go stringify*() -> util/addresses/addresses.go From*()
uncategorized/addresses.go Extract() -> util/addresses/addresses.go SliceFromSet()
runtime/extract.go register* -> util/addresses/registration.go Register*()
uncategorized/eth.go -> util/eth/eth.go

previously we had some map[Address]bool address sets, this changes them to map[Address]struct{} which I thought we compromised on