### PR TITLE
metrics: avoid empty api_request_latencies_* entries

### DIFF
--- a/.changelog/692.bugfix.md
+++ b/.changelog/692.bugfix.md
@@ -1,0 +1,1 @@
+metrics: dont create new 'api_request_latencies_buckets' for 404s

--- a/metrics/requests.go
+++ b/metrics/requests.go
@@ -48,7 +48,9 @@ func (m *RequestMetrics) RequestCounts(endpoint, status string) prometheus.Count
 	return m.requestCounts.WithLabelValues(endpoint, status)
 }
 
-// RequestLatencies creates a new latency timer for the provided request endpoint.
-func (m *RequestMetrics) RequestLatencies(endpoint string) *prometheus.Timer {
-	return prometheus.NewTimer(m.requestLatencies.WithLabelValues(endpoint))
+// RequestLatencies fetches the Histogram Observer for the given endpoint
+// If it doesn't exist, a new one is created.
+// This creates 12 (with DefBuckets) empty tables in the prometheus database.
+func (m *RequestMetrics) RequestLatencies(endpoint string) prometheus.Observer {
+	return m.requestLatencies.WithLabelValues(endpoint)
 }


### PR DESCRIPTION
Prometheus was filling up unusually fast. 

```
$ promtool tsdb analyze /prometheus
Label names with highest cumulative label value length:
1376859 exported_endpoint
47404 __name__
37378 id
34344 mountpoint
22659 name

Highest cardinality labels:
64210 exported_endpoint
1311 __name__
519 name
357 id
282 le

Highest cardinality metric names:
787440 api_request_latencies_bucket
65620 api_request_latencies_sum
65620 api_request_latencies_count
7620 nginx_ingress_controller_request_duration_seconds_bucket
7416 etcd_request_duration_seconds_bucket
```
That is 1.4GB per day just from the labels' text values on that one histogram metric (probably more for the table structure overhead).

So I queried `api_request_latencies_bucket` and found it was creating a new label for every unique request, including 404s.
```
exported_endpoint="/ Copy of "
exported_endpoint="/ /evil.com/"
exported_endpoint="/ /bin/cat /etc/passwd"
exported_endpoint="/ /interact.sh/"
exported_endpoint="/ Set-Cookie:crlfinjection/.."
exported_endpoint="/ ../web-inf/web.xml"
exported_endpoint="/!.htaccess"
```

Cause: While the comment was correct, that `prometheus.Timer` doesn't create a record until it's observed, `WithLabelValues` does, so `timer := m.RequestLatencies(metricName)` was creating a bunch of new labels for every spam request the server received. https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#HistogramVec.GetMetricWithLabelValues

