### PR TITLE
delegations: do not track rewards as delegations

### DIFF
--- a/.changelog/713.bugfix.md
+++ b/.changelog/713.bugfix.md
@@ -1,0 +1,1 @@
+delegations: do not track rewards as delegations

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -881,11 +881,17 @@ func (m *processor) queueEscrows(batch *storage.QueryBatch, data *stakingData) e
 			amount,
 			newShares,
 		)
-		batch.Queue(queries.ConsensusAddDelegationsUpsert,
-			escrower,
-			owner,
-			newShares,
-		)
+		if newShares != "0" {
+			// When rewards are distributed, an `AddEscrowEvent` with `new_shares` set to 0 is emitted. This makes sense,
+			// since rewards increase the Escrow balance without adding new shares - it increases the existing shares price.
+			//
+			// Do not track these as delegations.
+			batch.Queue(queries.ConsensusAddDelegationsUpsert,
+				escrower,
+				owner,
+				newShares,
+			)
+		}
 	}
 	for _, e := range data.TakeEscrows {
 		if e.DebondingAmount == nil {


### PR DESCRIPTION
One more source of chain.delegations with `0` shares.

See relevant oasis-core code: https://github.com/oasisprotocol/oasis-core/blob/774316020d821c99307f444a4de21775fc01f048/go/consensus/cometbft/apps/staking/state/state.go#L996-L1001