### PR TITLE
delegations: remove delegations with 0 shares

### DIFF
--- a/.changelog/711.feature.md
+++ b/.changelog/711.feature.md
@@ -1,0 +1,1 @@
+delegations: delete delegations with 0 shares

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -338,15 +338,6 @@ var (
         escrow_balance_active = chain.accounts.escrow_balance_active + $2,
         escrow_total_shares_active = chain.accounts.escrow_total_shares_active + $3`
 
-	ConsensusAddDelegationsUpsertReplace = `
-    INSERT INTO chain.delegations
-      (delegatee, delegator, shares)
-    VALUES
-      ($1, $2, $3)
-    ON CONFLICT (delegatee, delegator) DO UPDATE
-    SET
-      shares = excluded.shares`
-
 	ConsensusAddDelegationsUpsert = `
     INSERT INTO chain.delegations (delegatee, delegator, shares)
       VALUES ($1, $2, $3)
@@ -380,6 +371,10 @@ var (
     UPDATE chain.delegations
       SET shares = shares - $3
         WHERE delegatee = $1 AND delegator = $2`
+
+	ConsensusDelegationDeleteIfZeroShares = `
+    DELETE FROM chain.delegations
+      WHERE delegatee = $1 AND delegator = $2 AND shares = 0`
 
 	ConsensusDebondingStartDebondingDelegationsInsert = `
     INSERT INTO chain.debonding_delegations (delegatee, delegator, shares, debond_end)

--- a/storage/migrations/17_delegations_zero_shares.up.sql
+++ b/storage/migrations/17_delegations_zero_shares.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Starting with this commit, the delegations with zero shares will get cleaned up
+-- at the debond start time (on reclaim escrow transaction). Here we clean up the
+-- delegations that were already debonded and have 0 shares at the time of this
+-- deployment.
+DELETE FROM chain.delegations
+    WHERE shares = 0;
+
+COMMIT;


### PR DESCRIPTION
This will ensure that the delegations with 0 shares get cleaned up/removed from the table.
