### PR TITLE
augment ix_accounts_related_transactions_address_block index

### DIFF
--- a/.changelog/697.bugfix.md
+++ b/.changelog/697.bugfix.md
@@ -1,0 +1,1 @@
+db: augment accounts_related_transactions_address index

--- a/storage/migrations/00_consensus.up.sql
+++ b/storage/migrations/00_consensus.up.sql
@@ -301,7 +301,9 @@ CREATE TABLE chain.accounts_related_transactions
   tx_index UINT31 NOT NULL,
   FOREIGN KEY (tx_block, tx_index) REFERENCES chain.transactions(block, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX ix_accounts_related_transactions_address ON chain.accounts_related_transactions (account_address);
+CREATE INDEX ix_accounts_related_transactions_address ON chain.accounts_related_transactions (account_address); -- Removed in 14_accounts_rel_tx_index.up.sql
+-- Added in 14_accounts_rel_tx_index.up.sql
+-- CREATE INDEX ix_accounts_related_transactions_address_block ON chain.accounts_related_transactions(account_address, tx_block);
 CREATE INDEX ix_accounts_related_transactions_block ON chain.accounts_related_transactions (tx_block);
 
 -- Tracks the current (consensus) height of the node.

--- a/storage/migrations/14_accounts_rel_tx_index.up.sql
+++ b/storage/migrations/14_accounts_rel_tx_index.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS chain.ix_accounts_related_transactions_address;
+
+CREATE INDEX ix_accounts_related_transactions_address_block ON chain.accounts_related_transactions(account_address, tx_block);
+
+COMMIT;


### PR DESCRIPTION
@csillag reported that the `/consensus/transactions?rel={}` endpoint was very slow. Further investigation showed that the existing index did not contain enough information, which is fixed in this PR.

testing: Already enabled in testnet production; sample query is now performant: https://nexus.prd.oasis.io/v1/consensus/transactions?limit=10&offset=0&rel=oasis1qp65laz8zsa9a305wxeslpnkh9x4dv2h2qhjz0ec
