### PR TITLE
API docs workaround to separate search panel in sidebar

### DIFF
--- a/.changelog/731.trivial.md
+++ b/.changelog/731.trivial.md
@@ -1,0 +1,1 @@
+API docs workaround to separate search panel in sidebar

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -3,7 +3,11 @@
 openapi: 3.0.3
 info:
   title: Oasis Nexus API V1
-  description: An API for accessing indexed data from the Oasis Network.
+  description: |
+    An API for accessing indexed data from the Oasis Network.
+
+    <!-- Acts as a separator after search in sidebar -->
+    # Endpoints
   version: 0.1.0
 
 servers:
@@ -481,7 +485,7 @@ paths:
           name: name
           schema:
             type: string
-          description: | 
+          description: |
             A filter on the validator name. Every returned validator will have
             a name that is a superstring of the input param.
       responses:
@@ -1937,7 +1941,7 @@ components:
           type: integer
           format: uint64
           description: The number of accounts that have delegated token to this account.
-          
+
     NodeList:
       allOf:
         - $ref: '#/components/schemas/List'

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -11,9 +11,9 @@ info:
   version: 0.1.0
 
 servers:
-  - url: http://nexus.oasis.io/v1
+  - url: https://nexus.oasis.io/v1
     description: Mainnet index endpoint.
-  - url: http://testnet.nexus.oasis.io/v1
+  - url: https://testnet.nexus.oasis.io/v1
     description: Testnet index endpoint.
 
 x-query-params:


### PR DESCRIPTION
| Before | After 689dae04fb48c1a4bb22b3e0fcfca61177563144 | After 35bda82e9df9d8eebd64603f7b8a94414232c400 |
| --- | --- | --- |
|  search looks less confusing | |
| ![nexus oasis io_v1_spec_v1 html](https://github.com/user-attachments/assets/a115aa63-5dfb-446a-af3d-1721209000ff) | ![_home_luka_Downloads_nexus_api_spec_v1 html](https://github.com/user-attachments/assets/74e8d5be-c97e-4cfa-9de4-f738ae698e75) | ![_home_luka_Downloads_nexus_api_spec_v1 html (1)](https://github.com/user-attachments/assets/272311b1-5908-49a8-980a-b4aa555c980e) |
| but start is more empty |   |
| ![nexus oasis io_v1_spec_v1 html (1)](https://github.com/user-attachments/assets/b346517b-dd3f-49a8-9147-ffb9d7e171f4) | ![_home_luka_Downloads_nexus_api_spec_v1 html (1)](https://github.com/user-attachments/assets/1d1694a3-13c7-4b99-a68e-770002694a52) | ![_home_luka_Downloads_nexus_api_spec_v1 html](https://github.com/user-attachments/assets/82c889ae-cbb5-416a-afe2-3ed56cf3749f) |