### PR TITLE
pontusx/pontusx_dev post-launch bugfixes

### DIFF
--- a/.changelog/701.bugfix.md
+++ b/.changelog/701.bugfix.md
@@ -1,0 +1,1 @@
+handle edge case for pontusx_test to pontusx rename

--- a/analyzer/aggregate_stats/aggregate_stats.go
+++ b/analyzer/aggregate_stats/aggregate_stats.go
@@ -48,7 +48,7 @@ var statsLayers = []string{
 	layerConsensus,
 	string(common.RuntimeEmerald),
 	string(common.RuntimeSapphire),
-	string(common.RuntimePontusx),
+	string(common.RuntimePontusxTest),
 	string(common.RuntimePontusxDev),
 	string(common.RuntimeCipher),
 }

--- a/analyzer/evmverifier/sourcify/client.go
+++ b/analyzer/evmverifier/sourcify/client.go
@@ -24,16 +24,16 @@ const (
 // https://docs.sourcify.dev/docs/chains/
 var sourcifyChains = map[common.ChainName]map[common.Runtime]string{
 	common.ChainNameTestnet: {
-		common.RuntimeEmerald:    "42261",
-		common.RuntimeSapphire:   "23295",
-		common.RuntimePontusx:    "23295", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
-		common.RuntimePontusxDev: "23295", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
+		common.RuntimeEmerald:     "42261",
+		common.RuntimeSapphire:    "23295",
+		common.RuntimePontusxTest: "23295", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
+		common.RuntimePontusxDev:  "23295", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
 	},
 	common.ChainNameMainnet: {
-		common.RuntimeEmerald:    "42262",
-		common.RuntimeSapphire:   "23294",
-		common.RuntimePontusx:    "23294", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
-		common.RuntimePontusxDev: "23294", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
+		common.RuntimeEmerald:     "42262",
+		common.RuntimeSapphire:    "23294",
+		common.RuntimePontusxTest: "23294", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
+		common.RuntimePontusxDev:  "23294", // XXX: We're stealing sapphire data here. TODO: use dedicated verifications.
 	},
 }
 

--- a/analyzer/node_stats/node_stats.go
+++ b/analyzer/node_stats/node_stats.go
@@ -44,9 +44,9 @@ func NewAnalyzer(
 		cfg.Interval = 3 * time.Second
 	}
 	logger = logger.With("analyzer", nodeStatsAnalyzerName)
-	// Default to [consensus, emerald, sapphire, pontusx] if layers is not specified.
+	// Default to [consensus, emerald, sapphire, pontusx_test, pontusx_dev] if layers is not specified.
 	if len(layers) == 0 {
-		layers = []common.Layer{common.LayerConsensus, common.LayerEmerald, common.LayerSapphire, common.LayerPontusx}
+		layers = []common.Layer{common.LayerConsensus, common.LayerEmerald, common.LayerSapphire, common.LayerPontusxTest, common.LayerPontusxDev}
 	}
 	p := &processor{
 		layers:          layers,

--- a/analyzer/runtime/runtime_test.go
+++ b/analyzer/runtime/runtime_test.go
@@ -124,7 +124,7 @@ func setupAnalyzer(t *testing.T, testDb *postgres.Client, node *mockNode) analyz
 	sourceConfig := config.SourceConfig{
 		ChainName: "testnet",
 	}
-	runtimeMetadata := sourceConfig.SDKParaTime("pontusx")
+	runtimeMetadata := sourceConfig.SDKParaTime("pontusx_dev")
 
 	// Determine the min and max rounds at which the mock node has data.
 	minRound := math.MaxInt64
@@ -148,7 +148,7 @@ func setupAnalyzer(t *testing.T, testDb *postgres.Client, node *mockNode) analyz
 
 	analyzer, err := runtime.NewRuntimeAnalyzer(
 		"testnet",
-		"pontusx", // We borrow a real runtime's name to comply with DB's enums.
+		"pontusx_dev", // We borrow a real runtime's name to comply with DB's enums.
 		runtimeMetadata,
 		config.BlockRange{From: uint64(minRound), To: uint64(maxRound)},
 		10 /*batchSize*/, analyzer.SlowSyncMode, node, testDb, logger)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -279,8 +279,8 @@ func RuntimeFromURLMiddleware(baseURL string) func(next http.Handler) http.Handl
 				runtime = common.RuntimeSapphire
 			case strings.HasPrefix(path, "/cipher/"):
 				runtime = common.RuntimeCipher
-			case strings.HasPrefix(path, "/pontusx/"):
-				runtime = common.RuntimePontusx
+			case strings.HasPrefix(path, "/pontusxtest/"):
+				runtime = common.RuntimePontusxTest
 			case strings.HasPrefix(path, "/pontusxdev/"):
 				runtime = common.RuntimePontusxDev
 			}

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1226,13 +1226,13 @@ components:
       type: string
       # NOTE: Change IsValid() in util.go if you change this.
       # https://github.com/oasisprotocol/nexus/blob/v0.0.16/api/v1/types/util.go#L40
-      enum: [emerald, sapphire, pontusx, pontusxdev, cipher, consensus]
+      enum: [emerald, sapphire, pontusxtest, pontusxdev, cipher, consensus]
 
     Runtime:
       type: string
       # NOTE: Change IsValid() in util.go if you change this.
       # https://github.com/oasisprotocol/nexus/blob/v0.0.16/api/v1/types/util.go#L49
-      enum: [emerald, sapphire, pontusx, pontusxdev, cipher]
+      enum: [emerald, sapphire, pontusxtest, pontusxdev, cipher]
 
     StakingAddress:
       type: string

--- a/api/v1/types/util.go
+++ b/api/v1/types/util.go
@@ -43,7 +43,7 @@ func (c ConsensusEventType) IsValid() bool {
 
 func (c Layer) IsValid() bool {
 	switch c {
-	case LayerConsensus, LayerCipher, LayerEmerald, LayerSapphire, LayerPontusx, LayerPontusxdev:
+	case LayerConsensus, LayerCipher, LayerEmerald, LayerSapphire, LayerPontusxtest, LayerPontusxdev:
 		return true
 	default:
 		return false
@@ -52,7 +52,7 @@ func (c Layer) IsValid() bool {
 
 func (c Runtime) IsValid() bool {
 	switch c {
-	case RuntimeCipher, RuntimeEmerald, RuntimeSapphire, RuntimePontusx, RuntimePontusxdev:
+	case RuntimeCipher, RuntimeEmerald, RuntimeSapphire, RuntimePontusxtest, RuntimePontusxdev:
 		return true
 	default:
 		return false

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -261,12 +261,12 @@ func addAnalyzer(analyzers []SyncedAnalyzer, errSoFar error, syncTag string, ana
 }
 
 var (
-	syncTagConsensus  = "consensus"
-	syncTagEmerald    = string(common.RuntimeEmerald)
-	syncTagSapphire   = string(common.RuntimeSapphire)
-	syncTagCipher     = string(common.RuntimeCipher)
-	syncTagPontusx    = string(common.RuntimePontusx)
-	syncTagPontusxDev = string(common.RuntimePontusxDev)
+	syncTagConsensus   = "consensus"
+	syncTagEmerald     = string(common.RuntimeEmerald)
+	syncTagSapphire    = string(common.RuntimeSapphire)
+	syncTagCipher      = string(common.RuntimeCipher)
+	syncTagPontusxTest = string(common.RuntimePontusxTest)
+	syncTagPontusxDev  = string(common.RuntimePontusxDev)
 )
 
 // NewService creates new Service.
@@ -330,7 +330,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 	}
 	addFastSyncRuntimeAnalyzers(common.RuntimeEmerald, cfg.Analyzers.Emerald)
 	addFastSyncRuntimeAnalyzers(common.RuntimeSapphire, cfg.Analyzers.Sapphire)
-	addFastSyncRuntimeAnalyzers(common.RuntimePontusx, cfg.Analyzers.Pontusx)
+	addFastSyncRuntimeAnalyzers(common.RuntimePontusxTest, cfg.Analyzers.PontusxTest)
 	addFastSyncRuntimeAnalyzers(common.RuntimePontusxDev, cfg.Analyzers.PontusxDev)
 	addFastSyncRuntimeAnalyzers(common.RuntimeCipher, cfg.Analyzers.Cipher)
 
@@ -365,14 +365,14 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return runtime.NewRuntimeAnalyzer(cfg.Source.ChainName, common.RuntimeSapphire, runtimeMetadata, cfg.Analyzers.Sapphire.SlowSyncRange(), cfg.Analyzers.Sapphire.BatchSize, analyzer.SlowSyncMode, sourceClient, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.Pontusx != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimePontusx)
-			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusx)
+	if cfg.Analyzers.PontusxTest != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimePontusxTest)
+			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusxTest)
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(cfg.Source.ChainName, common.RuntimePontusx, runtimeMetadata, cfg.Analyzers.Pontusx.SlowSyncRange(), cfg.Analyzers.Pontusx.BatchSize, analyzer.SlowSyncMode, sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(cfg.Source.ChainName, common.RuntimePontusxTest, runtimeMetadata, cfg.Analyzers.PontusxTest.SlowSyncRange(), cfg.Analyzers.PontusxTest.BatchSize, analyzer.SlowSyncMode, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDev != nil {
@@ -413,13 +413,13 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmtokens.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireEvmTokens.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxEvmTokens != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusx)
+	if cfg.Analyzers.PontusxTestEvmTokens != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusxTest)
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokens.NewAnalyzer(common.RuntimePontusx, cfg.Analyzers.PontusxEvmTokens.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
+			return evmtokens.NewAnalyzer(common.RuntimePontusxTest, cfg.Analyzers.PontusxTestEvmTokens.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevEvmTokens != nil {
@@ -457,9 +457,9 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmnfts.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireEvmNfts.ItemBasedAnalyzerConfig, sourceClient, ipfsClient, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxEvmNfts != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusx)
+	if cfg.Analyzers.PontusxTestEvmNfts != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusxTest)
 			if err1 != nil {
 				return nil, err1
 			}
@@ -467,7 +467,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmnfts.NewAnalyzer(common.RuntimePontusx, cfg.Analyzers.PontusxEvmNfts.ItemBasedAnalyzerConfig, sourceClient, ipfsClient, dbClient, logger)
+			return evmnfts.NewAnalyzer(common.RuntimePontusxTest, cfg.Analyzers.PontusxTestEvmNfts.ItemBasedAnalyzerConfig, sourceClient, ipfsClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevEvmNfts != nil {
@@ -503,14 +503,14 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmtokenbalances.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireEvmTokenBalances.ItemBasedAnalyzerConfig, runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxEvmTokenBalances != nil {
-		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimePontusx)
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusx)
+	if cfg.Analyzers.PontusxTestEvmTokenBalances != nil {
+		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimePontusxTest)
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusxTest)
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewAnalyzer(common.RuntimePontusx, cfg.Analyzers.PontusxEvmTokenBalances.ItemBasedAnalyzerConfig, runtimeMetadata, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewAnalyzer(common.RuntimePontusxTest, cfg.Analyzers.PontusxTestEvmTokenBalances.ItemBasedAnalyzerConfig, runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevEvmTokenBalances != nil {
@@ -541,13 +541,13 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmcontractcode.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireContractCode.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxContractCode != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusx)
+	if cfg.Analyzers.PontusxTestContractCode != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			sourceClient, err1 := sources.Runtime(ctx, common.RuntimePontusxTest)
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmcontractcode.NewAnalyzer(common.RuntimePontusx, cfg.Analyzers.PontusxContractCode.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
+			return evmcontractcode.NewAnalyzer(common.RuntimePontusxTest, cfg.Analyzers.PontusxTestContractCode.ItemBasedAnalyzerConfig, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevContractCode != nil {
@@ -569,9 +569,9 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmverifier.NewAnalyzer(cfg.Source.ChainName, common.RuntimeSapphire, cfg.Analyzers.SapphireContractVerifier.ItemBasedAnalyzerConfig, cfg.Analyzers.SapphireContractVerifier.SourcifyServerUrl, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxContractVerifier != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			return evmverifier.NewAnalyzer(cfg.Source.ChainName, common.RuntimePontusx, cfg.Analyzers.PontusxContractVerifier.ItemBasedAnalyzerConfig, cfg.Analyzers.PontusxContractVerifier.SourcifyServerUrl, dbClient, logger)
+	if cfg.Analyzers.PontusxTestContractVerifier != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			return evmverifier.NewAnalyzer(cfg.Source.ChainName, common.RuntimePontusxTest, cfg.Analyzers.PontusxTestContractVerifier.ItemBasedAnalyzerConfig, cfg.Analyzers.PontusxTestContractVerifier.SourcifyServerUrl, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevContractVerifier != nil {
@@ -589,9 +589,9 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			return evmabibackfill.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireAbi.ItemBasedAnalyzerConfig, dbClient, logger)
 		})
 	}
-	if cfg.Analyzers.PontusxAbi != nil {
-		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusx, func() (A, error) {
-			return evmabibackfill.NewAnalyzer(common.RuntimePontusx, cfg.Analyzers.PontusxAbi.ItemBasedAnalyzerConfig, dbClient, logger)
+	if cfg.Analyzers.PontusxTestAbi != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxTest, func() (A, error) {
+			return evmabibackfill.NewAnalyzer(common.RuntimePontusxTest, cfg.Analyzers.PontusxTestAbi.ItemBasedAnalyzerConfig, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.PontusxDevAbi != nil {
@@ -615,7 +615,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			// fail if the node does not support the runtime, which is valid. If
 			// the analyzer expects the node to support the runtime but it does not,
 			// the analyzer will log an error.
-			for _, runtime := range []common.Runtime{common.RuntimeEmerald, common.RuntimeCipher, common.RuntimeSapphire, common.RuntimePontusx} {
+			for _, runtime := range []common.Runtime{common.RuntimeEmerald, common.RuntimeCipher, common.RuntimeSapphire, common.RuntimePontusxTest, common.RuntimePontusxDev} {
 				client, err2 := sources.Runtime(ctx, runtime)
 				if err2 != nil {
 					logger.Warn("unable to instantiate runtime client for node stats analyzer", "runtime", runtime)

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -124,7 +124,7 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 	var networkConfig *sdkConfig.Network
 	if cfg.Source != nil {
 		networkConfig = cfg.Source.SDKNetwork()
-		apiRuntimes := []common.Runtime{common.RuntimeEmerald, common.RuntimeSapphire, common.RuntimePontusx, common.RuntimePontusxDev}
+		apiRuntimes := []common.Runtime{common.RuntimeEmerald, common.RuntimeSapphire, common.RuntimePontusxTest, common.RuntimePontusxDev}
 		for _, runtime := range apiRuntimes {
 			client, err2 := source.NewRuntimeClient(ctx, cfg.Source, runtime)
 			if err2 != nil {

--- a/common/types.go
+++ b/common/types.go
@@ -224,23 +224,23 @@ const (
 type Layer string
 
 const (
-	LayerConsensus  Layer = "consensus"
-	LayerEmerald    Layer = "emerald"
-	LayerCipher     Layer = "cipher"
-	LayerSapphire   Layer = "sapphire"
-	LayerPontusx    Layer = "pontusx"
-	LayerPontusxDev Layer = "pontusx_dev"
+	LayerConsensus   Layer = "consensus"
+	LayerEmerald     Layer = "emerald"
+	LayerCipher      Layer = "cipher"
+	LayerSapphire    Layer = "sapphire"
+	LayerPontusxTest Layer = "pontusx_test"
+	LayerPontusxDev  Layer = "pontusx_dev"
 )
 
 // Runtime is an identifier for a runtime on the Oasis Network.
 type Runtime string
 
 const (
-	RuntimeEmerald    Runtime = "emerald"
-	RuntimeCipher     Runtime = "cipher"
-	RuntimeSapphire   Runtime = "sapphire"
-	RuntimePontusx    Runtime = "pontusx"
-	RuntimePontusxDev Runtime = "pontusx_dev"
+	RuntimeEmerald     Runtime = "emerald"
+	RuntimeCipher      Runtime = "cipher"
+	RuntimeSapphire    Runtime = "sapphire"
+	RuntimePontusxTest Runtime = "pontusx_test"
+	RuntimePontusxDev  Runtime = "pontusx_dev"
 )
 
 type CallFormat string

--- a/config/config.go
+++ b/config/config.go
@@ -91,8 +91,8 @@ func (cfg *AnalysisConfig) Validate() error {
 			return err
 		}
 	}
-	if cfg.Analyzers.Pontusx != nil {
-		if err := cfg.Analyzers.Pontusx.Validate(); err != nil {
+	if cfg.Analyzers.PontusxTest != nil {
+		if err := cfg.Analyzers.PontusxTest.Validate(); err != nil {
 			return err
 		}
 	}
@@ -131,37 +131,37 @@ func (cfg *AnalysisConfig) Validate() error {
 }
 
 type AnalyzersList struct {
-	Consensus  *BlockBasedAnalyzerConfig `koanf:"consensus"`
-	Emerald    *BlockBasedAnalyzerConfig `koanf:"emerald"`
-	Sapphire   *BlockBasedAnalyzerConfig `koanf:"sapphire"`
-	Pontusx    *BlockBasedAnalyzerConfig `koanf:"pontusx"`
-	PontusxDev *BlockBasedAnalyzerConfig `koanf:"pontusx_dev"`
-	Cipher     *BlockBasedAnalyzerConfig `koanf:"cipher"`
+	Consensus   *BlockBasedAnalyzerConfig `koanf:"consensus"`
+	Emerald     *BlockBasedAnalyzerConfig `koanf:"emerald"`
+	Sapphire    *BlockBasedAnalyzerConfig `koanf:"sapphire"`
+	PontusxTest *BlockBasedAnalyzerConfig `koanf:"pontusx_test"`
+	PontusxDev  *BlockBasedAnalyzerConfig `koanf:"pontusx_dev"`
+	Cipher      *BlockBasedAnalyzerConfig `koanf:"cipher"`
 
-	EmeraldEvmTokens           *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_emerald"`
-	SapphireEvmTokens          *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_sapphire"`
-	PontusxEvmTokens           *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_pontusx"`
-	PontusxDevEvmTokens        *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_pontusx_dev"`
-	EmeraldEvmNfts             *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_emerald"`
-	SapphireEvmNfts            *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_sapphire"`
-	PontusxEvmNfts             *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_pontusx"`
-	PontusxDevEvmNfts          *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_pontusx_dev"`
-	EmeraldEvmTokenBalances    *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_emerald"`
-	SapphireEvmTokenBalances   *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_sapphire"`
-	PontusxEvmTokenBalances    *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_pontusx"`
-	PontusxDevEvmTokenBalances *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_pontusx_dev"`
-	EmeraldContractCode        *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_emerald"`
-	SapphireContractCode       *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_sapphire"`
-	PontusxContractCode        *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_pontusx"`
-	PontusxDevContractCode     *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_pontusx_dev"`
-	EmeraldContractVerifier    *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_emerald"`
-	SapphireContractVerifier   *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_sapphire"`
-	PontusxContractVerifier    *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_pontusx"`
-	PontusxDevContractVerifier *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_pontusx_dev"`
-	EmeraldAbi                 *EvmAbiAnalyzerConfig          `koanf:"evm_abi_emerald"`
-	SapphireAbi                *EvmAbiAnalyzerConfig          `koanf:"evm_abi_sapphire"`
-	PontusxAbi                 *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx"`
-	PontusxDevAbi              *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx_dev"`
+	EmeraldEvmTokens            *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_emerald"`
+	SapphireEvmTokens           *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_sapphire"`
+	PontusxTestEvmTokens        *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_pontusx_test"`
+	PontusxDevEvmTokens         *EvmTokensAnalyzerConfig       `koanf:"evm_tokens_pontusx_dev"`
+	EmeraldEvmNfts              *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_emerald"`
+	SapphireEvmNfts             *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_sapphire"`
+	PontusxTestEvmNfts          *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_pontusx_test"`
+	PontusxDevEvmNfts           *EvmTokensAnalyzerConfig       `koanf:"evm_nfts_pontusx_dev"`
+	EmeraldEvmTokenBalances     *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_emerald"`
+	SapphireEvmTokenBalances    *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_sapphire"`
+	PontusxTestEvmTokenBalances *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_pontusx_test"`
+	PontusxDevEvmTokenBalances  *EvmTokensAnalyzerConfig       `koanf:"evm_token_balances_pontusx_dev"`
+	EmeraldContractCode         *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_emerald"`
+	SapphireContractCode        *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_sapphire"`
+	PontusxTestContractCode     *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_pontusx_test"`
+	PontusxDevContractCode      *EvmContractCodeAnalyzerConfig `koanf:"evm_contract_code_pontusx_dev"`
+	EmeraldContractVerifier     *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_emerald"`
+	SapphireContractVerifier    *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_sapphire"`
+	PontusxTestContractVerifier *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_pontusx_test"`
+	PontusxDevContractVerifier  *EVMContractVerifierConfig     `koanf:"evm_contract_verifier_pontusx_dev"`
+	EmeraldAbi                  *EvmAbiAnalyzerConfig          `koanf:"evm_abi_emerald"`
+	SapphireAbi                 *EvmAbiAnalyzerConfig          `koanf:"evm_abi_sapphire"`
+	PontusxTestAbi              *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx_test"`
+	PontusxDevAbi               *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx_dev"`
 
 	MetadataRegistry *MetadataRegistryConfig `koanf:"metadata_registry"`
 	NodeStats        *NodeStatsConfig        `koanf:"node_stats"`
@@ -235,12 +235,7 @@ func (sc *SourceConfig) SDKNetwork() *sdkConfig.Network {
 }
 
 func (sc *SourceConfig) SDKParaTime(runtime common.Runtime) *sdkConfig.ParaTime {
-	// TODO: remove this shim once pontusx_test is renamed to pontusx
-	sdkRuntimeName := string(runtime)
-	if sc.ChainName == "testnet" && runtime == common.RuntimePontusx {
-		sdkRuntimeName = "pontusx_test"
-	}
-	return sc.SDKNetwork().ParaTimes.All[sdkRuntimeName]
+	return sc.SDKNetwork().ParaTimes.All[string(runtime)]
 }
 
 type CacheConfig struct {

--- a/config/history.go
+++ b/config/history.go
@@ -146,11 +146,11 @@ var DefaultChains = map[common.ChainName]*History{
 				GenesisHeight: 17751681,
 				ChainContext:  "0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76",
 				RuntimeStartRounds: map[common.Runtime]uint64{
-					common.RuntimeCipher:     1730319,
-					common.RuntimeEmerald:    2627790,
-					common.RuntimeSapphire:   2995927,
-					common.RuntimePontusx:    0,
-					common.RuntimePontusxDev: 0,
+					common.RuntimeCipher:      1730319,
+					common.RuntimeEmerald:     2627790,
+					common.RuntimeSapphire:    2995927,
+					common.RuntimePontusxTest: 0,
+					common.RuntimePontusxDev:  0,
 				},
 			},
 			{

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -68,13 +68,33 @@ func translateTokenType(tokenType common.TokenType) apiTypes.EvmTokenType {
 	}
 }
 
+// The apiTypes Layers may be named differently from Nexus-internal Layers
+// to make the api more ergonomic.
+func translateLayer(layer apiTypes.Layer) common.Layer {
+	switch layer {
+	case apiTypes.LayerConsensus:
+		return common.LayerConsensus
+	case apiTypes.LayerCipher:
+		return common.LayerCipher
+	case apiTypes.LayerEmerald:
+		return common.LayerEmerald
+	case apiTypes.LayerSapphire:
+		return common.LayerSapphire
+	case apiTypes.LayerPontusxtest:
+		return common.LayerPontusxTest
+	case apiTypes.LayerPontusxdev:
+		return common.LayerPontusxDev
+	default:
+		return "unexpected_layer"
+	}
+}
+
 // runtimeNameToID returns the runtime ID for the given network and runtime name.
 func runtimeNameToID(chainName common.ChainName, name common.Runtime) (string, error) {
 	network, exists := oasisConfig.DefaultNetworks.All[string(chainName)]
 	if !exists {
 		return "", fmt.Errorf("unknown network: %s", chainName)
 	}
-
 	paratime, exists := network.ParaTimes.All[string(name)]
 	if !exists {
 		return "", fmt.Errorf("unknown runtime: %s", name)
@@ -2030,7 +2050,7 @@ func (c *StorageClient) TxVolumes(ctx context.Context, layer apiTypes.Layer, p a
 	rows, err := c.db.Query(
 		ctx,
 		query,
-		layer,
+		translateLayer(layer),
 		p.Limit,
 		p.Offset,
 	)
@@ -2071,7 +2091,7 @@ func (c *StorageClient) DailyActiveAccounts(ctx context.Context, layer apiTypes.
 	rows, err := c.db.Query(
 		ctx,
 		query,
-		layer,
+		translateLayer(layer),
 		p.Limit,
 		p.Offset,
 	)

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-CREATE TYPE public.runtime AS ENUM ('emerald', 'sapphire', 'cipher'); -- 'pontusx' and 'pontusx_dev' added in subsequent migrations.
+CREATE TYPE public.runtime AS ENUM ('emerald', 'sapphire', 'cipher'); -- 'pontusx_test' and 'pontusx_dev' added in subsequent migrations.
 CREATE TYPE public.call_format AS ENUM ('encrypted/x25519-deoxysii');
 
 CREATE TABLE chain.runtime_blocks

--- a/storage/migrations/19_pontusx_rename.up.sql
+++ b/storage/migrations/19_pontusx_rename.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- The new 'pontusx_test' runtime was initially tracked as 'pontusx' in the database. We 
+-- rename the existing enum value to migrate 'pontusx' data to 'pontusx_test'. 
+ALTER TYPE public.runtime RENAME VALUE 'pontusx' TO 'pontusx_test';
+
+UPDATE analysis.processed_blocks
+SET 
+    analyzer = 'pontusx_test'
+WHERE
+    analyzer = 'pontusx';
+
+COMMIT;


### PR DESCRIPTION
Previously, nexus would directly use the paratime name in the sdk-config, which is inconsistent with our internal `runtime` enum in the database. We are planning to [change the sdk-config](https://github.com/oasisprotocol/oasis-sdk/pull/1797), so this PR is intended as a patch until the upstream fix goes in.

Also contains several bugfixes for the pontusx api server. Already deployed in staging/production.