### PR TITLE
storage/client: don't crash on 0 delegated shares

### DIFF
--- a/.changelog/719.bugfix.md
+++ b/.changelog/719.bugfix.md
@@ -1,0 +1,1 @@
+storage/client: don't crash on delegations with 0 shares


### PR DESCRIPTION
Due to bugs, we can end up with invalid delegations in DB with 0 shares.

I believe most of these cases are fixed in: https://github.com/oasisprotocol/nexus/pull/713 https://github.com/oasisprotocol/nexus/pull/711 https://github.com/oasisprotocol/nexus/pull/712
but still, don't panic since this is part of the public API; instead, log an error and report 0 shares.