### PR TITLE
Mark is_verified deprecated in API spec, not just in description

### DIFF
--- a/.changelog/723.trivial.md
+++ b/.changelog/723.trivial.md
@@ -1,0 +1,1 @@
+Mark is_verified deprecated in API spec

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2925,6 +2925,7 @@ components:
             The number of addresses that have a nonzero balance of this token.
           example: 123
         is_verified:
+          deprecated: true
           type: boolean
           description: |
             Whether the contract has been successfully verified by Sourcify.


### PR DESCRIPTION

| Before | After |
| --- | --- |
| ![_home_luka_oasis_explorer_explorer-frontend_src_oasis-nexus_redoc-static html](https://github.com/oasisprotocol/nexus/assets/3758846/62853b03-3c99-4b6b-8224-0630315d6656) | ![_home_luka_oasis_explorer_explorer-frontend_src_oasis-nexus_redoc-static html (1)](https://github.com/oasisprotocol/nexus/assets/3758846/af8fa428-387d-44e2-ac5f-176ab7528a5d) |
 