### PR TITLE
node stats analyzer: handle nonexistent runtimes gracefully

### DIFF
--- a/.changelog/693.bugfix.md
+++ b/.changelog/693.bugfix.md
@@ -1,0 +1,1 @@
+analyzer: make node stats analyzer more robust to unsupported runtimes

--- a/analyzer/node_stats/node_stats.go
+++ b/analyzer/node_stats/node_stats.go
@@ -36,9 +36,7 @@ func NewAnalyzer(
 	cfg config.ItemBasedAnalyzerConfig,
 	layers []common.Layer,
 	consensusClient nodeapi.ConsensusApiLite,
-	emeraldClient nodeapi.RuntimeApiLite,
-	sapphireClient nodeapi.RuntimeApiLite,
-	pontusxClient nodeapi.RuntimeApiLite,
+	runtimeClients map[common.Runtime]nodeapi.RuntimeApiLite,
 	target storage.TargetStorage,
 	logger *log.Logger,
 ) (analyzer.Analyzer, error) {
@@ -53,13 +51,9 @@ func NewAnalyzer(
 	p := &processor{
 		layers:          layers,
 		consensusSource: consensusClient,
-		runtimeSources: map[common.Runtime]nodeapi.RuntimeApiLite{
-			common.RuntimeEmerald:  emeraldClient,
-			common.RuntimeSapphire: sapphireClient,
-			common.RuntimePontusx:  pontusxClient,
-		},
-		target: target,
-		logger: logger.With("analyzer", nodeStatsAnalyzerName),
+		runtimeSources:  runtimeClients,
+		target:          target,
+		logger:          logger.With("analyzer", nodeStatsAnalyzerName),
 	}
 
 	return item.NewAnalyzer[common.Layer](

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -25,6 +25,10 @@ func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkP
 	apis := map[string]nodeapi.RuntimeApiLite{}
 	for _, record := range history.Records {
 		if archiveConfig, ok := nodes[record.ArchiveName]; ok {
+			// If sdkPT is nil, the subsequent sdkConn.Runtime() call will panic
+			if sdkPT == nil {
+				return nil, fmt.Errorf("no paratime specified")
+			}
 			sdkConn, err := connections.SDKConnect(ctx, record.ChainContext, archiveConfig.ResolvedRuntimeNode(runtime), fastStartup)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
the node stats analyzer errored after redeploying on mainnet. This PR cleans up the analyzer and makes it more robust to unsupported runtimes.