### PR TITLE
always enable cors middleware, even on failing requests

### DIFF
--- a/.changelog/733.trivial.md
+++ b/.changelog/733.trivial.md
@@ -1,0 +1,1 @@
+api: always enable cors

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -183,11 +183,13 @@ func (s *Service) Start() {
 			BaseURL: v1BaseURL,
 			Middlewares: []apiTypes.MiddlewareFunc{
 				api.RuntimeFromURLMiddleware(v1BaseURL),
-				api.CorsMiddleware,
 			},
 			BaseRouter:       baseRouter,
 			ErrorHandlerFunc: api.HumanReadableJsonErrorHandler,
 		})
+	// Manually apply the CORS middleware; we want it to run always.
+	// HandlerWithOptions() above does not apply it to some requests (404 URLs, requests with bad params, etc.).
+	handler = api.CorsMiddleware(handler)
 	// Manually apply the metrics middleware; we want it to run always, and at the outermost layer.
 	// HandlerWithOptions() above does not apply it to some requests (404 URLs, requests with bad params, etc.).
 	handler = api.MetricsMiddleware(metrics.NewDefaultRequestMetrics(moduleName), *s.logger)(handler)

--- a/tests/e2e_regression/damask/expected/bad_account.headers
+++ b/tests/e2e_regression/damask/expected/bad_account.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 400 Bad Request
 Content-Type: application/json; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING

--- a/tests/e2e_regression/damask/expected/bad_node.headers
+++ b/tests/e2e_regression/damask/expected/bad_node.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 400 Bad Request
 Content-Type: application/json; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING

--- a/tests/e2e_regression/damask/expected/spec.headers
+++ b/tests/e2e_regression/damask/expected/spec.headers
@@ -3,5 +3,6 @@ Accept-Ranges: bytes
 Content-Length: UNINTERESTING
 Content-Type: application/x-yaml
 Last-Modified: UNINTERESTING
+Vary: Origin
 Date: UNINTERESTING
 

--- a/tests/e2e_regression/damask/expected/trailing_slash.headers
+++ b/tests/e2e_regression/damask/expected/trailing_slash.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 404 Not Found
 Content-Type: text/plain; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING

--- a/tests/e2e_regression/eden/expected/bad_account.headers
+++ b/tests/e2e_regression/eden/expected/bad_account.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 400 Bad Request
 Content-Type: application/json; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING

--- a/tests/e2e_regression/eden/expected/bad_node.headers
+++ b/tests/e2e_regression/eden/expected/bad_node.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 400 Bad Request
 Content-Type: application/json; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING

--- a/tests/e2e_regression/eden/expected/spec.headers
+++ b/tests/e2e_regression/eden/expected/spec.headers
@@ -3,5 +3,6 @@ Accept-Ranges: bytes
 Content-Length: UNINTERESTING
 Content-Type: application/x-yaml
 Last-Modified: UNINTERESTING
+Vary: Origin
 Date: UNINTERESTING
 

--- a/tests/e2e_regression/eden/expected/trailing_slash.headers
+++ b/tests/e2e_regression/eden/expected/trailing_slash.headers
@@ -1,5 +1,6 @@
 HTTP/1.1 404 Not Found
 Content-Type: text/plain; charset=utf-8
+Vary: Origin
 X-Content-Type-Options: nosniff
 Date: UNINTERESTING
 Content-Length: UNINTERESTING


### PR DESCRIPTION
Addresses https://app.clickup.com/t/86954afaz

CORS headers were not returned for failing/malformed requests; this PR fixes that by manually running the CORS middleware.

```
» curl -i -H 'Origin: example.com' 'localhost:8008/v1/consensus/accounts/oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg1k'
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Content-Type: application/json; charset=utf-8
Vary: Origin
X-Content-Type-Options: nosniff
Date: Wed, 31 Jul 2024 22:20:53 GMT
Content-Length: 227

{"msg":"Invalid format for parameter address: error unmarshalling 'oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg1k' text as *api.Address: address: decoding from bech32 failed: decoding bech32 failed: invalid separator index 43"}
```

@lukaw3d please lmk if this isn't sufficient; I tried testing on browser but I wasn't able to see the cors headers at all, even for successful requests. (maybe bc of cloudflare?)

![Screenshot 2024-07-31 at 6 28 06 PM](https://github.com/user-attachments/assets/3d644e6d-7868-4b30-8d0d-bb83d38557b9)
