### PR TITLE
Andrew7234/parallelize data fetch

### DIFF
--- a/.changelog/736.internal.md
+++ b/.changelog/736.internal.md
@@ -1,0 +1,1 @@
+consensus analyzer: parallelize data fetch


### PR DESCRIPTION
Fetching data for a single block in consensus takes ~2.2 sec according to grafana:
![Screenshot 2024-08-09 at 2 08 14 PM](https://github.com/user-attachments/assets/d992012d-515c-491b-8614-4979a28ffe62)

This PR parallelizes some of the grpc calls. Based on local testing using the port-forwarded node, the per-block time averages around 1.2sec, with occasional spikes to 1.9.