### PR TITLE
Andrew7234/api entity address

### DIFF
--- a/.changelog/685.breaking.md
+++ b/.changelog/685.breaking.md
@@ -1,0 +1,1 @@
+api: query entities by address instead of pubkey

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -410,16 +410,16 @@ paths:
                 $ref: '#/components/schemas/EntityList'
         <<: *common_error_responses
 
-  /consensus/entities/{entity_id}:
+  /consensus/entities/{address}:
     get:
       summary: Returns an entity registered at the consensus layer.
       parameters:
         - in: path
-          name: entity_id
+          name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
-          description: The entity ID of the entity to return.
+            allOf: [$ref: '#/components/schemas/StakingAddress']
+          description: The address of the entity to return.
       responses:
         '200':
           description: |
@@ -431,19 +431,19 @@ paths:
                 $ref: '#/components/schemas/Entity'
         <<: *common_error_responses
 
-  /consensus/entities/{entity_id}/nodes:
+  /consensus/entities/{address}/nodes:
     get:
       summary: Returns a list of nodes registered at the consensus layer.
       parameters:
         - *limit
         - *offset
         - in: path
-          name: entity_id
+          name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: |
-            The entity ID of the controlling entity of the nodes to return.
+            The address of the controlling entity of the nodes to return.
       responses:
         '200':
           description: |
@@ -454,18 +454,18 @@ paths:
                 $ref: '#/components/schemas/NodeList'
         <<: *common_error_responses
 
-  /consensus/entities/{entity_id}/nodes/{node_id}:
+  /consensus/entities/{address}/nodes/{node_id}:
     get:
       summary: Returns a node registered at the consensus layer.
       parameters:
         - in: path
-          name: entity_id
+          name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: |
             The entity ID of the entity controlling the node to return.
-          example: *entity_id_1
+          example: *staking_address_1
         - in: path
           name: node_id
           required: true
@@ -499,15 +499,15 @@ paths:
                 $ref: '#/components/schemas/ValidatorList'
         <<: *common_error_responses
 
-  /consensus/validators/{entity_id}:
+  /consensus/validators/{address}:
     get:
       summary: Returns a validator registered at the consensus layer.
       parameters:
         - in: path
-          name: entity_id
+          name: address
           required: true
           schema:
-            allOf: [$ref: '#/components/schemas/Ed25519PubKey']
+            allOf: [$ref: '#/components/schemas/StakingAddress']
           description: The entity ID of the entity to return.
       responses:
         '200':

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -119,28 +119,28 @@ func (srv *StrictServerImpl) GetConsensusEntities(ctx context.Context, request a
 	return apiTypes.GetConsensusEntities200JSONResponse(*entities), nil
 }
 
-func (srv *StrictServerImpl) GetConsensusEntitiesEntityId(ctx context.Context, request apiTypes.GetConsensusEntitiesEntityIdRequestObject) (apiTypes.GetConsensusEntitiesEntityIdResponseObject, error) {
-	entity, err := srv.dbClient.Entity(ctx, request.EntityId)
+func (srv *StrictServerImpl) GetConsensusEntitiesAddress(ctx context.Context, request apiTypes.GetConsensusEntitiesAddressRequestObject) (apiTypes.GetConsensusEntitiesAddressResponseObject, error) {
+	entity, err := srv.dbClient.Entity(ctx, request.Address)
 	if err != nil {
 		return nil, err
 	}
-	return apiTypes.GetConsensusEntitiesEntityId200JSONResponse(*entity), nil
+	return apiTypes.GetConsensusEntitiesAddress200JSONResponse(*entity), nil
 }
 
-func (srv *StrictServerImpl) GetConsensusEntitiesEntityIdNodes(ctx context.Context, request apiTypes.GetConsensusEntitiesEntityIdNodesRequestObject) (apiTypes.GetConsensusEntitiesEntityIdNodesResponseObject, error) {
-	nodes, err := srv.dbClient.EntityNodes(ctx, request.EntityId, request.Params)
+func (srv *StrictServerImpl) GetConsensusEntitiesAddressNodes(ctx context.Context, request apiTypes.GetConsensusEntitiesAddressNodesRequestObject) (apiTypes.GetConsensusEntitiesAddressNodesResponseObject, error) {
+	nodes, err := srv.dbClient.EntityNodes(ctx, request.Address, request.Params)
 	if err != nil {
 		return nil, err
 	}
-	return apiTypes.GetConsensusEntitiesEntityIdNodes200JSONResponse(*nodes), nil
+	return apiTypes.GetConsensusEntitiesAddressNodes200JSONResponse(*nodes), nil
 }
 
-func (srv *StrictServerImpl) GetConsensusEntitiesEntityIdNodesNodeId(ctx context.Context, request apiTypes.GetConsensusEntitiesEntityIdNodesNodeIdRequestObject) (apiTypes.GetConsensusEntitiesEntityIdNodesNodeIdResponseObject, error) {
-	node, err := srv.dbClient.EntityNode(ctx, request.EntityId, request.NodeId)
+func (srv *StrictServerImpl) GetConsensusEntitiesAddressNodesNodeId(ctx context.Context, request apiTypes.GetConsensusEntitiesAddressNodesNodeIdRequestObject) (apiTypes.GetConsensusEntitiesAddressNodesNodeIdResponseObject, error) {
+	node, err := srv.dbClient.EntityNode(ctx, request.Address, request.NodeId)
 	if err != nil {
 		return nil, err
 	}
-	return apiTypes.GetConsensusEntitiesEntityIdNodesNodeId200JSONResponse(*node), nil
+	return apiTypes.GetConsensusEntitiesAddressNodesNodeId200JSONResponse(*node), nil
 }
 
 func (srv *StrictServerImpl) GetConsensusEpochs(ctx context.Context, request apiTypes.GetConsensusEpochsRequestObject) (apiTypes.GetConsensusEpochsResponseObject, error) {
@@ -252,15 +252,15 @@ func (srv *StrictServerImpl) GetConsensusValidators(ctx context.Context, request
 	return apiTypes.GetConsensusValidators200JSONResponse(*validators), nil
 }
 
-func (srv *StrictServerImpl) GetConsensusValidatorsEntityId(ctx context.Context, request apiTypes.GetConsensusValidatorsEntityIdRequestObject) (apiTypes.GetConsensusValidatorsEntityIdResponseObject, error) {
-	validators, err := srv.dbClient.Validators(ctx, apiTypes.GetConsensusValidatorsParams{Limit: common.Ptr(uint64(1))}, &request.EntityId)
+func (srv *StrictServerImpl) GetConsensusValidatorsAddress(ctx context.Context, request apiTypes.GetConsensusValidatorsAddressRequestObject) (apiTypes.GetConsensusValidatorsAddressResponseObject, error) {
+	validators, err := srv.dbClient.Validators(ctx, apiTypes.GetConsensusValidatorsParams{Limit: common.Ptr(uint64(1))}, &request.Address)
 	if err != nil {
 		return nil, err
 	}
 	if len(validators.Validators) == 0 {
-		return apiTypes.GetConsensusValidatorsEntityId404JSONResponse{}, nil
+		return apiTypes.GetConsensusValidatorsAddress404JSONResponse{}, nil
 	}
-	return apiTypes.GetConsensusValidatorsEntityId200JSONResponse(validators.Validators[0]), nil
+	return apiTypes.GetConsensusValidatorsAddress200JSONResponse(validators.Validators[0]), nil
 }
 
 func (srv *StrictServerImpl) GetRuntimeBlocks(ctx context.Context, request apiTypes.GetRuntimeBlocksRequestObject) (apiTypes.GetRuntimeBlocksResponseObject, error) {

--- a/tests/e2e_regression/damask/test_cases.sh
+++ b/tests/e2e_regression/damask/test_cases.sh
@@ -11,13 +11,13 @@ source "$E2E_REGRESSION_DIR/common_test_cases.sh"
 testCases=(
   "${commonTestCases[@]}"
   'block                          /v1/consensus/blocks/8049500'
-  'entity                         /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As='
-  'entity_nodes                   /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes'
-  'node                           /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/LuIdtuiEPLBJefXVieVruy4kf04jjp5CBJFWVes0ZuE='
-  'bad_node                       /v1/consensus/entities/WazI78lMcmjyCH5+5RKkkfOTUR+XheHIohlqMu+a9As=/nodes/NOTANODE'
+  'entity                         /v1/consensus/entities/oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt'
+  'entity_nodes                   /v1/consensus/entities/oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt/nodes'
+  'node                           /v1/consensus/entities/oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt/nodes/LuIdtuiEPLBJefXVieVruy4kf04jjp5CBJFWVes0ZuE='
+  'bad_node                       /v1/consensus/entities/oasis1qz0ea28d8p4xk8xztems60wq22f9pm2yyyd82tmt/nodes/NOTANODE'
   'epoch                          /v1/consensus/epochs/13403'
   'tx                             /v1/consensus/transactions/f7a03e0912d355901ee794e5fec79a6b4c91363fc27d953596ee6de5c1492798'
-  'validator                      /v1/consensus/validators/HPeLbzc88IoYEP0TC4nqSxfxdPCPjduLeJqFvmxFye8='
+  'validator                      /v1/consensus/validators/oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a'
   'emerald_tx                     /v1/emerald/transactions/a6471a9c6f3307087586da9156f3c9876fbbaf4b23910cd9a2ac524a54d0aefe'
   'emerald_failed_tx              /v1/emerald/transactions/a7e76442c52a3cb81f719bde26c9a6179bd3415f96740d91a93ee8f205b45150'
   'emerald_token_nfts             /v1/emerald/evm_tokens/oasis1qqewaa87rnyshyqs7yutnnpzzetejecgeu005l8u/nfts'

--- a/tests/e2e_regression/eden/test_cases.sh
+++ b/tests/e2e_regression/eden/test_cases.sh
@@ -11,13 +11,13 @@ source "$E2E_REGRESSION_DIR/common_test_cases.sh"
 testCases=(
   "${commonTestCases[@]}"
   'block                              /v1/consensus/blocks/16818000'
-  'entity                             /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
-  'entity_nodes                       /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes'
-  'node                               /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/6wbL5%2fOxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA='
-  'bad_node                           /v1/consensus/entities/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=/nodes/NOTANODE'
+  'entity                             /v1/consensus/entities/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm'
+  'entity_nodes                       /v1/consensus/entities/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm/nodes'
+  'node                               /v1/consensus/entities/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm/nodes/6wbL5%2fOxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA='
+  'bad_node                           /v1/consensus/entities/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm/nodes/NOTANODE'
   'epoch                              /v1/consensus/epochs/28017'
   'tx                                 /v1/consensus/transactions/142d43e5194b738ab2223f8d0b42326fab06edd714a8cefc59a078b89b5de057'
-  'validator                          /v1/consensus/validators/9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4='
+  'validator                          /v1/consensus/validators/oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm'
   'emerald_tx                         /v1/emerald/transactions/ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d'
   'emerald_failed_tx                  /v1/emerald/transactions/35fdc8261dd81be8187c858aa9a623085494baf0565d414f48562a856147c093'
   'emerald_events_by_nft              /v1/emerald/events?contract_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx&nft_id=1'


### PR DESCRIPTION
This PR makes consensus entities query-able by oasis address instead of entity pubkey. This affects multiple endpoints. 

Notes:
* this is a *breaking* change. We _could_ continue support for pubkey querying, but the implementation would be a bit messier (akin to the recent query by EthOrOasisAddress)

Open question:
* nodes are still only query-able by pubkey (eg `node_id`) as we do not currently track their addresses. Is there a demand for querying the `/consensus/entities/{address}/nodes/{node_id}` endpoint by node address instead?