### PR TITLE
Andrew7234/consensus account stats

### DIFF
--- a/.changelog/698.feature.md
+++ b/.changelog/698.feature.md
@@ -1,0 +1,1 @@
+api: add num_txns stat for consensus accounts

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2092,7 +2092,7 @@ components:
 
     Account:
       type: object
-      required: [address, nonce, available, escrow, debonding, allowances]
+      required: [address, nonce, available, escrow, debonding, allowances, stats]
       properties:
         address:
           type: string
@@ -2128,6 +2128,8 @@ components:
           items:
             allOf: [$ref: '#/components/schemas/Allowance']
           description: The allowances made by this account.
+        stats:
+          allOf: [$ref: '#/components/schemas/AccountStats']
       description: |
         A consensus layer account.
 
@@ -2966,7 +2968,7 @@ components:
 
     AccountStats:
       type: object
-      required: [total_sent, total_received, num_txns]
+      required: [num_txns]
       properties:
         total_sent:
           allOf: [$ref: '#/components/schemas/TextBigInt']

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -817,6 +817,17 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 		a.Allowances = append(a.Allowances, al)
 	}
 
+	err = c.db.QueryRow(
+		ctx,
+		queries.AccountStats,
+		address.String(),
+	).Scan(
+		&a.Stats.NumTxns,
+	)
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
 	return &a, nil
 }
 
@@ -1736,8 +1747,8 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	case nil:
 	case pgx.ErrNoRows:
 		// If an account address has no activity, default to 0.
-		a.Stats.TotalSent = common.NewBigInt(0)
-		a.Stats.TotalReceived = common.NewBigInt(0)
+		a.Stats.TotalSent = common.Ptr(common.NewBigInt(0))
+		a.Stats.TotalReceived = common.Ptr(common.NewBigInt(0))
 		a.Stats.NumTxns = 0
 	default:
 		return nil, wrapError(err)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -191,6 +191,12 @@ const (
 		FROM chain.accounts
 		WHERE address = $1::text`
 
+	AccountStats = `
+		SELECT
+			COUNT(*)
+		FROM chain.accounts_related_transactions
+		WHERE account_address = $1::text`
+
 	AccountAllowances = `
 		SELECT beneficiary, allowance
 			FROM chain.allowances

--- a/tests/e2e_regression/common_test_cases.sh
+++ b/tests/e2e_regression/common_test_cases.sh
@@ -40,6 +40,7 @@ commonTestCases=(
   'blocks                             /v1/consensus/blocks'
   'bad_account                        /v1/consensus/accounts/oasis1aaaaaaa'
   'account                            /v1/consensus/accounts/oasis1qp0302fv0gz858azasg663ax2epakk5fcssgza7j'
+  'account_with_tx                    /v1/consensus/accounts/oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3'
   'runtime-only_account               /v1/consensus/accounts/oasis1qphyxz5csvprhnn09r49nuyzl0jdw0wsj5xpvsg2'
   'delegations                        /v1/consensus/accounts/oasis1qpk366qvtjrfrthjp3xuej5mhvvtnkr8fy02hm2s/delegations'
   'delegations_to                     /v1/consensus/accounts/oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6/delegations_to'

--- a/tests/e2e_regression/damask/expected/account.body
+++ b/tests/e2e_regression/damask/expected/account.body
@@ -6,5 +6,8 @@
   "debonding_delegations_balance": "0",
   "delegations_balance": "0",
   "escrow": "0",
-  "nonce": 5
+  "nonce": 5,
+  "stats": {
+    "num_txns": 0
+  }
 }

--- a/tests/e2e_regression/damask/expected/account_with_tx.body
+++ b/tests/e2e_regression/damask/expected/account_with_tx.body
@@ -1,0 +1,13 @@
+{
+  "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
+  "allowances": [],
+  "available": "98499977445996",
+  "debonding": "12381788591465821",
+  "debonding_delegations_balance": "0",
+  "delegations_balance": "6250650662907336",
+  "escrow": "224562518782971131",
+  "nonce": 8,
+  "stats": {
+    "num_txns": 2
+  }
+}

--- a/tests/e2e_regression/damask/expected/account_with_tx.headers
+++ b/tests/e2e_regression/damask/expected/account_with_tx.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/damask/expected/accounts.body
+++ b/tests/e2e_regression/damask/expected/accounts.body
@@ -6,7 +6,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000kj5dj5tf48x0rhzf8298dw78w2yzvza727z",
@@ -14,7 +17,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002d6rv8r0zmhfe69th39rm0uaz4j6rsm5glcy",
@@ -22,7 +28,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002zmd2psenqaklm55cx0z2uwuttzzy5gcdjm4",
@@ -30,7 +39,10 @@
       "available": "100000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0046fqy37v9u70mrdskf99z620h0tfcgzcu73u",
@@ -38,7 +50,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -46,7 +61,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006nj305aks8cqwatrpzzf3j3we4tk5vkrzlkk",
@@ -54,7 +72,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006t7se986qq37ygvrx6wwa55s5wgcnu34m88n",
@@ -62,7 +83,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0088hdxzs8r94ae048rhrpv4m0taumcqanhe4u",
@@ -70,7 +94,10 @@
       "available": "175000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008f6fg9kqk6gt9vxf5yk2d5wv7vm2x5tkc88y",
@@ -78,7 +105,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008xpw8calf0pnpjnfsn09ute9en62uq94gfts",
@@ -86,7 +116,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0098rk2cd0unzr7666987cultg9c5rxgep2crk",
@@ -94,7 +127,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp009q6yrfgu0w0aaekyl3dtum9e06u46qetknhm",
@@ -102,7 +138,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00a7x3t08vnevjqgkmnyacd47cxumvhvp5665f",
@@ -110,7 +149,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00c73tjphyes84t6lxcl5n5qyqd0ymu5283dn3",
@@ -118,7 +160,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cnz84jzlvp49rsfpslaje026k55q352ysfxj",
@@ -126,7 +171,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00e7emjdfllmu3f0e65cn97cvumcfskuusmy7h",
@@ -134,7 +182,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -142,7 +193,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00fnd2q8xmjvavt0j09ywazcu2gkd2duw6f9th",
@@ -150,7 +204,10 @@
       "available": "1128000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ftxjm73zqxsnsx2wd82umsvzj88gt5f5lfu7",
@@ -158,7 +215,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00g3stymym336s04u2jdh7zhqmf2xxpcatppgz",
@@ -166,7 +226,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -174,7 +237,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gjlafqsrrlafcqsa09twkg5c4979mu2mypmh",
@@ -182,7 +248,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -190,7 +259,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lppkfccyycwud82an4rt8g4dz84p5ydm9qvj",
@@ -198,7 +270,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -206,7 +281,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nhzaacke8chwnrrvnp8uf4nlznrtfu92j8ln",
@@ -214,7 +292,10 @@
       "available": "67461",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -222,7 +303,10 @@
       "available": "916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pcmvajl5mmllh2t785mdcj3f890y8v9mrrq6",
@@ -230,7 +314,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pt4yuul66v3y0ednn0a7glnap4fe5uczs5tg",
@@ -238,7 +325,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00qfjw0e43ew8n708tzjyfs8zs379tnyc7yvn0",
@@ -246,7 +336,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -254,7 +347,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -262,7 +358,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -270,7 +369,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8azzdpusgv9c7edlq3c9yl09v3dq5genyh2",
@@ -278,7 +380,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8s2d90gvfe904mjqsmnat9j3m2y2q6rz99f",
@@ -286,7 +391,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -294,7 +402,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00slzdmuy84eefcths8qvr9whys0zuwyms2gpj",
@@ -302,7 +413,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00svannwrsrl5g5n3qq5624xcyrd9tyvdgl4jy",
@@ -310,7 +424,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -318,7 +435,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vpm4627l2yes6x9vkmmdfk2flh70jgzmch44",
@@ -326,7 +446,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 25
+      "nonce": 25,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w0xae4lfegn8g76apusnzjzgjd0upyx7vsnj",
@@ -334,7 +457,10 @@
       "available": "308067746400",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w23hwk0r70046azuv39965n4qvc77ug7eaf7",
@@ -342,7 +468,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -350,7 +479,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnym496x0jt96a72fm48tw67jms6acwe73k7",
@@ -358,7 +490,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wrpk868nrwe58t7wy5k9jd7l3rucagsjh263",
@@ -366,7 +501,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00x0kh4jm3smgmcde773jpmhwr0tmuggxgjhf7",
@@ -374,7 +512,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xfr5gysq6wa0g625jydlvgcnq803vy7frvkc",
@@ -382,7 +523,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02042wd8nphz2vsqljnrdfgd74cmzh2gkxte4a",
@@ -390,7 +534,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -398,7 +545,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020sm24feve562fcg3jrmyn7kt8gxgh5tzgj0z",
@@ -406,7 +556,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -414,7 +567,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023glr0j2jqa6x5p6x4uy8mkauv5m5aujecjh0",
@@ -422,7 +578,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -430,7 +589,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024xls80wznu2mjylypwf92nvmrrc88ypjzfvg",
@@ -438,7 +600,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0250stl9hafjjzmj2ssyg4zxu0ep53zquueuqr",
@@ -446,7 +611,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0263aadc9a5j46ye3pfuczg2asfta75g0xzt4p",
@@ -454,7 +622,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp026plsj5nf8nw6cycjgp76mqyjww3cj5g4jt3w",
@@ -462,7 +633,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0274fgqdd3r5v0dnrrzhvutgrt8luflqyzc9nm",
@@ -470,7 +644,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0282vrk8x04ksjrsmkejvqqjk8kh9kpq2d0mar",
@@ -478,7 +655,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0283axkf6zennrc98gyamvxqt4rsepqyrrm892",
@@ -486,7 +666,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028760nlsnqll6jfdhzka4nqsnrnjdhu8mga50",
@@ -494,7 +677,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028afe3nzkl9x5jgmmwrh85zep5ndl6vj0sj4k",
@@ -502,7 +688,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028auep6llxlkwrl3jsrqmtcvlg24c2u0gzsae",
@@ -510,7 +699,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028f8nfzfjrhk9shjyt56raukk9ux6wussykds",
@@ -518,7 +710,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028h3q28jqm47sadekfgs7ur7g4cp5fu99tf4p",
@@ -526,7 +721,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028tzl3mudsug9j2eh9hkrjzllmmc6u5pn2kvj",
@@ -534,7 +732,10 @@
       "available": "31400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0297t4m5eqhucezc5kf70ney5256gensqlv7ax",
@@ -542,7 +743,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c025kxm9xkqfl2t38uprv33r4k054sjrxrjg",
@@ -550,7 +754,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c0zt8jj4j4l0j495qncq02mcxxg3hy6pd6yv",
@@ -558,7 +765,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02cj9uxgxw0nguflnpqfhu3m78qkjgzgyguhgl",
@@ -566,7 +776,10 @@
       "available": "5687",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 11
+      "nonce": 11,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02d24e8s7szanudyxjukgkuflc58x4vcl05cyf",
@@ -574,7 +787,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02f3xr9j3jrm8pdka0gsccq2s6u4aqkunsscts",
@@ -582,7 +798,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fmhltqdhhgg06ycw6q4n6kkx8kppyys3lucp",
@@ -590,7 +809,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fre745kazh7k277tnkq7csngpcgjvggrnmqg",
@@ -598,7 +820,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fw5w30h82vkxs5l4lsrqfhm2cfc9jgfjgyu8",
@@ -606,7 +831,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02g2fupa3ctt37lr5l2lvf4f4zqlmwwvxp75jh",
@@ -614,7 +842,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ggy3qs6aw63frtmvuu0hphuftgylnvpunw0f",
@@ -622,7 +853,10 @@
       "available": "497057401",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02hp4hks20zzmgxaq0jyt92qkh450uugsjw50d",
@@ -630,7 +864,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02jzag8kq9gyxvk67hz7d3uc9hg6x05qtttw26",
@@ -638,7 +875,10 @@
       "available": "5000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02kh4zlx5z8vrkwndh4dq4em5j5d3xuvrwa6fd",
@@ -646,7 +886,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02maxhquje0sjaus86xvnehxj27ctkjy4u7qpt",
@@ -654,7 +897,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02mr4e0atk388zzjmwzgmqv06xc0ygfc5sug7u",
@@ -662,7 +908,10 @@
       "available": "11000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n3yn3pfn8ssyjaq6c9j9nrekrmkvhyewqeau",
@@ -670,7 +919,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n4zy9ujsvgvkzp7cvqnu7r6t5dhxqg3ls8ty",
@@ -678,7 +930,10 @@
       "available": "3413684872332",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n9lrth0sxp57raez0te2gdsxw9tts5xtwn9e",
@@ -686,7 +941,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02q090easm9stmx9uuxjl0w3te3fx0xsy922nr",
@@ -694,7 +952,10 @@
       "available": "22681",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02qp880805m68duadtfw79024pxkyrwuumvaar",
@@ -702,7 +963,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02r4qua8xvm6d6h824aylgdg6jdrznyqrzw7r8",
@@ -710,7 +974,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ryrw7804pnp6tr87lghdf438he85jgc30pg2",
@@ -718,7 +985,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02tdch2tdzvcayrydrkcx3qp4kjwdgfsdn827g",
@@ -726,7 +996,10 @@
       "available": "3900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02texvup5tqw58c055rvcgglduj8mjkvlrm44n",
@@ -734,7 +1007,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02u763rg5y5ec4s3ppzxhgy2ucznp4tsretuau",
@@ -742,7 +1018,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ucem2cfjsqnxev5hmr4rckzqdtk33c6cvev8",
@@ -750,7 +1029,10 @@
       "available": "189900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02uvs0asxcjkm94dgfxug7v3p9av7xccptrsuq",
@@ -758,7 +1040,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02w7m7rlpe8hxwljesh3y869tgu8njyyxt4ryp",
@@ -766,7 +1051,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02xeyxyzr03m88xpv7gpv3k3qag3gf8c44x996",
@@ -774,7 +1062,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0302fv0gz858azasg663ax2epakk5fcssgza7j",
@@ -782,7 +1073,10 @@
       "available": "744704363502",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp030grkp04yl7l2mjcskk79z20vrct62ua5m3pw",
@@ -790,7 +1084,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp032gakpngap7zv30kjm7pp6tx084ktvgajjzzw",
@@ -798,7 +1095,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/damask/expected/accounts_extraneous_key.body
+++ b/tests/e2e_regression/damask/expected/accounts_extraneous_key.body
@@ -6,7 +6,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000kj5dj5tf48x0rhzf8298dw78w2yzvza727z",
@@ -14,7 +17,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002d6rv8r0zmhfe69th39rm0uaz4j6rsm5glcy",
@@ -22,7 +28,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002zmd2psenqaklm55cx0z2uwuttzzy5gcdjm4",
@@ -30,7 +39,10 @@
       "available": "100000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0046fqy37v9u70mrdskf99z620h0tfcgzcu73u",
@@ -38,7 +50,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -46,7 +61,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006nj305aks8cqwatrpzzf3j3we4tk5vkrzlkk",
@@ -54,7 +72,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006t7se986qq37ygvrx6wwa55s5wgcnu34m88n",
@@ -62,7 +83,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0088hdxzs8r94ae048rhrpv4m0taumcqanhe4u",
@@ -70,7 +94,10 @@
       "available": "175000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008f6fg9kqk6gt9vxf5yk2d5wv7vm2x5tkc88y",
@@ -78,7 +105,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008xpw8calf0pnpjnfsn09ute9en62uq94gfts",
@@ -86,7 +116,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0098rk2cd0unzr7666987cultg9c5rxgep2crk",
@@ -94,7 +127,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp009q6yrfgu0w0aaekyl3dtum9e06u46qetknhm",
@@ -102,7 +138,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00a7x3t08vnevjqgkmnyacd47cxumvhvp5665f",
@@ -110,7 +149,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00c73tjphyes84t6lxcl5n5qyqd0ymu5283dn3",
@@ -118,7 +160,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cnz84jzlvp49rsfpslaje026k55q352ysfxj",
@@ -126,7 +171,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00e7emjdfllmu3f0e65cn97cvumcfskuusmy7h",
@@ -134,7 +182,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -142,7 +193,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00fnd2q8xmjvavt0j09ywazcu2gkd2duw6f9th",
@@ -150,7 +204,10 @@
       "available": "1128000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ftxjm73zqxsnsx2wd82umsvzj88gt5f5lfu7",
@@ -158,7 +215,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00g3stymym336s04u2jdh7zhqmf2xxpcatppgz",
@@ -166,7 +226,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -174,7 +237,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gjlafqsrrlafcqsa09twkg5c4979mu2mypmh",
@@ -182,7 +248,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -190,7 +259,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lppkfccyycwud82an4rt8g4dz84p5ydm9qvj",
@@ -198,7 +270,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -206,7 +281,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nhzaacke8chwnrrvnp8uf4nlznrtfu92j8ln",
@@ -214,7 +292,10 @@
       "available": "67461",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -222,7 +303,10 @@
       "available": "916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pcmvajl5mmllh2t785mdcj3f890y8v9mrrq6",
@@ -230,7 +314,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pt4yuul66v3y0ednn0a7glnap4fe5uczs5tg",
@@ -238,7 +325,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00qfjw0e43ew8n708tzjyfs8zs379tnyc7yvn0",
@@ -246,7 +336,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -254,7 +347,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -262,7 +358,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -270,7 +369,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8azzdpusgv9c7edlq3c9yl09v3dq5genyh2",
@@ -278,7 +380,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8s2d90gvfe904mjqsmnat9j3m2y2q6rz99f",
@@ -286,7 +391,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -294,7 +402,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00slzdmuy84eefcths8qvr9whys0zuwyms2gpj",
@@ -302,7 +413,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00svannwrsrl5g5n3qq5624xcyrd9tyvdgl4jy",
@@ -310,7 +424,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -318,7 +435,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vpm4627l2yes6x9vkmmdfk2flh70jgzmch44",
@@ -326,7 +446,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 25
+      "nonce": 25,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w0xae4lfegn8g76apusnzjzgjd0upyx7vsnj",
@@ -334,7 +457,10 @@
       "available": "308067746400",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w23hwk0r70046azuv39965n4qvc77ug7eaf7",
@@ -342,7 +468,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -350,7 +479,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnym496x0jt96a72fm48tw67jms6acwe73k7",
@@ -358,7 +490,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wrpk868nrwe58t7wy5k9jd7l3rucagsjh263",
@@ -366,7 +501,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00x0kh4jm3smgmcde773jpmhwr0tmuggxgjhf7",
@@ -374,7 +512,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xfr5gysq6wa0g625jydlvgcnq803vy7frvkc",
@@ -382,7 +523,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02042wd8nphz2vsqljnrdfgd74cmzh2gkxte4a",
@@ -390,7 +534,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -398,7 +545,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020sm24feve562fcg3jrmyn7kt8gxgh5tzgj0z",
@@ -406,7 +556,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -414,7 +567,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023glr0j2jqa6x5p6x4uy8mkauv5m5aujecjh0",
@@ -422,7 +578,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -430,7 +589,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024xls80wznu2mjylypwf92nvmrrc88ypjzfvg",
@@ -438,7 +600,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0250stl9hafjjzmj2ssyg4zxu0ep53zquueuqr",
@@ -446,7 +611,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0263aadc9a5j46ye3pfuczg2asfta75g0xzt4p",
@@ -454,7 +622,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp026plsj5nf8nw6cycjgp76mqyjww3cj5g4jt3w",
@@ -462,7 +633,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0274fgqdd3r5v0dnrrzhvutgrt8luflqyzc9nm",
@@ -470,7 +644,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0282vrk8x04ksjrsmkejvqqjk8kh9kpq2d0mar",
@@ -478,7 +655,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0283axkf6zennrc98gyamvxqt4rsepqyrrm892",
@@ -486,7 +666,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028760nlsnqll6jfdhzka4nqsnrnjdhu8mga50",
@@ -494,7 +677,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028afe3nzkl9x5jgmmwrh85zep5ndl6vj0sj4k",
@@ -502,7 +688,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028auep6llxlkwrl3jsrqmtcvlg24c2u0gzsae",
@@ -510,7 +699,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028f8nfzfjrhk9shjyt56raukk9ux6wussykds",
@@ -518,7 +710,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028h3q28jqm47sadekfgs7ur7g4cp5fu99tf4p",
@@ -526,7 +721,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028tzl3mudsug9j2eh9hkrjzllmmc6u5pn2kvj",
@@ -534,7 +732,10 @@
       "available": "31400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0297t4m5eqhucezc5kf70ney5256gensqlv7ax",
@@ -542,7 +743,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c025kxm9xkqfl2t38uprv33r4k054sjrxrjg",
@@ -550,7 +754,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c0zt8jj4j4l0j495qncq02mcxxg3hy6pd6yv",
@@ -558,7 +765,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02cj9uxgxw0nguflnpqfhu3m78qkjgzgyguhgl",
@@ -566,7 +776,10 @@
       "available": "5687",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 11
+      "nonce": 11,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02d24e8s7szanudyxjukgkuflc58x4vcl05cyf",
@@ -574,7 +787,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02f3xr9j3jrm8pdka0gsccq2s6u4aqkunsscts",
@@ -582,7 +798,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fmhltqdhhgg06ycw6q4n6kkx8kppyys3lucp",
@@ -590,7 +809,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fre745kazh7k277tnkq7csngpcgjvggrnmqg",
@@ -598,7 +820,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fw5w30h82vkxs5l4lsrqfhm2cfc9jgfjgyu8",
@@ -606,7 +831,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02g2fupa3ctt37lr5l2lvf4f4zqlmwwvxp75jh",
@@ -614,7 +842,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ggy3qs6aw63frtmvuu0hphuftgylnvpunw0f",
@@ -622,7 +853,10 @@
       "available": "497057401",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02hp4hks20zzmgxaq0jyt92qkh450uugsjw50d",
@@ -630,7 +864,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02jzag8kq9gyxvk67hz7d3uc9hg6x05qtttw26",
@@ -638,7 +875,10 @@
       "available": "5000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02kh4zlx5z8vrkwndh4dq4em5j5d3xuvrwa6fd",
@@ -646,7 +886,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02maxhquje0sjaus86xvnehxj27ctkjy4u7qpt",
@@ -654,7 +897,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02mr4e0atk388zzjmwzgmqv06xc0ygfc5sug7u",
@@ -662,7 +908,10 @@
       "available": "11000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n3yn3pfn8ssyjaq6c9j9nrekrmkvhyewqeau",
@@ -670,7 +919,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n4zy9ujsvgvkzp7cvqnu7r6t5dhxqg3ls8ty",
@@ -678,7 +930,10 @@
       "available": "3413684872332",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n9lrth0sxp57raez0te2gdsxw9tts5xtwn9e",
@@ -686,7 +941,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02q090easm9stmx9uuxjl0w3te3fx0xsy922nr",
@@ -694,7 +952,10 @@
       "available": "22681",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02qp880805m68duadtfw79024pxkyrwuumvaar",
@@ -702,7 +963,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02r4qua8xvm6d6h824aylgdg6jdrznyqrzw7r8",
@@ -710,7 +974,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ryrw7804pnp6tr87lghdf438he85jgc30pg2",
@@ -718,7 +985,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02tdch2tdzvcayrydrkcx3qp4kjwdgfsdn827g",
@@ -726,7 +996,10 @@
       "available": "3900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02texvup5tqw58c055rvcgglduj8mjkvlrm44n",
@@ -734,7 +1007,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02u763rg5y5ec4s3ppzxhgy2ucznp4tsretuau",
@@ -742,7 +1018,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ucem2cfjsqnxev5hmr4rckzqdtk33c6cvev8",
@@ -750,7 +1029,10 @@
       "available": "189900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02uvs0asxcjkm94dgfxug7v3p9av7xccptrsuq",
@@ -758,7 +1040,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02w7m7rlpe8hxwljesh3y869tgu8njyyxt4ryp",
@@ -766,7 +1051,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02xeyxyzr03m88xpv7gpv3k3qag3gf8c44x996",
@@ -774,7 +1062,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0302fv0gz858azasg663ax2epakk5fcssgza7j",
@@ -782,7 +1073,10 @@
       "available": "744704363502",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp030grkp04yl7l2mjcskk79z20vrct62ua5m3pw",
@@ -790,7 +1084,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp032gakpngap7zv30kjm7pp6tx084ktvgajjzzw",
@@ -798,7 +1095,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/damask/expected/min_balance.body
+++ b/tests/e2e_regression/damask/expected/min_balance.body
@@ -6,7 +6,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -14,7 +17,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0088hdxzs8r94ae048rhrpv4m0taumcqanhe4u",
@@ -22,7 +28,10 @@
       "available": "175000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -30,7 +39,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00fnd2q8xmjvavt0j09ywazcu2gkd2duw6f9th",
@@ -38,7 +50,10 @@
       "available": "1128000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -46,7 +61,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -54,7 +72,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -62,7 +83,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -70,7 +94,10 @@
       "available": "916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -78,7 +105,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -86,7 +116,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -94,7 +127,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -102,7 +138,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -110,7 +149,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w0xae4lfegn8g76apusnzjzgjd0upyx7vsnj",
@@ -118,7 +160,10 @@
       "available": "308067746400",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -126,7 +171,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -134,7 +182,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -142,7 +193,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -150,7 +204,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028tzl3mudsug9j2eh9hkrjzllmmc6u5pn2kvj",
@@ -158,7 +215,10 @@
       "available": "31400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0297t4m5eqhucezc5kf70ney5256gensqlv7ax",
@@ -166,7 +226,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c0zt8jj4j4l0j495qncq02mcxxg3hy6pd6yv",
@@ -174,7 +237,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fmhltqdhhgg06ycw6q4n6kkx8kppyys3lucp",
@@ -182,7 +248,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fre745kazh7k277tnkq7csngpcgjvggrnmqg",
@@ -190,7 +259,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ggy3qs6aw63frtmvuu0hphuftgylnvpunw0f",
@@ -198,7 +270,10 @@
       "available": "497057401",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02jzag8kq9gyxvk67hz7d3uc9hg6x05qtttw26",
@@ -206,7 +281,10 @@
       "available": "5000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02kh4zlx5z8vrkwndh4dq4em5j5d3xuvrwa6fd",
@@ -214,7 +292,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02maxhquje0sjaus86xvnehxj27ctkjy4u7qpt",
@@ -222,7 +303,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02mr4e0atk388zzjmwzgmqv06xc0ygfc5sug7u",
@@ -230,7 +314,10 @@
       "available": "11000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n3yn3pfn8ssyjaq6c9j9nrekrmkvhyewqeau",
@@ -238,7 +325,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n4zy9ujsvgvkzp7cvqnu7r6t5dhxqg3ls8ty",
@@ -246,7 +336,10 @@
       "available": "3413684872332",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n9lrth0sxp57raez0te2gdsxw9tts5xtwn9e",
@@ -254,7 +347,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02tdch2tdzvcayrydrkcx3qp4kjwdgfsdn827g",
@@ -262,7 +358,10 @@
       "available": "3900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02u763rg5y5ec4s3ppzxhgy2ucznp4tsretuau",
@@ -270,7 +369,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ucem2cfjsqnxev5hmr4rckzqdtk33c6cvev8",
@@ -278,7 +380,10 @@
       "available": "189900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0302fv0gz858azasg663ax2epakk5fcssgza7j",
@@ -286,7 +391,10 @@
       "available": "744704363502",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp030grkp04yl7l2mjcskk79z20vrct62ua5m3pw",
@@ -294,7 +402,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp032gakpngap7zv30kjm7pp6tx084ktvgajjzzw",
@@ -302,7 +413,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp035mtxqmt5uamqj35xp0sg0pmh4s6x95ngvt5v",
@@ -310,7 +424,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp036vwpy7hkye0fxmxa2vuhc49r0nv0yyjrh0ss",
@@ -318,7 +435,10 @@
       "available": "300000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp037gd08rnpry2pm6lr4u6qgsysdd26dsfsc7x9",
@@ -326,7 +446,10 @@
       "available": "411900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0394v5dyugnlakjsm4vdhgm374sj2usu3ay00z",
@@ -334,7 +457,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ans0jzzn4vak3y2mvl5af5qwcngxcs8h25xl",
@@ -342,7 +468,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ap4ps8d204nw4y335lc5zyxw9l7g8vespy98",
@@ -350,7 +479,10 @@
       "available": "2538835787150",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03awwuh9ygldhaujfqhsntxw7f7wrx4vtrv3gq",
@@ -358,7 +490,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ecafgzkdek22trj399j3xn5qlxwgxvxlt82q",
@@ -366,7 +501,10 @@
       "available": "400000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ejsn62rd6uguadgfhyhgu7dpnq5xvqzahh3w",
@@ -374,7 +512,10 @@
       "available": "500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03el2l2zunt8kjnnaels9vghpq2zwjdynn6zwf",
@@ -382,7 +523,10 @@
       "available": "50000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03grg6l57h56ev2fltkyjnqqjntg5yrg3jadc3",
@@ -390,7 +534,10 @@
       "available": "6488000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03gtguq6xl2dnajtmh9ghae8sfzp3a4ywq7alw",
@@ -398,7 +545,10 @@
       "available": "95900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03m7huvzgmh0350ck03yv6dtnx7242kve5t3wx",
@@ -406,7 +556,10 @@
       "available": "400000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03pqs447zzt497ndcxkz842g4gnujju5fv8vxz",
@@ -414,7 +567,10 @@
       "available": "6900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03pw8222vkxn59x8qvcykl6n7qh44ryctktnmp",
@@ -422,7 +578,10 @@
       "available": "2900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03tr0fulqq5st52kemdr5humlrsfw98smhvf2g",
@@ -430,7 +589,10 @@
       "available": "10000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03vvx0retvarq5495fmdcwy6eudk9vevmak4kt",
@@ -438,7 +600,10 @@
       "available": "9300000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 8
+      "nonce": 8,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03yyvems3s5jtgvtzwn5jqurhjj3f9cq89p470",
@@ -446,7 +611,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0442kh0p7fuya4nqp7qek702rrvvphqqv00sce",
@@ -454,7 +622,10 @@
       "available": "99900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp044p7qp2l9h6kwgla5svc9qzltp5grlcchhjs3",
@@ -462,7 +633,10 @@
       "available": "20000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0457rvj592ukwwftk95uq2yes2cq244skc005u",
@@ -470,7 +644,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp048vzvyf8cdjqhru23zmpgc4vf0hxwese26647",
@@ -478,7 +655,10 @@
       "available": "6900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0493zz44duzs5xa8tjg5g0q20067ltzqevfsy6",
@@ -486,7 +666,10 @@
       "available": "2693400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04aptwxv3pmcqy3k6n7wpgnmejdmjjasls7ac2",
@@ -494,7 +677,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04aue9kupt28sdpknrx44zdq9snpk7hugkchc3",
@@ -502,7 +688,10 @@
       "available": "699999999",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04dsx8j95vxpv39dy0na4qc6y759cnmu37dmva",
@@ -510,7 +699,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04gvy3xv7d0dzdv8zn3jnnslh725uymsl48te6",
@@ -518,7 +710,10 @@
       "available": "21000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04lry8wzpawhq48r2sfn8a2w2edyt75gtggsmx",
@@ -526,7 +721,10 @@
       "available": "8531100000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04n4y79vkjf36xpumt9ae8t24t53a20u7573rv",
@@ -534,7 +732,10 @@
       "available": "695866468",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04q4ra4wg87jnndevummkq9sm229kjxvmqg5ze",
@@ -542,7 +743,10 @@
       "available": "300000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04upjaw3m6gktracvrrdrvwzdcxgl3cvc9qc24",
@@ -550,7 +754,10 @@
       "available": "37464974260",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04z4fsw57td5ahsdp6ffx6eups2fcrjvh9ft3l",
@@ -558,7 +765,10 @@
       "available": "1300000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp04z7tuyuasa69vzseqkluh7zya4f35xv6g38ym",
@@ -566,7 +776,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp052dtymzwleem7nlkxrnzp9lxhcaze5gpdq66z",
@@ -574,7 +787,10 @@
       "available": "12000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0538ytpt0wtxyy924jlfyhuz94tm5skspfy6mx",
@@ -582,7 +798,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp055zsmnpewaaa4ddz0rzvjqjdhxrc0356v0cmd",
@@ -590,7 +809,10 @@
       "available": "4918700000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp059yspjx7nuhs85kup6k99rz3c7wt7fgmgk4hz",
@@ -598,7 +820,10 @@
       "available": "6500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 11
+      "nonce": 11,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05a338jeqxrhdakpdh9k5q2efvnhmvgymk7fna",
@@ -606,7 +831,10 @@
       "available": "400000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05d3n92xyjwwnm82vdqmghrtl7l8r5eyn2gnzw",
@@ -614,7 +842,10 @@
       "available": "2900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05elhgff6n34t758efy6y0drhy7lqw4sj80gg4",
@@ -622,7 +853,10 @@
       "available": "10000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05j5jd9ragpp9w3q98ddcnnxdda7l0hut0t47n",
@@ -630,7 +864,10 @@
       "available": "610087903",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05l3hl8tm893rweh3ez4pa2u5rv6mcvy676mrs",
@@ -638,7 +875,10 @@
       "available": "3000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05mn83rr70jh5s3lwfyusrnu4xg429vyahz5mj",
@@ -646,7 +886,10 @@
       "available": "25900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05ndmmylmdjjwc34zqv0e6vq2l59hl65cuezqw",
@@ -654,7 +897,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05nj9nwkvfmxcm9u7asv739qku8ek3es9gmha5",
@@ -662,7 +908,10 @@
       "available": "4707284760",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05ut8dwkk00f0k33pjvh24qs5wu9tyv5uyflxp",
@@ -670,7 +919,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05v0umf4t79fkj9ckcn2vn66056sjd5grf9udf",
@@ -678,7 +930,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05v7gexfp7nh9z9pqtwzrkvldjspraecmjgyte",
@@ -686,7 +941,10 @@
       "available": "800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05wp5nwz29fpvnwvdxpplyhllcrfmvqq8ulepz",
@@ -694,7 +952,10 @@
       "available": "800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05x4ssvjg9867m8rjkludk43re0y480c5r2y8n",
@@ -702,7 +963,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05xzre088lr95ryfvsn86hquuntqvxly4sc3m3",
@@ -710,7 +974,10 @@
       "available": "513124520",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp05yrvh8wtxylphmwfgkgtswy797tzd2u564n0m",
@@ -718,7 +985,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp064n4qpe2mfnkkqytdx6n5q2v285ngnsewweku",
@@ -726,7 +996,10 @@
       "available": "3530230228850",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp065ghs5wfcsmwq98daw83zmjq4kxmjtckur50j",
@@ -734,7 +1007,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp066as3fwjhjw8wjv3p0rafjxnhmt7ad5qmfyfq",
@@ -742,7 +1018,10 @@
       "available": "3187279137713",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp067ekdegws80fhsemu8xv0dkyq3ahvmynhqdfe",
@@ -750,7 +1029,10 @@
       "available": "9726415410",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06fecjzkwdfwzzcal7yzea5xvuqza8ugnnp90n",
@@ -758,7 +1040,10 @@
       "available": "16562900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06femjaryl3924uugflmq2ecfsqcjn4y4xy4ah",
@@ -766,7 +1051,10 @@
       "available": "500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06fvu7qnzud4cla44nwst635vv8rg43sxhx4ep",
@@ -774,7 +1062,10 @@
       "available": "1400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06j9auxaaskc7f7fafy5cuhvwjdyna4gryan3n",
@@ -782,7 +1073,10 @@
       "available": "215937477601",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 12
+      "nonce": 12,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06mjhl3cqdsdgy3re3zk22py6te7kq25mxxv40",
@@ -790,7 +1084,10 @@
       "available": "6986000210",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp06nz9xht0ndsfn0l8yu39rv5eympekhcu8hhdp",
@@ -798,7 +1095,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/damask/expected/runtime-only_account.body
+++ b/tests/e2e_regression/damask/expected/runtime-only_account.body
@@ -6,5 +6,8 @@
   "debonding_delegations_balance": "0",
   "delegations_balance": "0",
   "escrow": "0",
-  "nonce": 0
+  "nonce": 0,
+  "stats": {
+    "num_txns": 0
+  }
 }

--- a/tests/e2e_regression/eden/expected/account.body
+++ b/tests/e2e_regression/eden/expected/account.body
@@ -6,5 +6,8 @@
   "debonding_delegations_balance": "0",
   "delegations_balance": "0",
   "escrow": "0",
-  "nonce": 5
+  "nonce": 5,
+  "stats": {
+    "num_txns": 0
+  }
 }

--- a/tests/e2e_regression/eden/expected/account_with_tx.body
+++ b/tests/e2e_regression/eden/expected/account_with_tx.body
@@ -1,0 +1,13 @@
+{
+  "address": "oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3",
+  "allowances": [],
+  "available": "3036607278631",
+  "debonding": "1965872937151756",
+  "debonding_delegations_balance": "0",
+  "delegations_balance": "2037661421211704",
+  "escrow": "281559416810441006",
+  "nonce": 22,
+  "stats": {
+    "num_txns": 3
+  }
+}

--- a/tests/e2e_regression/eden/expected/account_with_tx.headers
+++ b/tests/e2e_regression/eden/expected/account_with_tx.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden/expected/accounts.body
+++ b/tests/e2e_regression/eden/expected/accounts.body
@@ -6,7 +6,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000fhq57588cd7hmrszzm4vchkf64nmgvr6try",
@@ -14,7 +17,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000hx7p3elxrglmg6r98zkenk0sjt4ks986dc3",
@@ -22,7 +28,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000kj5dj5tf48x0rhzf8298dw78w2yzvza727z",
@@ -30,7 +39,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00254dnrcdexf6eph5nns3yjn0rptqw5ttzqs0",
@@ -38,7 +50,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002d6rv8r0zmhfe69th39rm0uaz4j6rsm5glcy",
@@ -46,7 +61,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002ex775uku5g5q8p7ghsgu923thyr4yhfkm5j",
@@ -54,7 +72,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002x6upufh2h9qgkp3xaauz3psjvafhgc60g68",
@@ -62,7 +83,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002zmd2psenqaklm55cx0z2uwuttzzy5gcdjm4",
@@ -70,7 +94,10 @@
       "available": "100000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0033cpqmr59uyf5m2meq8kj5swrccm8gvur5rm",
@@ -78,7 +105,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0036xtdxumaav7t3f2rxkpcl4u7uqafgs58gpp",
@@ -86,7 +116,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0046fqy37v9u70mrdskf99z620h0tfcgzcu73u",
@@ -94,7 +127,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -102,7 +138,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp005txjcwj3d8hmre0vxr2ve3z3dxpk25x7zps4",
@@ -110,7 +149,10 @@
       "available": "8100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp005ufkeewhfsl4m8h2c2gd44u8sjah7skp60vs",
@@ -118,7 +160,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006mgh23l6fz7ap27m04wzflwawxw02cqzsezm",
@@ -126,7 +171,10 @@
       "available": "51530000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006nj305aks8cqwatrpzzf3j3we4tk5vkrzlkk",
@@ -134,7 +182,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006t7se986qq37ygvrx6wwa55s5wgcnu34m88n",
@@ -142,7 +193,10 @@
       "available": "3992089",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0073gmez9cgwpp8hx43dhefljj5unresgqmznj",
@@ -150,7 +204,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0078p43wkm3f7y9gwpxd8ymj9q0aqdes9ej0m8",
@@ -158,7 +215,10 @@
       "available": "702000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp007rrxvqzps77ds8jj96nraa9gwudj95r6876v",
@@ -166,7 +226,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp007t0eem9sf950de6z7jlacf2qv5glsgufcc74",
@@ -174,7 +237,10 @@
       "available": "3279800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0088hdxzs8r94ae048rhrpv4m0taumcqanhe4u",
@@ -182,7 +248,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008f6fg9kqk6gt9vxf5yk2d5wv7vm2x5tkc88y",
@@ -190,7 +259,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008qtlx587fcu9cx6a56ehsjkj5g5dnsfw85rr",
@@ -198,7 +270,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008xpw8calf0pnpjnfsn09ute9en62uq94gfts",
@@ -206,7 +281,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0098rk2cd0unzr7666987cultg9c5rxgep2crk",
@@ -214,7 +292,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp009q6yrfgu0w0aaekyl3dtum9e06u46qetknhm",
@@ -222,7 +303,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00a7x3t08vnevjqgkmnyacd47cxumvhvp5665f",
@@ -230,7 +314,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00c73tjphyes84t6lxcl5n5qyqd0ymu5283dn3",
@@ -238,7 +325,10 @@
       "available": "312226292912",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 30
+      "nonce": 30,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ceps9zwtkrn58lz6xvr9ddsj2x4l8yq408pr",
@@ -246,7 +336,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cm4ww7q0lpf4ruyt8ezuw64gjnmt6q08th8v",
@@ -254,7 +347,10 @@
       "available": "3884900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cnz84jzlvp49rsfpslaje026k55q352ysfxj",
@@ -262,7 +358,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cvnj42wqcuzelqg6ser9cyndlyhdeyqvf5vz",
@@ -270,7 +369,10 @@
       "available": "7658685000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00d0hp8pdzncpg39ynrkg547wyfdcrh57485hy",
@@ -278,7 +380,10 @@
       "available": "10001388000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00dggglpnyg3536p0hr5redjfytfzclvqseyk9",
@@ -286,7 +391,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00dvavlz633e6fmput904jlvzjdxaf5y5slz3c",
@@ -294,7 +402,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00e7emjdfllmu3f0e65cn97cvumcfskuusmy7h",
@@ -302,7 +413,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -310,7 +424,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00espas4yufdg4uuzh63s6gysz52628qqr9zm5",
@@ -318,7 +435,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00fnd2q8xmjvavt0j09ywazcu2gkd2duw6f9th",
@@ -326,7 +446,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ftxjm73zqxsnsx2wd82umsvzj88gt5f5lfu7",
@@ -334,7 +457,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00g3stymym336s04u2jdh7zhqmf2xxpcatppgz",
@@ -342,7 +468,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -350,7 +479,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gjlafqsrrlafcqsa09twkg5c4979mu2mypmh",
@@ -358,7 +490,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -366,7 +501,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lad2j8hnh4ek3kekgulqjcrxgr8g9cluyw68",
@@ -374,7 +512,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00llca30cdv3rl09sduzk64hv5u7tkh5m4veuf",
@@ -382,7 +523,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lppkfccyycwud82an4rt8g4dz84p5ydm9qvj",
@@ -390,7 +534,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00mwz4ey42w80n0xyy6tgrlvsa8k5qhv77s6rc",
@@ -398,7 +545,10 @@
       "available": "23358829000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -406,7 +556,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00narafc2krmwqaw45ww9t6mmc4cy2nujmpmkq",
@@ -414,7 +567,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nfpl7a6059kz5um0ykqvdzxkuxg3py200xz0",
@@ -422,7 +578,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nhzaacke8chwnrrvnp8uf4nlznrtfu92j8ln",
@@ -430,7 +589,10 @@
       "available": "67461",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nkqfuwgshzwe2w25vwy765ccd2zlaus34t3c",
@@ -438,7 +600,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -446,7 +611,10 @@
       "available": "1916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 16
+      "nonce": 16,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pcmvajl5mmllh2t785mdcj3f890y8v9mrrq6",
@@ -454,7 +622,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pt4yuul66v3y0ednn0a7glnap4fe5uczs5tg",
@@ -462,7 +633,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pxap66dg7qtry5ts9r6j85ej2mj765eqs5ue",
@@ -470,7 +644,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00qfjw0e43ew8n708tzjyfs8zs379tnyc7yvn0",
@@ -478,7 +655,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -486,7 +666,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -494,7 +677,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -502,7 +688,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8azzdpusgv9c7edlq3c9yl09v3dq5genyh2",
@@ -510,7 +699,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8s2d90gvfe904mjqsmnat9j3m2y2q6rz99f",
@@ -518,7 +710,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -526,7 +721,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00slzdmuy84eefcths8qvr9whys0zuwyms2gpj",
@@ -534,7 +732,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00suftr2lg2su9h45uaj98yx3rk4496usqmpdy",
@@ -542,7 +743,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00svannwrsrl5g5n3qq5624xcyrd9tyvdgl4jy",
@@ -550,7 +754,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00t58xv7qmfxe202t7gfggq8ny78fsrvl2zxw8",
@@ -558,7 +765,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00uekkldaw7njq8ukmzsvzkdhyrp7wqgutv3g3",
@@ -566,7 +776,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -574,7 +787,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vpm4627l2yes6x9vkmmdfk2flh70jgzmch44",
@@ -582,7 +798,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 25
+      "nonce": 25,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vzlerguawefhrnlynm0wfmluukth4crhe5px",
@@ -590,7 +809,10 @@
       "available": "600800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w0xae4lfegn8g76apusnzjzgjd0upyx7vsnj",
@@ -598,7 +820,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w23hwk0r70046azuv39965n4qvc77ug7eaf7",
@@ -606,7 +831,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -614,7 +842,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnmpcmjwc5upc6l30ztknjsl7w8wtc9ejp72",
@@ -622,7 +853,10 @@
       "available": "6386958",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnym496x0jt96a72fm48tw67jms6acwe73k7",
@@ -630,7 +864,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wrpk868nrwe58t7wy5k9jd7l3rucagsjh263",
@@ -638,7 +875,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00x0kh4jm3smgmcde773jpmhwr0tmuggxgjhf7",
@@ -646,7 +886,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xfr5gysq6wa0g625jydlvgcnq803vy7frvkc",
@@ -654,7 +897,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xg20un6q95kk3yjwp3tky493020u85gjjewn",
@@ -662,7 +908,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xstfeexvy59ufcfg0az4z7xenyhtrysq9n6e",
@@ -670,7 +919,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00y0schgensw0xn0hpv7setrj2k2h4nqq62qyk",
@@ -678,7 +930,10 @@
       "available": "259900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00y7rrweu4v9llqqydcst04mapgle5vq34v77u",
@@ -686,7 +941,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02042wd8nphz2vsqljnrdfgd74cmzh2gkxte4a",
@@ -694,7 +952,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -702,7 +963,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020czl4w8sudc2wdj5zwxrskuq54cxnqhy4l8a",
@@ -710,7 +974,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020g2q9g7agse8pgmvjd5f9075lylptygpw5aa",
@@ -718,7 +985,10 @@
       "available": "10980000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020sm24feve562fcg3jrmyn7kt8gxgh5tzgj0z",
@@ -726,7 +996,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020t3lt8y098s8pd7jlgwfsj8f9q56qv40fruk",
@@ -734,7 +1007,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -742,7 +1018,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022weu0tv9qdsqtsncj2dfnfnet3sddghgpqgs",
@@ -750,7 +1029,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023glr0j2jqa6x5p6x4uy8mkauv5m5aujecjh0",
@@ -758,7 +1040,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023qm2v0w9njrkx5nsf89tdnmh4famry4qsw7l",
@@ -766,7 +1051,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023ywpc43he3yz6tfxsw75ydympcuary0jc9t5",
@@ -774,7 +1062,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -782,7 +1073,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024swmcac4vluht42r6sm4vky54rla8v8938j2",
@@ -790,7 +1084,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024td9qsd8ar0v997slwv59vydxe0cay4veryd",
@@ -798,7 +1095,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/eden/expected/accounts_extraneous_key.body
+++ b/tests/e2e_regression/eden/expected/accounts_extraneous_key.body
@@ -6,7 +6,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000fhq57588cd7hmrszzm4vchkf64nmgvr6try",
@@ -14,7 +17,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000hx7p3elxrglmg6r98zkenk0sjt4ks986dc3",
@@ -22,7 +28,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp000kj5dj5tf48x0rhzf8298dw78w2yzvza727z",
@@ -30,7 +39,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00254dnrcdexf6eph5nns3yjn0rptqw5ttzqs0",
@@ -38,7 +50,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002d6rv8r0zmhfe69th39rm0uaz4j6rsm5glcy",
@@ -46,7 +61,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002ex775uku5g5q8p7ghsgu923thyr4yhfkm5j",
@@ -54,7 +72,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002x6upufh2h9qgkp3xaauz3psjvafhgc60g68",
@@ -62,7 +83,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp002zmd2psenqaklm55cx0z2uwuttzzy5gcdjm4",
@@ -70,7 +94,10 @@
       "available": "100000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0033cpqmr59uyf5m2meq8kj5swrccm8gvur5rm",
@@ -78,7 +105,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0036xtdxumaav7t3f2rxkpcl4u7uqafgs58gpp",
@@ -86,7 +116,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0046fqy37v9u70mrdskf99z620h0tfcgzcu73u",
@@ -94,7 +127,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -102,7 +138,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp005txjcwj3d8hmre0vxr2ve3z3dxpk25x7zps4",
@@ -110,7 +149,10 @@
       "available": "8100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp005ufkeewhfsl4m8h2c2gd44u8sjah7skp60vs",
@@ -118,7 +160,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006mgh23l6fz7ap27m04wzflwawxw02cqzsezm",
@@ -126,7 +171,10 @@
       "available": "51530000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006nj305aks8cqwatrpzzf3j3we4tk5vkrzlkk",
@@ -134,7 +182,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006t7se986qq37ygvrx6wwa55s5wgcnu34m88n",
@@ -142,7 +193,10 @@
       "available": "3992089",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0073gmez9cgwpp8hx43dhefljj5unresgqmznj",
@@ -150,7 +204,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0078p43wkm3f7y9gwpxd8ymj9q0aqdes9ej0m8",
@@ -158,7 +215,10 @@
       "available": "702000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp007rrxvqzps77ds8jj96nraa9gwudj95r6876v",
@@ -166,7 +226,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp007t0eem9sf950de6z7jlacf2qv5glsgufcc74",
@@ -174,7 +237,10 @@
       "available": "3279800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0088hdxzs8r94ae048rhrpv4m0taumcqanhe4u",
@@ -182,7 +248,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008f6fg9kqk6gt9vxf5yk2d5wv7vm2x5tkc88y",
@@ -190,7 +259,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008qtlx587fcu9cx6a56ehsjkj5g5dnsfw85rr",
@@ -198,7 +270,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp008xpw8calf0pnpjnfsn09ute9en62uq94gfts",
@@ -206,7 +281,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0098rk2cd0unzr7666987cultg9c5rxgep2crk",
@@ -214,7 +292,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp009q6yrfgu0w0aaekyl3dtum9e06u46qetknhm",
@@ -222,7 +303,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00a7x3t08vnevjqgkmnyacd47cxumvhvp5665f",
@@ -230,7 +314,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00c73tjphyes84t6lxcl5n5qyqd0ymu5283dn3",
@@ -238,7 +325,10 @@
       "available": "312226292912",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 30
+      "nonce": 30,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ceps9zwtkrn58lz6xvr9ddsj2x4l8yq408pr",
@@ -246,7 +336,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cm4ww7q0lpf4ruyt8ezuw64gjnmt6q08th8v",
@@ -254,7 +347,10 @@
       "available": "3884900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cnz84jzlvp49rsfpslaje026k55q352ysfxj",
@@ -262,7 +358,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cvnj42wqcuzelqg6ser9cyndlyhdeyqvf5vz",
@@ -270,7 +369,10 @@
       "available": "7658685000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00d0hp8pdzncpg39ynrkg547wyfdcrh57485hy",
@@ -278,7 +380,10 @@
       "available": "10001388000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00dggglpnyg3536p0hr5redjfytfzclvqseyk9",
@@ -286,7 +391,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00dvavlz633e6fmput904jlvzjdxaf5y5slz3c",
@@ -294,7 +402,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00e7emjdfllmu3f0e65cn97cvumcfskuusmy7h",
@@ -302,7 +413,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -310,7 +424,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00espas4yufdg4uuzh63s6gysz52628qqr9zm5",
@@ -318,7 +435,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00fnd2q8xmjvavt0j09ywazcu2gkd2duw6f9th",
@@ -326,7 +446,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ftxjm73zqxsnsx2wd82umsvzj88gt5f5lfu7",
@@ -334,7 +457,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00g3stymym336s04u2jdh7zhqmf2xxpcatppgz",
@@ -342,7 +468,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -350,7 +479,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gjlafqsrrlafcqsa09twkg5c4979mu2mypmh",
@@ -358,7 +490,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -366,7 +501,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lad2j8hnh4ek3kekgulqjcrxgr8g9cluyw68",
@@ -374,7 +512,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00llca30cdv3rl09sduzk64hv5u7tkh5m4veuf",
@@ -382,7 +523,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lppkfccyycwud82an4rt8g4dz84p5ydm9qvj",
@@ -390,7 +534,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00mwz4ey42w80n0xyy6tgrlvsa8k5qhv77s6rc",
@@ -398,7 +545,10 @@
       "available": "23358829000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -406,7 +556,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00narafc2krmwqaw45ww9t6mmc4cy2nujmpmkq",
@@ -414,7 +567,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nfpl7a6059kz5um0ykqvdzxkuxg3py200xz0",
@@ -422,7 +578,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nhzaacke8chwnrrvnp8uf4nlznrtfu92j8ln",
@@ -430,7 +589,10 @@
       "available": "67461",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nkqfuwgshzwe2w25vwy765ccd2zlaus34t3c",
@@ -438,7 +600,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -446,7 +611,10 @@
       "available": "1916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 16
+      "nonce": 16,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pcmvajl5mmllh2t785mdcj3f890y8v9mrrq6",
@@ -454,7 +622,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pt4yuul66v3y0ednn0a7glnap4fe5uczs5tg",
@@ -462,7 +633,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00pxap66dg7qtry5ts9r6j85ej2mj765eqs5ue",
@@ -470,7 +644,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00qfjw0e43ew8n708tzjyfs8zs379tnyc7yvn0",
@@ -478,7 +655,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -486,7 +666,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -494,7 +677,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -502,7 +688,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8azzdpusgv9c7edlq3c9yl09v3dq5genyh2",
@@ -510,7 +699,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s8s2d90gvfe904mjqsmnat9j3m2y2q6rz99f",
@@ -518,7 +710,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -526,7 +721,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00slzdmuy84eefcths8qvr9whys0zuwyms2gpj",
@@ -534,7 +732,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00suftr2lg2su9h45uaj98yx3rk4496usqmpdy",
@@ -542,7 +743,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00svannwrsrl5g5n3qq5624xcyrd9tyvdgl4jy",
@@ -550,7 +754,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00t58xv7qmfxe202t7gfggq8ny78fsrvl2zxw8",
@@ -558,7 +765,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00uekkldaw7njq8ukmzsvzkdhyrp7wqgutv3g3",
@@ -566,7 +776,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -574,7 +787,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vpm4627l2yes6x9vkmmdfk2flh70jgzmch44",
@@ -582,7 +798,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 25
+      "nonce": 25,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vzlerguawefhrnlynm0wfmluukth4crhe5px",
@@ -590,7 +809,10 @@
       "available": "600800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w0xae4lfegn8g76apusnzjzgjd0upyx7vsnj",
@@ -598,7 +820,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00w23hwk0r70046azuv39965n4qvc77ug7eaf7",
@@ -606,7 +831,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -614,7 +842,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnmpcmjwc5upc6l30ztknjsl7w8wtc9ejp72",
@@ -622,7 +853,10 @@
       "available": "6386958",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnym496x0jt96a72fm48tw67jms6acwe73k7",
@@ -630,7 +864,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wrpk868nrwe58t7wy5k9jd7l3rucagsjh263",
@@ -638,7 +875,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00x0kh4jm3smgmcde773jpmhwr0tmuggxgjhf7",
@@ -646,7 +886,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xfr5gysq6wa0g625jydlvgcnq803vy7frvkc",
@@ -654,7 +897,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 7
+      "nonce": 7,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xg20un6q95kk3yjwp3tky493020u85gjjewn",
@@ -662,7 +908,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00xstfeexvy59ufcfg0az4z7xenyhtrysq9n6e",
@@ -670,7 +919,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00y0schgensw0xn0hpv7setrj2k2h4nqq62qyk",
@@ -678,7 +930,10 @@
       "available": "259900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00y7rrweu4v9llqqydcst04mapgle5vq34v77u",
@@ -686,7 +941,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02042wd8nphz2vsqljnrdfgd74cmzh2gkxte4a",
@@ -694,7 +952,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -702,7 +963,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020czl4w8sudc2wdj5zwxrskuq54cxnqhy4l8a",
@@ -710,7 +974,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020g2q9g7agse8pgmvjd5f9075lylptygpw5aa",
@@ -718,7 +985,10 @@
       "available": "10980000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020sm24feve562fcg3jrmyn7kt8gxgh5tzgj0z",
@@ -726,7 +996,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020t3lt8y098s8pd7jlgwfsj8f9q56qv40fruk",
@@ -734,7 +1007,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -742,7 +1018,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022weu0tv9qdsqtsncj2dfnfnet3sddghgpqgs",
@@ -750,7 +1029,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023glr0j2jqa6x5p6x4uy8mkauv5m5aujecjh0",
@@ -758,7 +1040,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023qm2v0w9njrkx5nsf89tdnmh4famry4qsw7l",
@@ -766,7 +1051,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023ywpc43he3yz6tfxsw75ydympcuary0jc9t5",
@@ -774,7 +1062,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -782,7 +1073,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024swmcac4vluht42r6sm4vky54rla8v8938j2",
@@ -790,7 +1084,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp024td9qsd8ar0v997slwv59vydxe0cay4veryd",
@@ -798,7 +1095,10 @@
       "available": "0",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/eden/expected/min_balance.body
+++ b/tests/e2e_regression/eden/expected/min_balance.body
@@ -6,7 +6,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00254dnrcdexf6eph5nns3yjn0rptqw5ttzqs0",
@@ -14,7 +17,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0033cpqmr59uyf5m2meq8kj5swrccm8gvur5rm",
@@ -22,7 +28,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0052pu6cdst4grc9htdx4c5cc42hx99sufv6f5",
@@ -30,7 +39,10 @@
       "available": "1500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 9
+      "nonce": 9,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp005txjcwj3d8hmre0vxr2ve3z3dxpk25x7zps4",
@@ -38,7 +50,10 @@
       "available": "8100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006mgh23l6fz7ap27m04wzflwawxw02cqzsezm",
@@ -46,7 +61,10 @@
       "available": "51530000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp006t7se986qq37ygvrx6wwa55s5wgcnu34m88n",
@@ -54,7 +72,10 @@
       "available": "3992089",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0078p43wkm3f7y9gwpxd8ymj9q0aqdes9ej0m8",
@@ -62,7 +83,10 @@
       "available": "702000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp007t0eem9sf950de6z7jlacf2qv5glsgufcc74",
@@ -70,7 +94,10 @@
       "available": "3279800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00c73tjphyes84t6lxcl5n5qyqd0ymu5283dn3",
@@ -78,7 +105,10 @@
       "available": "312226292912",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 30
+      "nonce": 30,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cm4ww7q0lpf4ruyt8ezuw64gjnmt6q08th8v",
@@ -86,7 +116,10 @@
       "available": "3884900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00cvnj42wqcuzelqg6ser9cyndlyhdeyqvf5vz",
@@ -94,7 +127,10 @@
       "available": "7658685000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00d0hp8pdzncpg39ynrkg547wyfdcrh57485hy",
@@ -102,7 +138,10 @@
       "available": "10001388000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00eh8k8nywj9qqjy7sw9e7ml3g2ffylgcd0954",
@@ -110,7 +149,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gh2xzswsddks578q2w3xv8ayzuxmc5luanl7",
@@ -118,7 +160,10 @@
       "available": "330467776570",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00gl2xnaly8nhxp8wxes805ekmmknhc59gugy6",
@@ -126,7 +171,10 @@
       "available": "2000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00lad2j8hnh4ek3kekgulqjcrxgr8g9cluyw68",
@@ -134,7 +182,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00mwz4ey42w80n0xyy6tgrlvsa8k5qhv77s6rc",
@@ -142,7 +193,10 @@
       "available": "23358829000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00myl9jglx33q6p6azxsqx0xswqhffr5dnt5vp",
@@ -150,7 +204,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00narafc2krmwqaw45ww9t6mmc4cy2nujmpmkq",
@@ -158,7 +215,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00nyjtvahwlp5452ndca5l82jvcfr8xqratswg",
@@ -166,7 +226,10 @@
       "available": "1916795745",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 16
+      "nonce": 16,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ra8zwdrqmptdh3xwepj4jmf4ceeqzcd0dsgz",
@@ -174,7 +237,10 @@
       "available": "11900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00rue5tygytj39hgk0ygmwze39clx7egqlz8h4",
@@ -182,7 +248,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00s6dkgulsxc8vycjxwupwwlh02x38xsua4z57",
@@ -190,7 +259,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00sdw3f85dykwgq4hjtct43fn6gda295uauwlf",
@@ -198,7 +270,10 @@
       "available": "2475125000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00ul440fjeuq58qv95p3et3erz026c8q86uj5v",
@@ -206,7 +281,10 @@
       "available": "5900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00vzlerguawefhrnlynm0wfmluukth4crhe5px",
@@ -214,7 +292,10 @@
       "available": "600800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wltgunnj9w982hkmwe4lpc5zg6eq3sdhds90",
@@ -222,7 +303,10 @@
       "available": "31900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00wnmpcmjwc5upc6l30ztknjsl7w8wtc9ejp72",
@@ -230,7 +314,10 @@
       "available": "6386958",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp00y0schgensw0xn0hpv7setrj2k2h4nqq62qyk",
@@ -238,7 +325,10 @@
       "available": "259900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0207jnr57604q9f4wk7tkxqssg6ex9furl2mns",
@@ -246,7 +336,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020g2q9g7agse8pgmvjd5f9075lylptygpw5aa",
@@ -254,7 +347,10 @@
       "available": "10980000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp020t3lt8y098s8pd7jlgwfsj8f9q56qv40fruk",
@@ -262,7 +358,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022pmrltefaj2a87faj34zf465zz54rqwehsk5",
@@ -270,7 +369,10 @@
       "available": "29928000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp022weu0tv9qdsqtsncj2dfnfnet3sddghgpqgs",
@@ -278,7 +380,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp023qm2v0w9njrkx5nsf89tdnmh4famry4qsw7l",
@@ -286,7 +391,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02466fxnecqe8s8ghe5estg3f4gpjf9srywzcv",
@@ -294,7 +402,10 @@
       "available": "408800000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp028tzl3mudsug9j2eh9hkrjzllmmc6u5pn2kvj",
@@ -302,7 +413,10 @@
       "available": "31400000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0297t4m5eqhucezc5kf70ney5256gensqlv7ax",
@@ -310,7 +424,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp029kd0r60ccckld0440lmcknuryk29wq0pa00a",
@@ -318,7 +435,10 @@
       "available": "5771561870000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ajsljlgvv4t2l3x5csslyzj0rfvfkqzek7te",
@@ -326,7 +446,10 @@
       "available": "2227774628257",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02c0zt8jj4j4l0j495qncq02mcxxg3hy6pd6yv",
@@ -334,7 +457,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02crh78v89n3533vpdxfmpzmt9j2y5fg0q7sjd",
@@ -342,7 +468,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fmhltqdhhgg06ycw6q4n6kkx8kppyys3lucp",
@@ -350,7 +479,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02fre745kazh7k277tnkq7csngpcgjvggrnmqg",
@@ -358,7 +490,10 @@
       "available": "100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ggy3qs6aw63frtmvuu0hphuftgylnvpunw0f",
@@ -366,7 +501,10 @@
       "available": "497057401",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02j2544udkjvqfm37dz67h8j84djwqwc9a8k3a",
@@ -374,7 +512,10 @@
       "available": "862118712430",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02j8n220mzjpjvckqkppj7pye5atct3gmn48rj",
@@ -382,7 +523,10 @@
       "available": "51949970510",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02jzag8kq9gyxvk67hz7d3uc9hg6x05qtttw26",
@@ -390,7 +534,10 @@
       "available": "5000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02kh4zlx5z8vrkwndh4dq4em5j5d3xuvrwa6fd",
@@ -398,7 +545,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ldyhflh26lnaqqztedwx45hpepn5d5gv43v4",
@@ -406,7 +556,10 @@
       "available": "2277395554657",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02maxhquje0sjaus86xvnehxj27ctkjy4u7qpt",
@@ -414,7 +567,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02mp338hgzjq4h3j5uvvpq3dltkpa8rca4hcrs",
@@ -422,7 +578,10 @@
       "available": "42900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02mr4e0atk388zzjmwzgmqv06xc0ygfc5sug7u",
@@ -430,7 +589,10 @@
       "available": "11000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n3yn3pfn8ssyjaq6c9j9nrekrmkvhyewqeau",
@@ -438,7 +600,10 @@
       "available": "24800000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02n9lrth0sxp57raez0te2gdsxw9tts5xtwn9e",
@@ -446,7 +611,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02r4qua8xvm6d6h824aylgdg6jdrznyqrzw7r8",
@@ -454,7 +622,10 @@
       "available": "297665891840",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02tdch2tdzvcayrydrkcx3qp4kjwdgfsdn827g",
@@ -462,7 +633,10 @@
       "available": "3900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02u763rg5y5ec4s3ppzxhgy2ucznp4tsretuau",
@@ -470,7 +644,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02ucem2cfjsqnxev5hmr4rckzqdtk33c6cvev8",
@@ -478,7 +655,10 @@
       "available": "189900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02uxdh8hzmf354yrmnfhrfrv98qw32xsr5vkd9",
@@ -486,7 +666,10 @@
       "available": "151629005063033",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02vqyfk629kxwthtgz74nytm8urp5n354cazet",
@@ -494,7 +677,10 @@
       "available": "41464200000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02x3r3dvx4cemekurmk7v3h0j4vljhjy4zq2dq",
@@ -502,7 +688,10 @@
       "available": "171320000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp02xswcpzz4dwfu9nxsryf4nl4za6f9jq3dd3a7",
@@ -510,7 +699,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0302fv0gz858azasg663ax2epakk5fcssgza7j",
@@ -518,7 +710,10 @@
       "available": "744704363502",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 5
+      "nonce": 5,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp030grkp04yl7l2mjcskk79z20vrct62ua5m3pw",
@@ -526,7 +721,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp032gakpngap7zv30kjm7pp6tx084ktvgajjzzw",
@@ -534,7 +732,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0330t2jrmwudv8uw2f4cwes3ddzlyht5yd6v07",
@@ -542,7 +743,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp034rlcaj9ps889wdk9sza8azkmqfpyzyhk0kxy",
@@ -550,7 +754,10 @@
       "available": "5000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp035mtxqmt5uamqj35xp0sg0pmh4s6x95ngvt5v",
@@ -558,7 +765,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp036vwpy7hkye0fxmxa2vuhc49r0nv0yyjrh0ss",
@@ -566,7 +776,10 @@
       "available": "300000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp037annn8kk4rhtq5hj7aqnh7yykc39458ajcrx",
@@ -574,7 +787,10 @@
       "available": "29900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp037gd08rnpry2pm6lr4u6qgsysdd26dsfsc7x9",
@@ -582,7 +798,10 @@
       "available": "4007962165070",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp037gepxehttrharaadguy5dgzmp6f0ayq7zeq4",
@@ -590,7 +809,10 @@
       "available": "600000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 4
+      "nonce": 4,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp038pfxse0dv2svmy9jlhernqk0rmcdjss8mpc8",
@@ -598,7 +820,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp0394v5dyugnlakjsm4vdhgm374sj2usu3ay00z",
@@ -606,7 +831,10 @@
       "available": "1200000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ans0jzzn4vak3y2mvl5af5qwcngxcs8h25xl",
@@ -614,7 +842,10 @@
       "available": "1900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ap4ps8d204nw4y335lc5zyxw9l7g8vespy98",
@@ -622,7 +853,10 @@
       "available": "2538835787150",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03awwuh9ygldhaujfqhsntxw7f7wrx4vtrv3gq",
@@ -630,7 +864,10 @@
       "available": "1100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03e2qtv9kpds750e8cq5yzck6zjxkpquxgnshx",
@@ -638,7 +875,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ecafgzkdek22trj399j3xn5qlxwgxvxlt82q",
@@ -646,7 +886,10 @@
       "available": "400000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ejsn62rd6uguadgfhyhgu7dpnq5xvqzahh3w",
@@ -654,7 +897,10 @@
       "available": "500000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03el2l2zunt8kjnnaels9vghpq2zwjdynn6zwf",
@@ -662,7 +908,10 @@
       "available": "50000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03endw0utzjyhpekkw3qscqzt8ccvh6y4yxd5h",
@@ -670,7 +919,10 @@
       "available": "2048408562",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03fzayupldn4fwwla67vv4yz9facdmqq7kl9qm",
@@ -678,7 +930,10 @@
       "available": "454869938",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 18
+      "nonce": 18,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03gtguq6xl2dnajtmh9ghae8sfzp3a4ywq7alw",
@@ -686,7 +941,10 @@
       "available": "95900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03llhhntujl6y2xgmkjunml8drjj506cjghz96",
@@ -694,7 +952,10 @@
       "available": "2027996714870",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03m7huvzgmh0350ck03yv6dtnx7242kve5t3wx",
@@ -702,7 +963,10 @@
       "available": "1000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 12
+      "nonce": 12,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03p3vumc9dzj5pphx5uetecvc4fx63ac07dvvs",
@@ -710,7 +974,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03pqs447zzt497ndcxkz842g4gnujju5fv8vxz",
@@ -718,7 +985,10 @@
       "available": "6900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03pw8222vkxn59x8qvcykl6n7qh44ryctktnmp",
@@ -726,7 +996,10 @@
       "available": "2900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03qeq8sfjeeffu9snju23u8ftlskcw2vpl8fhk",
@@ -734,7 +1007,10 @@
       "available": "1000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03ql5jzna0qp549usgj37l0wz4ad877gwrf4nk",
@@ -742,7 +1018,10 @@
       "available": "7704620000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03r7fap9cg5rlvmt0shj73qnru8kn09cu7m676",
@@ -750,7 +1029,10 @@
       "available": "272233102174",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 6
+      "nonce": 6,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03t6j0pgpcxkn6uplh45e2637muaxfjyatmfsf",
@@ -758,7 +1040,10 @@
       "available": "5100000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 2
+      "nonce": 2,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03tr0fulqq5st52kemdr5humlrsfw98smhvf2g",
@@ -766,7 +1051,10 @@
       "available": "10000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 0
+      "nonce": 0,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03vvx0retvarq5495fmdcwy6eudk9vevmak4kt",
@@ -774,7 +1062,10 @@
       "available": "6728913414",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 14
+      "nonce": 14,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03xe32mzscq8kakwve7225ff4jq2qqgcdext0j",
@@ -782,7 +1073,10 @@
       "available": "17216606899998",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 10
+      "nonce": 10,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03xmt8cdytarklayg6705k3pkyu57nfslqz0tn",
@@ -790,7 +1084,10 @@
       "available": "4900000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 1
+      "nonce": 1,
+      "stats": {
+        "num_txns": 0
+      }
     },
     {
       "address": "oasis1qp03yggm0cne5rvz3jgkm2uzdg920dttsqe0qgep",
@@ -798,7 +1095,10 @@
       "available": "500000000000",
       "debonding": "0",
       "escrow": "0",
-      "nonce": 3
+      "nonce": 3,
+      "stats": {
+        "num_txns": 0
+      }
     }
   ],
   "is_total_count_clipped": true,

--- a/tests/e2e_regression/eden/expected/runtime-only_account.body
+++ b/tests/e2e_regression/eden/expected/runtime-only_account.body
@@ -6,5 +6,8 @@
   "debonding_delegations_balance": "0",
   "delegations_balance": "0",
   "escrow": "0",
-  "nonce": 0
+  "nonce": 0,
+  "stats": {
+    "num_txns": 0
+  }
 }


### PR DESCRIPTION
Explorer folks requested account-level stats for consensus. This PR adds `num_txns` stats for this purpose. Note that we do not track total sent/received currently and so those fields are now optional.