### PR TITLE
api/epochs: Skip 'end_height' for latest epoch

### DIFF
--- a/.changelog/709.bugfix.md
+++ b/.changelog/709.bugfix.md
@@ -1,0 +1,1 @@
+`/api/consensus/<epoch>`: Do not return end_height for currently active epoch

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1004,6 +1004,7 @@ func (c *StorageClient) Epochs(ctx context.Context, p apiTypes.GetConsensusEpoch
 	res, err := c.withTotalCount(
 		ctx,
 		queries.Epochs,
+		nil,
 		p.Limit,
 		p.Offset,
 	)
@@ -1033,8 +1034,10 @@ func (c *StorageClient) Epoch(ctx context.Context, epoch int64) (*Epoch, error) 
 	var e Epoch
 	if err := c.db.QueryRow(
 		ctx,
-		queries.Epoch,
+		queries.Epochs,
 		epoch,
+		1,
+		0,
 	).Scan(&e.ID, &e.StartHeight, &e.EndHeight); err != nil {
 		return nil, wrapError(err)
 	}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -252,14 +252,10 @@ const (
 		SELECT id, start_height,
 			(CASE id WHEN (SELECT max(id) FROM chain.epochs) THEN NULL ELSE end_height END) AS end_height
 			FROM chain.epochs
+		WHERE ($1::bigint IS NULL OR id = $1::bigint)
 		ORDER BY id DESC
-		LIMIT $1::bigint
-		OFFSET $2::bigint`
-
-	Epoch = `
-		SELECT id, start_height, end_height
-			FROM chain.epochs
-			WHERE id = $1::bigint`
+		LIMIT $2::bigint
+		OFFSET $3::bigint`
 
 	Proposals = `
 		SELECT id, submitter, state, deposit, handler, cp_target_version, rhp_target_version, rcp_target_version,

--- a/tests/e2e_regression/damask/expected/epoch.body
+++ b/tests/e2e_regression/damask/expected/epoch.body
@@ -1,5 +1,4 @@
 {
-  "end_height": 8049955,
   "id": 13403,
   "start_height": 8049556
 }


### PR DESCRIPTION
The `/consensus/epochs/<latest_epoch>` endpoint for the currently active epoch returns the ever increasing 'end_height'.
This is inconsistent with the API spec and also with the `/consensus/epochs`. Skip returning the `end_height` for the latest epoch.

For `/consensus/epochs` we already do this.