### PR TITLE
api: add validator agg stats

### DIFF
--- a/.changelog/738.feature.md
+++ b/.changelog/738.feature.md
@@ -1,0 +1,1 @@
+api: add total delegators to /validators

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -496,7 +496,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ValidatorList'
+                  $ref: '#/components/schemas/ValidatorList'
+                
         <<: *common_error_responses
 
   /consensus/validators/{address}:
@@ -517,7 +518,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Validator'
+                $ref: '#/components/schemas/ValidatorList'
         <<: *common_error_responses
 
   /consensus/validators/{address}/history:
@@ -1843,18 +1844,48 @@ components:
       description: |
         An entity registered at the consensus layer.
 
+    ValidatorsResponse:
+      type: object
+      required: [validator_list, stats]
+      properties:
+        validator_list:
+          allOf: [$ref: '#/components/schemas/ValidatorList'] 
+        stats:
+          allOf: [$ref: '#/components/schemas/ValidatorAggStats']
+          description: Summary statistics across all consensus validators.
+
     ValidatorList:
       allOf:
         - $ref: '#/components/schemas/List'
         - type: object
-          required: [validators]
+          required: [validators, stats]
           properties:
             validators:
               type: array
               items:
                 allOf: [$ref: '#/components/schemas/Validator']
+            stats:
+              allOf: [$ref: '#/components/schemas/ValidatorAggStats']
+              description: Summary statistics across all consensus validators.
           description: |
-            A list of validators registered at the consensus layer.
+            A list of validators registered at the consensus layer, plus summary
+            statistics across all consensus validators.
+    
+    ValidatorAggStats:
+      type: object
+      required: [total_voting_power, total_delegators, total_staked_balance]
+      properties:
+        total_voting_power:
+          type: integer
+          format: int64
+          description: The total voting power across all validators.
+        total_delegators:
+          type: integer
+          format: uint64
+          description: The total number of delegators in the network.
+        total_staked_balance:
+          allOf: [$ref: '#/components/schemas/TextBigInt']
+          description: The total amount of token staked to validators.
 
     ValidatorCommissionBound:
       type: object
@@ -1899,7 +1930,7 @@ components:
 
     Validator:
       type: object
-      required: [entity_address, entity_id, escrow, voting_power, voting_power_total, active, start_date, rank, in_validator_set, current_rate, current_commission_bound]
+      required: [entity_address, entity_id, escrow, voting_power, active, start_date, rank, in_validator_set, current_rate, current_commission_bound]
       properties:
         entity_address:
           type: string
@@ -1922,10 +1953,6 @@ components:
           type: integer
           format: int64
           description: The voting power of this validator.
-        voting_power_total:
-          type: integer
-          format: int64
-          description: The total voting power across all validators.
         active:
           type: boolean
           description: Whether the entity has a node that is registered for being a validator, node is up to date, and has successfully registered itself. It may or may not be part of validator set.

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -260,7 +260,11 @@ func (srv *StrictServerImpl) GetConsensusValidatorsAddress(ctx context.Context, 
 	if len(validators.Validators) == 0 {
 		return apiTypes.GetConsensusValidatorsAddress404JSONResponse{}, nil
 	}
-	return apiTypes.GetConsensusValidatorsAddress200JSONResponse(validators.Validators[0]), nil
+	// Truncate ValidatorList to only include the top matching validator.
+	if len(validators.Validators) > 1 {
+		validators.Validators = validators.Validators[:1]
+	}
+	return apiTypes.GetConsensusValidatorsAddress200JSONResponse(*validators), nil
 }
 
 func (srv *StrictServerImpl) GetConsensusValidatorsAddressHistory(ctx context.Context, request apiTypes.GetConsensusValidatorsAddressHistoryRequestObject) (apiTypes.GetConsensusValidatorsAddressHistoryResponseObject, error) {

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -84,8 +84,11 @@ type ProposalVotes = api.ProposalVotes
 
 type ProposalVote = api.ProposalVote
 
-// ValidatorList is the storage response for GetValidators.
+// ValidatorList is the list of consensus validators.
 type ValidatorList = api.ValidatorList
+
+// ValidatorAggStats holds summary statistics for network validators.
+type ValidatorAggStats = api.ValidatorAggStats
 
 // Validator is the storage response for GetValidator.
 type Validator = api.Validator

--- a/tests/e2e_regression/damask/expected/validator.body
+++ b/tests/e2e_regression/damask/expected/validator.body
@@ -1,27 +1,37 @@
 {
-  "active": true,
-  "current_commission_bound": {
-    "epoch_end": 0,
-    "epoch_start": 2310,
-    "lower": 0,
-    "upper": 25000
+  "is_total_count_clipped": false,
+  "stats": {
+    "total_delegators": 35414,
+    "total_staked_balance": "5708092468704383083",
+    "total_voting_power": 307554773957760060
   },
-  "current_rate": 20000,
-  "entity_address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
-  "entity_id": "HPeLbzc88IoYEP0TC4nqSxfxdPCPjduLeJqFvmxFye8=",
-  "escrow": {
-    "active_balance": "557356819483297",
-    "active_shares": "506789203787843",
-    "debonding_balance": "0",
-    "debonding_shares": "0",
-    "num_delegators": 13,
-    "self_delegation_balance": "9263128275881",
-    "self_delegation_shares": "8422707392134"
-  },
-  "in_validator_set": true,
-  "node_id": "wqd9Yy3n7TWKfYRn2bI9Hd6/623CfC7NCUoRbQ5UkR8=",
-  "rank": 92,
-  "start_date": "2022-04-11T09:30:00Z",
-  "voting_power": 34834350461211,
-  "voting_power_total": 307554773957760060
+  "total_count": 1,
+  "validators": [
+    {
+      "active": true,
+      "current_commission_bound": {
+        "epoch_end": 0,
+        "epoch_start": 2310,
+        "lower": 0,
+        "upper": 25000
+      },
+      "current_rate": 20000,
+      "entity_address": "oasis1qr3w66akc8ud9a4zsgyjw2muvcfjgfszn5ycgc0a",
+      "entity_id": "HPeLbzc88IoYEP0TC4nqSxfxdPCPjduLeJqFvmxFye8=",
+      "escrow": {
+        "active_balance": "557356819483297",
+        "active_shares": "506789203787843",
+        "debonding_balance": "0",
+        "debonding_shares": "0",
+        "num_delegators": 13,
+        "self_delegation_balance": "9263128275881",
+        "self_delegation_shares": "8422707392134"
+      },
+      "in_validator_set": true,
+      "node_id": "wqd9Yy3n7TWKfYRn2bI9Hd6/623CfC7NCUoRbQ5UkR8=",
+      "rank": 92,
+      "start_date": "2022-04-11T09:30:00Z",
+      "voting_power": 34834350461211
+    }
+  ]
 }

--- a/tests/e2e_regression/damask/expected/validators.body
+++ b/tests/e2e_regression/damask/expected/validators.body
@@ -1,5 +1,10 @@
 {
   "is_total_count_clipped": false,
+  "stats": {
+    "total_delegators": 35414,
+    "total_staked_balance": "5708092468704383083",
+    "total_voting_power": 307554773957760060
+  },
   "total_count": 173,
   "validators": [
     {
@@ -26,8 +31,7 @@
       "node_id": "ked2iuR80WQdb4g7l+PqbQKGJAvD4+KVPFwuDc5nU6M=",
       "rank": 1,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 22858167394496476,
-      "voting_power_total": 307554773957760060
+      "voting_power": 22858167394496476
     },
     {
       "active": true,
@@ -53,8 +57,7 @@
       "node_id": "6wbL5/OxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA=",
       "rank": 2,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 20469550347833610,
-      "voting_power_total": 307554773957760060
+      "voting_power": 20469550347833610
     },
     {
       "active": true,
@@ -80,8 +83,7 @@
       "node_id": "lbxs4hlud9XNloIOdhJPaCahd7HtiY8QATCgGnFfCM0=",
       "rank": 3,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 16406759731504108,
-      "voting_power_total": 307554773957760060
+      "voting_power": 16406759731504108
     },
     {
       "active": true,
@@ -107,8 +109,7 @@
       "node_id": "xHvUU4I+dQ4oKvlfe4IXoKi8OT8vdAgfszQ5ciPL6HI=",
       "rank": 4,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 15076146157905980,
-      "voting_power_total": 307554773957760060
+      "voting_power": 15076146157905980
     },
     {
       "active": true,
@@ -134,8 +135,7 @@
       "node_id": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
       "rank": 5,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 14034975811348696,
-      "voting_power_total": 307554773957760060
+      "voting_power": 14034975811348696
     },
     {
       "active": true,
@@ -161,8 +161,7 @@
       "node_id": "aJFHeID4Q7qUfMa42dRwaa9PQrZ/cVDiE3WNt4bQjo0=",
       "rank": 6,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 12870128481056154,
-      "voting_power_total": 307554773957760060
+      "voting_power": 12870128481056154
     },
     {
       "active": true,
@@ -188,8 +187,7 @@
       "node_id": "u0ljAJgP5+HyEykOsa+tEqXdKJD41/5bxJ5tAA9eIxg=",
       "rank": 7,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 10415064572672196,
-      "voting_power_total": 307554773957760060
+      "voting_power": 10415064572672196
     },
     {
       "active": true,
@@ -215,8 +213,7 @@
       "node_id": "ITrwEekdZNqXrEzvw3GT6Q3AtHDd51f19nD2nVU/f0c=",
       "rank": 8,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 8938540510935232,
-      "voting_power_total": 307554773957760060
+      "voting_power": 8938540510935232
     },
     {
       "active": true,
@@ -242,8 +239,7 @@
       "node_id": "RyR58ibjevY8DqFHaqDfJhe1zm0XeY83hPk78qtcUic=",
       "rank": 9,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 7554425624524300,
-      "voting_power_total": 307554773957760060
+      "voting_power": 7554425624524300
     },
     {
       "active": true,
@@ -269,8 +265,7 @@
       "node_id": "4bv9f6NqLf4+6+QII+p48KgpagFXk9PgIdefbuo2spA=",
       "rank": 10,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 6361879056009996,
-      "voting_power_total": 307554773957760060
+      "voting_power": 6361879056009996
     },
     {
       "active": true,
@@ -296,8 +291,7 @@
       "node_id": "5UbIi8RQj4flFn9N8wHjQqp6QwZFJi2QdD2mOYLa/sY=",
       "rank": 11,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 5311202506753837,
-      "voting_power_total": 307554773957760060
+      "voting_power": 5311202506753837
     },
     {
       "active": true,
@@ -323,8 +317,7 @@
       "node_id": "Y7mD0uNLcWvuRRTgIARWsAhFisb669haOdhZJuc9Tvc=",
       "rank": 12,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4756004814108503,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4756004814108503
     },
     {
       "active": true,
@@ -350,8 +343,7 @@
       "node_id": "HnLtoQyiKOkr2NMcQsQ4UH0HW8qkLRGWn4mgkDLNoEo=",
       "rank": 13,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4717962664697105,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4717962664697105
     },
     {
       "active": true,
@@ -377,8 +369,7 @@
       "node_id": "QtzFQlvzg+9999TIUZSCrvvhPUyGKp4HxXC4M1SfgVk=",
       "rank": 14,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4710561313803889,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4710561313803889
     },
     {
       "active": true,
@@ -404,8 +395,7 @@
       "node_id": "3xkzy9g5wL1sqGY8cnd6A7kFuwFM4yuUt0nEJrdHNJ0=",
       "rank": 15,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4291882895061947,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4291882895061947
     },
     {
       "active": true,
@@ -431,8 +421,7 @@
       "node_id": "1Eh9S7bnBnYzhdMuRc8W1DtGsjgMptbRktoE7tw/HiA=",
       "rank": 16,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4243272681621272,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4243272681621272
     },
     {
       "active": true,
@@ -458,8 +447,7 @@
       "node_id": "+CS8pbR8HUix6kGpUQjCv/QxMLVp9J8MkFuV+w6yRbM=",
       "rank": 17,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 4125023347841469,
-      "voting_power_total": 307554773957760060
+      "voting_power": 4125023347841469
     },
     {
       "active": true,
@@ -485,8 +473,7 @@
       "node_id": "IEkIQb2o8l0xlFIpN47FmOYcBmFch9DsZGs8OuZqQ6g=",
       "rank": 18,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3971772995405142,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3971772995405142
     },
     {
       "active": true,
@@ -512,8 +499,7 @@
       "node_id": "4Tz2fSohCN3mm3I9sA6hAQMv/8nmj4ssIXKoOBnxBek=",
       "rank": 19,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3848560816095546,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3848560816095546
     },
     {
       "active": true,
@@ -539,8 +525,7 @@
       "node_id": "QOkzQ7D2zdHmMtZa/6qhmopvhe6ZTodb4I1hoHeA1oQ=",
       "rank": 20,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3773957546507548,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3773957546507548
     },
     {
       "active": true,
@@ -566,8 +551,7 @@
       "node_id": "f1wwQPdE6avSzRoaayfIwEe8PukXdIYOuDdJ9CDQLCE=",
       "rank": 21,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3711691429534619,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3711691429534619
     },
     {
       "active": true,
@@ -593,8 +577,7 @@
       "node_id": "MnmXWIpf1hEok0rIcynmHfYR6kvWuyH6VdCJARVN5oY=",
       "rank": 22,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3638097937125399,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3638097937125399
     },
     {
       "active": true,
@@ -620,8 +603,7 @@
       "node_id": "dMaOtmpPbdB7ukYfXdo+ssTTCjX2Qspmi1YJIg5Hcr0=",
       "rank": 23,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3630478047562991,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3630478047562991
     },
     {
       "active": true,
@@ -647,8 +629,7 @@
       "node_id": "lTC9wxlqYTUvXSV2bJxj0w2JWGdlY6pZFIx68V/qYB4=",
       "rank": 24,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3567868054786941,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3567868054786941
     },
     {
       "active": true,
@@ -674,8 +655,7 @@
       "node_id": "SW5hffFy0nOLvIfmbkFk9to5NFO8w+QxkxiAfx4a094=",
       "rank": 25,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3561070141187375,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3561070141187375
     },
     {
       "active": true,
@@ -701,8 +681,7 @@
       "node_id": "25hzSeb4IPl2+wsn2LPe7hw9IlLmfj1aTdO36XAaB1s=",
       "rank": 26,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3547358222021774,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3547358222021774
     },
     {
       "active": true,
@@ -728,8 +707,7 @@
       "node_id": "QFAWexckwRHNxkIty67NCpY8LHwlrcGp/v0ziDSlgFs=",
       "rank": 27,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3520053057311359,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3520053057311359
     },
     {
       "active": true,
@@ -755,8 +733,7 @@
       "node_id": "ROe9AtvfOFX6bu+5vhRCR87qYXSzp5NfELBqB3Hdgrw=",
       "rank": 28,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3507236023751237,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3507236023751237
     },
     {
       "active": true,
@@ -782,8 +759,7 @@
       "node_id": "4rUqFOE27urnaltMm2XqyuxcghXs4xRep3AV3mXSTt4=",
       "rank": 29,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3480055254820319,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3480055254820319
     },
     {
       "active": true,
@@ -809,8 +785,7 @@
       "node_id": "jZ2/EOnpmPCxCfd5wrrLINNdZSPWyhIx9UqJgZ8sHYk=",
       "rank": 30,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3430786203382342,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3430786203382342
     },
     {
       "active": true,
@@ -836,8 +811,7 @@
       "node_id": "lCQsP7Rhw/EdcM2sVDXOzWcUDHx47wGJDBah4xw6c90=",
       "rank": 31,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3428469605587385,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3428469605587385
     },
     {
       "active": true,
@@ -863,8 +837,7 @@
       "node_id": "AVQbWvlbKOHi3z8uibbOVl3xsCJsw2YtWG5XXdbhhpI=",
       "rank": 32,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3404320124840650,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3404320124840650
     },
     {
       "active": true,
@@ -890,8 +863,7 @@
       "node_id": "nvzaqYTHiG3xo5C5TlfmfyvQgb5aQolfKzsVqT3T/RU=",
       "rank": 33,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3389241958543140,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3389241958543140
     },
     {
       "active": true,
@@ -917,8 +889,7 @@
       "node_id": "UVpVC08tK+uPlx9s5JXbranCodW8q4cPLjrtzY5D7q8=",
       "rank": 34,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3354390405223519,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3354390405223519
     },
     {
       "active": true,
@@ -944,8 +915,7 @@
       "node_id": "eudq22Uwt0ciC7/BYN3TsUy+MCataTkQjwS/BBlgvJE=",
       "rank": 35,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3341324665752066,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3341324665752066
     },
     {
       "active": true,
@@ -971,8 +941,7 @@
       "node_id": "jezrY6n61D/wD39nZKC+LpYfOZt5AN8gZ5SWu9vypD8=",
       "rank": 36,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3322778310817539,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3322778310817539
     },
     {
       "active": true,
@@ -998,8 +967,7 @@
       "node_id": "XanOOptLq+tmEky6Olf3dVO6HZcUJs8f6ESxIvMmO0E=",
       "rank": 37,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3203104871552375,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3203104871552375
     },
     {
       "active": true,
@@ -1025,8 +993,7 @@
       "node_id": "ioLADiyiFmIms+8fib3N36/TX5XEnHrs2vWcH5LxHGo=",
       "rank": 38,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3197108156187150,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3197108156187150
     },
     {
       "active": true,
@@ -1052,8 +1019,7 @@
       "node_id": "p7pJUBSdgF4PfgKrn8JJl4xhVZXMu9h1TfNlAU5VjBU=",
       "rank": 39,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3191406157768919,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3191406157768919
     },
     {
       "active": true,
@@ -1079,8 +1045,7 @@
       "node_id": "AZJhDCByjr/YdTvA7uFnIeYcg7iuHPGiDrJRKaEOYHA=",
       "rank": 40,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3181155665049443,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3181155665049443
     },
     {
       "active": true,
@@ -1106,8 +1071,7 @@
       "node_id": "/LlzNoccjtMUbW6fXa/3KKVa6JN+qwnGQrB4u631nR8=",
       "rank": 41,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3098104208076802,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3098104208076802
     },
     {
       "active": true,
@@ -1133,8 +1097,7 @@
       "node_id": "JThJEQbC1iFVbdy6nFz6mSwChY5xgnOwbWAV3igG6mE=",
       "rank": 42,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 3005901951081247,
-      "voting_power_total": 307554773957760060
+      "voting_power": 3005901951081247
     },
     {
       "active": true,
@@ -1160,8 +1123,7 @@
       "node_id": "0NNKQ47YtOqSioa05EBWgW9Lrh8vQlp2Fe9q3uzdoxk=",
       "rank": 43,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2987161585746164,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2987161585746164
     },
     {
       "active": true,
@@ -1187,8 +1149,7 @@
       "node_id": "y4LZvdQ/k9RBiPLSvBHt/8GhbOVEHY/LfIdgk0iXUho=",
       "rank": 44,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2980385927163672,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2980385927163672
     },
     {
       "active": true,
@@ -1214,8 +1175,7 @@
       "node_id": "I/Vnwyi7FJdROFe64fbaqE3t55OLcUBY8hVK64VNrqc=",
       "rank": 45,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2978684042870848,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2978684042870848
     },
     {
       "active": true,
@@ -1241,8 +1201,7 @@
       "node_id": "GrfIMoanLXIPuS91RhqdikNLcebWN26tMM2/iIA8cAE=",
       "rank": 46,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2977757025602604,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2977757025602604
     },
     {
       "active": true,
@@ -1268,8 +1227,7 @@
       "node_id": "+7Jku1SXiunTIHYxYNu4WGNo2g3uSQh2bXych4f1fDc=",
       "rank": 47,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2905193732984898,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2905193732984898
     },
     {
       "active": true,
@@ -1295,8 +1253,7 @@
       "node_id": "ejPrx9xTpKV3GTZgthFQWf3UPMFFBseRtc0A17ak1TU=",
       "rank": 48,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2901760067938284,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2901760067938284
     },
     {
       "active": true,
@@ -1322,8 +1279,7 @@
       "node_id": "Kv7anzrQTWYDQRLCo1/pkMRV65HpvJCvSEjO/R8wHkc=",
       "rank": 49,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2886749169587693,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2886749169587693
     },
     {
       "active": true,
@@ -1349,8 +1305,7 @@
       "node_id": "LHA2Gbme/AReIFXmxwD9m/Ae8sZ1d2U/DFRfecT72YM=",
       "rank": 50,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2824228935450265,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2824228935450265
     },
     {
       "active": true,
@@ -1376,8 +1331,7 @@
       "node_id": "K5roq8kvag0dzkdauemq4PLfQG/rA4ZeItZ/op2PfGo=",
       "rank": 51,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2765730702553221,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2765730702553221
     },
     {
       "active": true,
@@ -1403,8 +1357,7 @@
       "node_id": "1TDnq8Ps6agmT5CiS6CdIOj9D8sVWvr+AYX8wQ1u5HQ=",
       "rank": 52,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2738719780799548,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2738719780799548
     },
     {
       "active": true,
@@ -1430,8 +1383,7 @@
       "node_id": "0/0TJw2+i1XVYn3Z7igQSpdGoZ0cFdyI4GVcopmH2hI=",
       "rank": 53,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2732630983248227,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2732630983248227
     },
     {
       "active": true,
@@ -1457,8 +1409,7 @@
       "node_id": "hDQp4FhwWREN09nSGMPJAEYKeCmxG/joQivxfY3vyi8=",
       "rank": 54,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2654229914154646,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2654229914154646
     },
     {
       "active": true,
@@ -1484,8 +1435,7 @@
       "node_id": "RClDxygiGYEFeO90jnfHAIXm2QrP5TNQ5F50N77zKY4=",
       "rank": 55,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2627427637297179,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2627427637297179
     },
     {
       "active": true,
@@ -1511,8 +1461,7 @@
       "node_id": "9R8sWVuwyIoE64JXu2sdDWR6vdqFr/X9aEWvPE8G824=",
       "rank": 56,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2594740596025733,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2594740596025733
     },
     {
       "active": true,
@@ -1538,8 +1487,7 @@
       "node_id": "vBGuFf/8tdEMQPiiPggnLlWT9aCbIQgNcRM+EKh2kX0=",
       "rank": 57,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 2033620495290965,
-      "voting_power_total": 307554773957760060
+      "voting_power": 2033620495290965
     },
     {
       "active": true,
@@ -1565,8 +1513,7 @@
       "node_id": "p7+KBgOAk3ztUJrDqjn3NJN+Y725qFNWaGpLcU0H9+E=",
       "rank": 58,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 923130821372964,
-      "voting_power_total": 307554773957760060
+      "voting_power": 923130821372964
     },
     {
       "active": true,
@@ -1592,8 +1539,7 @@
       "node_id": "7E5It9hRik5ndQ1QtL3blTAX3pXSoPZPhGfLMQvbA+Q=",
       "rank": 59,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 837921377626274,
-      "voting_power_total": 307554773957760060
+      "voting_power": 837921377626274
     },
     {
       "active": true,
@@ -1619,8 +1565,7 @@
       "node_id": "6XcILTcGhjvVaWI/tRvZfUTp4huxgg6OBvFQrNmx9DY=",
       "rank": 60,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 798954826358082,
-      "voting_power_total": 307554773957760060
+      "voting_power": 798954826358082
     },
     {
       "active": true,
@@ -1646,8 +1591,7 @@
       "node_id": "e25jqMK9FwlwuV1VPS/dkriJlYh7zKp+1H9B8xAu2LI=",
       "rank": 61,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 571885906051952,
-      "voting_power_total": 307554773957760060
+      "voting_power": 571885906051952
     },
     {
       "active": true,
@@ -1673,8 +1617,7 @@
       "node_id": "apKOntFDXWhpOfYAn1r84IWDG2KGBBAox4usIDhZcns=",
       "rank": 62,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 531074824352845,
-      "voting_power_total": 307554773957760060
+      "voting_power": 531074824352845
     },
     {
       "active": true,
@@ -1700,8 +1643,7 @@
       "node_id": "pjWGVgRla8SJGvBWIP5gPPHgxsr1c2EOsUP5KJvQjgk=",
       "rank": 63,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 519190403626643,
-      "voting_power_total": 307554773957760060
+      "voting_power": 519190403626643
     },
     {
       "active": true,
@@ -1727,8 +1669,7 @@
       "node_id": "KqZ9G3aPJebYACkVTSiYxZJ3vJcsyHz+2f4Jyp5E8AM=",
       "rank": 64,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 514535351765026,
-      "voting_power_total": 307554773957760060
+      "voting_power": 514535351765026
     },
     {
       "active": true,
@@ -1754,8 +1695,7 @@
       "node_id": "REB7DjPPyYCknxakN3MyAOS746YWJtgE41g9ac+oZXU=",
       "rank": 65,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 488273719479174,
-      "voting_power_total": 307554773957760060
+      "voting_power": 488273719479174
     },
     {
       "active": true,
@@ -1781,8 +1721,7 @@
       "node_id": "h8I6YXqxPe9f7zjDcObn/lnhMyPEMyPglpGpHunOx50=",
       "rank": 66,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 433267137463139,
-      "voting_power_total": 307554773957760060
+      "voting_power": 433267137463139
     },
     {
       "active": true,
@@ -1808,8 +1747,7 @@
       "node_id": "IdElhqKVZCHY9Lo6222te1wSdhPPAz/OCsoSRkWrXXw=",
       "rank": 67,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 431595307888120,
-      "voting_power_total": 307554773957760060
+      "voting_power": 431595307888120
     },
     {
       "active": true,
@@ -1835,8 +1773,7 @@
       "node_id": "bOfhQD3tB9nyfyX9WC4J/fZ59HzVAqd6gQ8n+m9DY1g=",
       "rank": 68,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 422457510825231,
-      "voting_power_total": 307554773957760060
+      "voting_power": 422457510825231
     },
     {
       "active": true,
@@ -1862,8 +1799,7 @@
       "node_id": "jVPUq8aUDKe9jawIs7wPB4NBml27ft5kICIY7SBh/yQ=",
       "rank": 69,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 371296071818518,
-      "voting_power_total": 307554773957760060
+      "voting_power": 371296071818518
     },
     {
       "active": true,
@@ -1889,8 +1825,7 @@
       "node_id": "GY1goAIuGGSeVrhjhgVAp4JB0y6l3P5+TnozeBxu/kw=",
       "rank": 70,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 367383220162597,
-      "voting_power_total": 307554773957760060
+      "voting_power": 367383220162597
     },
     {
       "active": true,
@@ -1916,8 +1851,7 @@
       "node_id": "GYJsEu4Yp+CGEQVjy4owQAG6l6xEvGzcNM1xBHaEv6U=",
       "rank": 71,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 364545322261426,
-      "voting_power_total": 307554773957760060
+      "voting_power": 364545322261426
     },
     {
       "active": true,
@@ -1943,8 +1877,7 @@
       "node_id": "igLfuIxxqZATg0snKVTFoeRaqrlNq5r69ofncwlUA8I=",
       "rank": 72,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 360466788462161,
-      "voting_power_total": 307554773957760060
+      "voting_power": 360466788462161
     },
     {
       "active": true,
@@ -1970,8 +1903,7 @@
       "node_id": "e5ebJbZikm11u56wEOM9Ka1uVUS1Pckgc8RGmahs8Ss=",
       "rank": 73,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 357974505767857,
-      "voting_power_total": 307554773957760060
+      "voting_power": 357974505767857
     },
     {
       "active": true,
@@ -1997,8 +1929,7 @@
       "node_id": "6drUHh4qocfbBsA12qM8pTerEcbqhdaHt+v33sEr5kk=",
       "rank": 74,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 356739008677855,
-      "voting_power_total": 307554773957760060
+      "voting_power": 356739008677855
     },
     {
       "active": true,
@@ -2024,8 +1955,7 @@
       "node_id": "CPLy/FYKtIVK7JOspFi3G1Afkurqmh2tAtiDq4rnSfI=",
       "rank": 75,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 356706687975287,
-      "voting_power_total": 307554773957760060
+      "voting_power": 356706687975287
     },
     {
       "active": true,
@@ -2051,8 +1981,7 @@
       "node_id": "y6LXNa3NMtZzeXnz9GNBj9MZuSCwBvfBLkZu2YG2fU4=",
       "rank": 76,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 356580067483848,
-      "voting_power_total": 307554773957760060
+      "voting_power": 356580067483848
     },
     {
       "active": true,
@@ -2078,8 +2007,7 @@
       "node_id": "Y/wwhwec6KZFgmM25vKNCTw1FS71/9iv5Q2lWtFX2PA=",
       "rank": 77,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 356552034291065,
-      "voting_power_total": 307554773957760060
+      "voting_power": 356552034291065
     },
     {
       "active": true,
@@ -2105,8 +2033,7 @@
       "node_id": "5GNoYx8mSk4PjcXLyi2I50Bw7n1ATsqAtttVjRzTuEY=",
       "rank": 78,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 355945932773093,
-      "voting_power_total": 307554773957760060
+      "voting_power": 355945932773093
     },
     {
       "active": true,
@@ -2132,8 +2059,7 @@
       "node_id": "VHs9SQr/IC3ElqF1rNxFuCrkx/pWbhy46So19MQlZLE=",
       "rank": 79,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 345854331910333,
-      "voting_power_total": 307554773957760060
+      "voting_power": 345854331910333
     },
     {
       "active": true,
@@ -2159,8 +2085,7 @@
       "node_id": "HZGW8QfuMUv/JEa1HqT19HrGTdJY3mWH4nogaWrWK+0=",
       "rank": 80,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 344233775976673,
-      "voting_power_total": 307554773957760060
+      "voting_power": 344233775976673
     },
     {
       "active": true,
@@ -2186,8 +2111,7 @@
       "node_id": "orWbpXiShG+xIy/BxDtokUdZwNCg3A4oNSbqkpjbvZQ=",
       "rank": 81,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 341703467975830,
-      "voting_power_total": 307554773957760060
+      "voting_power": 341703467975830
     },
     {
       "active": true,
@@ -2213,8 +2137,7 @@
       "node_id": "MDvOFuiehs/VbW/s0e6DTn5b4fnsteQhCVd9E7T80Hs=",
       "rank": 82,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 317331486429319,
-      "voting_power_total": 307554773957760060
+      "voting_power": 317331486429319
     },
     {
       "active": true,
@@ -2240,8 +2163,7 @@
       "node_id": "mRRMUc8eU8zbqUWAiHDiBeRo6wqVImqQs91TxkGjuuU=",
       "rank": 83,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 224612925141865,
-      "voting_power_total": 307554773957760060
+      "voting_power": 224612925141865
     },
     {
       "active": true,
@@ -2267,8 +2189,7 @@
       "node_id": "DGntJaRFwLUKi879qSLbt1uP3w5cE5vMAlYMispiaFE=",
       "rank": 84,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 136593680024707,
-      "voting_power_total": 307554773957760060
+      "voting_power": 136593680024707
     },
     {
       "active": true,
@@ -2294,8 +2215,7 @@
       "node_id": "oFa261SRphbFBQ+QW6xcd9SZBMJrzsmDrYecSblNHv0=",
       "rank": 85,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 135661752518371,
-      "voting_power_total": 307554773957760060
+      "voting_power": 135661752518371
     },
     {
       "active": true,
@@ -2321,8 +2241,7 @@
       "node_id": "jqnsVyewFRvmYhhf4y0HoKXlMJkKQtdsnglqoOaAr2c=",
       "rank": 86,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 107133224178086,
-      "voting_power_total": 307554773957760060
+      "voting_power": 107133224178086
     },
     {
       "active": true,
@@ -2348,8 +2267,7 @@
       "node_id": "pnzDjfjrjsN+7TZJSw/HzZq+jA6HN3jPsSEOkh9kKWE=",
       "rank": 87,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 98799710438406,
-      "voting_power_total": 307554773957760060
+      "voting_power": 98799710438406
     },
     {
       "active": true,
@@ -2375,8 +2293,7 @@
       "node_id": "U7xmDzxndm9uL4qfFWau6d1dadgeH2yEP6q1L332lTE=",
       "rank": 88,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 96314157065928,
-      "voting_power_total": 307554773957760060
+      "voting_power": 96314157065928
     },
     {
       "active": true,
@@ -2402,8 +2319,7 @@
       "node_id": "ao6m4qMGefemuUiwr6GoqxaeWoX14uQ7YTxTajKADQg=",
       "rank": 89,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 90515510647488,
-      "voting_power_total": 307554773957760060
+      "voting_power": 90515510647488
     },
     {
       "active": true,
@@ -2429,8 +2345,7 @@
       "node_id": "5RIMVgnsN1D/HdvNxXCpE+lWH5U/SGYUrYsvhsTMbyA=",
       "rank": 90,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 80856677863643,
-      "voting_power_total": 307554773957760060
+      "voting_power": 80856677863643
     },
     {
       "active": true,
@@ -2456,8 +2371,7 @@
       "node_id": "hM2SObJhWRiFvIsGnplNPP9TgUkMMAD6Aynu+D0ry1E=",
       "rank": 91,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 76202824283500,
-      "voting_power_total": 307554773957760060
+      "voting_power": 76202824283500
     },
     {
       "active": true,
@@ -2483,8 +2397,7 @@
       "node_id": "wqd9Yy3n7TWKfYRn2bI9Hd6/623CfC7NCUoRbQ5UkR8=",
       "rank": 92,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 34834350461211,
-      "voting_power_total": 307554773957760060
+      "voting_power": 34834350461211
     },
     {
       "active": true,
@@ -2510,8 +2423,7 @@
       "node_id": "2cCzBxxmU/xnZwBf7aEoPiKXx5JWURZrkfHHXML8bmk=",
       "rank": 93,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 8949562500000,
-      "voting_power_total": 307554773957760060
+      "voting_power": 8949562500000
     },
     {
       "active": true,
@@ -2537,8 +2449,7 @@
       "node_id": "e4QCCt29Klvx1d8NsuJIUwxBmvq/soDhx6zSXG35IDo=",
       "rank": 94,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 1625000000000,
-      "voting_power_total": 307554773957760060
+      "voting_power": 1625000000000
     },
     {
       "active": true,
@@ -2564,8 +2475,7 @@
       "node_id": "IE9harmC4ZLU5fU9viDwuR4MKwuNVy7Di8mV51K39oM=",
       "rank": 95,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 200000000000,
-      "voting_power_total": 307554773957760060
+      "voting_power": 200000000000
     },
     {
       "active": true,
@@ -2591,8 +2501,7 @@
       "node_id": "g1N1PdE7dBT5yYyhCbVa44637hhsIpIH8EF8gFlmiIQ=",
       "rank": 96,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 14375000000,
-      "voting_power_total": 307554773957760060
+      "voting_power": 14375000000
     },
     {
       "active": true,
@@ -2618,8 +2527,7 @@
       "node_id": "Wb0BR+Ih7yuYgC+m4tFqtPP8G4jDH79iJaYkgNx6DY4=",
       "rank": 97,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2645,8 +2553,7 @@
       "node_id": "ZsA76RMHOOMS4tJhoCM0X1T6TN+JmFyXGWz54WBnw14=",
       "rank": 98,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2672,8 +2579,7 @@
       "node_id": "+zVbgQqOdY90Z2NQKXFByNT0OwLxj/Ho4j4qT5u2yKM=",
       "rank": 99,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2699,8 +2605,7 @@
       "node_id": "skPNqlh8lnR83RyK2clbAscktu5jY/fWq5OzcSZL6Iw=",
       "rank": 100,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2726,8 +2631,7 @@
       "node_id": "/6Dm7sBPDRXL4maL+RVHFHb3JCxZw5u6Fn0cfSxeolg=",
       "rank": 101,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2753,8 +2657,7 @@
       "node_id": "GWBXv2OxowCLsRGyT/cND2TKEs9kpo4xtvr1JTsB8R0=",
       "rank": 102,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2780,8 +2683,7 @@
       "node_id": "qHFe9LJXRDRERZgyJFCzbd4YSwqekUrrkkVb9AWaHXQ=",
       "rank": 103,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2807,8 +2709,7 @@
       "node_id": "c7ycVhiEqHbQfOdeeaj965nuxN8Hsb4BxMPbaPIipRw=",
       "rank": 104,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2834,8 +2735,7 @@
       "node_id": "CfdTYbSw5r7lgm2oNKIv8uHeJFmvl5q9iFcV1P5zFS0=",
       "rank": 105,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2861,8 +2761,7 @@
       "node_id": "axFry86SMrw5X4ITO+YHLLrVqW6N1vcaTgrTOJfQPCc=",
       "rank": 106,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2888,8 +2787,7 @@
       "node_id": "DudLYGDVKMgh/OZ0rOsoxeCNzSxalm4bvQsrsE/H9XA=",
       "rank": 107,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2915,8 +2813,7 @@
       "node_id": "FFKV7PJ9eyTwGjAf5CjO/l0Ec1mfeE2ViXwxTYcwmPo=",
       "rank": 108,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2942,8 +2839,7 @@
       "node_id": "bsq05GjUhJU7CdNOGrI2satPmpAUjRmT0gAGbWyfhLw=",
       "rank": 109,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2969,8 +2865,7 @@
       "node_id": "+isN1pgldZUB/ayTb8e1rbD4vXWiOsFKxOjZlZKvcEU=",
       "rank": 110,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2996,8 +2891,7 @@
       "node_id": "POpjxTxuw2cJsgtgzgfhrkPD3hVh2oYkHmELHonPgpQ=",
       "rank": 111,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3023,8 +2917,7 @@
       "node_id": "kilLHKVgCJC5T62styokgO0IHWmLClT85XzFDSBCjok=",
       "rank": 112,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3050,8 +2943,7 @@
       "node_id": "bbkPZRl8KA//0joD1R9HPnucJ4GklCoAtUoJrincsoo=",
       "rank": 113,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3077,8 +2969,7 @@
       "node_id": "ONNtkoEg0gKzrYd+ERdUz5Xq/D7S72IyCGbc6lJQcZk=",
       "rank": 114,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3104,8 +2995,7 @@
       "node_id": "vVcKIFmjqLRSp/sjKeX3yPQ3R/jf3lU2hAzXYd+4wnk=",
       "rank": 115,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3131,8 +3021,7 @@
       "node_id": "1Ofik7xZJ3Tb/JE+zHKNe3l8NbSK9h/92fjynrW7xw0=",
       "rank": 116,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3158,8 +3047,7 @@
       "node_id": "g/gNUJ3L8NbJilg+ivA0JHXFoCpzXwedqSLO3Xd0FSM=",
       "rank": 117,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3185,8 +3073,7 @@
       "node_id": "J2vFhYaht7l1B++dBUTzqubT72WfOeeBkI8rOamrgGc=",
       "rank": 118,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3212,8 +3099,7 @@
       "node_id": "NwJb7kl/uJUbhnYoxJXWpcc2zmbRVW6Norps326dz+k=",
       "rank": 119,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3239,8 +3125,7 @@
       "node_id": "Eeze8MB6KgnOs8rE1E90QX5i6JFq+z3e0dkTcxIzF5Y=",
       "rank": 120,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3266,8 +3151,7 @@
       "node_id": "TK0FcEOwv/hU5TI8PqWrhQiOy8VfP0vc8m7QViD4VMo=",
       "rank": 121,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3293,8 +3177,7 @@
       "node_id": "gsZZ8tBnXsNGUFjCtxaWba98fzzgQG5cmUW+Ag/aW4g=",
       "rank": 122,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3320,8 +3203,7 @@
       "node_id": "o+KFxCWnNyUstx2iCbMDvTsf+P/pDCC4lLxlljtOUeM=",
       "rank": 123,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3347,8 +3229,7 @@
       "node_id": "HwsTYDWFD/V6+DFRWxSfmKffLjzxLJjO45BNHk1gvZw=",
       "rank": 124,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3373,8 +3254,7 @@
       "in_validator_set": false,
       "rank": 125,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3399,8 +3279,7 @@
       "in_validator_set": false,
       "rank": 126,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3425,8 +3304,7 @@
       "in_validator_set": false,
       "rank": 127,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3451,8 +3329,7 @@
       "in_validator_set": false,
       "rank": 128,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3477,8 +3354,7 @@
       "in_validator_set": false,
       "rank": 129,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3503,8 +3379,7 @@
       "in_validator_set": false,
       "rank": 130,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3529,8 +3404,7 @@
       "in_validator_set": false,
       "rank": 131,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3555,8 +3429,7 @@
       "in_validator_set": false,
       "rank": 132,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3581,8 +3454,7 @@
       "in_validator_set": false,
       "rank": 133,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3607,8 +3479,7 @@
       "in_validator_set": false,
       "rank": 134,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3633,8 +3504,7 @@
       "in_validator_set": false,
       "rank": 135,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3659,8 +3529,7 @@
       "in_validator_set": false,
       "rank": 136,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3685,8 +3554,7 @@
       "in_validator_set": false,
       "rank": 137,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3711,8 +3579,7 @@
       "in_validator_set": false,
       "rank": 138,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3737,8 +3604,7 @@
       "in_validator_set": false,
       "rank": 139,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3763,8 +3629,7 @@
       "in_validator_set": false,
       "rank": 140,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3789,8 +3654,7 @@
       "in_validator_set": false,
       "rank": 141,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3815,8 +3679,7 @@
       "in_validator_set": false,
       "rank": 142,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3841,8 +3704,7 @@
       "in_validator_set": false,
       "rank": 143,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3867,8 +3729,7 @@
       "in_validator_set": false,
       "rank": 144,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3893,8 +3754,7 @@
       "in_validator_set": false,
       "rank": 145,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3919,8 +3779,7 @@
       "in_validator_set": false,
       "rank": 146,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3945,8 +3804,7 @@
       "in_validator_set": false,
       "rank": 147,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3971,8 +3829,7 @@
       "in_validator_set": false,
       "rank": 148,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3997,8 +3854,7 @@
       "in_validator_set": false,
       "rank": 149,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4023,8 +3879,7 @@
       "in_validator_set": false,
       "rank": 150,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4049,8 +3904,7 @@
       "in_validator_set": false,
       "rank": 151,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4075,8 +3929,7 @@
       "in_validator_set": false,
       "rank": 152,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4101,8 +3954,7 @@
       "in_validator_set": false,
       "rank": 153,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4127,8 +3979,7 @@
       "in_validator_set": false,
       "rank": 154,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4153,8 +4004,7 @@
       "in_validator_set": false,
       "rank": 155,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4179,8 +4029,7 @@
       "in_validator_set": false,
       "rank": 156,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4205,8 +4054,7 @@
       "in_validator_set": false,
       "rank": 157,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4231,8 +4079,7 @@
       "in_validator_set": false,
       "rank": 158,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4257,8 +4104,7 @@
       "in_validator_set": false,
       "rank": 159,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4283,8 +4129,7 @@
       "in_validator_set": false,
       "rank": 160,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4309,8 +4154,7 @@
       "in_validator_set": false,
       "rank": 161,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4335,8 +4179,7 @@
       "in_validator_set": false,
       "rank": 162,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4361,8 +4204,7 @@
       "in_validator_set": false,
       "rank": 163,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4387,8 +4229,7 @@
       "in_validator_set": false,
       "rank": 164,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4413,8 +4254,7 @@
       "in_validator_set": false,
       "rank": 165,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4439,8 +4279,7 @@
       "in_validator_set": false,
       "rank": 166,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4465,8 +4304,7 @@
       "in_validator_set": false,
       "rank": 167,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4491,8 +4329,7 @@
       "in_validator_set": false,
       "rank": 168,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4517,8 +4354,7 @@
       "in_validator_set": false,
       "rank": 169,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4543,8 +4379,7 @@
       "in_validator_set": false,
       "rank": 170,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4569,8 +4404,7 @@
       "in_validator_set": false,
       "rank": 171,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4595,8 +4429,7 @@
       "in_validator_set": false,
       "rank": 172,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4621,8 +4454,7 @@
       "in_validator_set": false,
       "rank": 173,
       "start_date": "2022-04-11T09:30:00Z",
-      "voting_power": 0,
-      "voting_power_total": 307554773957760060
+      "voting_power": 0
     }
   ]
 }

--- a/tests/e2e_regression/eden/expected/validator.body
+++ b/tests/e2e_regression/eden/expected/validator.body
@@ -1,27 +1,37 @@
 {
-  "active": true,
-  "current_commission_bound": {
-    "epoch_end": 0,
-    "epoch_start": 4725,
-    "lower": 0,
-    "upper": 25000
+  "is_total_count_clipped": false,
+  "stats": {
+    "total_delegators": 60793,
+    "total_staked_balance": "4755447159862365014",
+    "total_voting_power": 261234553964856260
   },
-  "current_rate": 10000,
-  "entity_address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
-  "entity_id": "9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=",
-  "escrow": {
-    "active_balance": "510451387625537252",
-    "active_shares": "409179768799490790",
-    "debonding_balance": "3665408095574550",
-    "debonding_shares": "3665408095574550",
-    "num_delegators": 10333,
-    "self_delegation_balance": "2732659347000638",
-    "self_delegation_shares": "2190510099335361"
-  },
-  "in_validator_set": true,
-  "node_id": "6wbL5/OxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA=",
-  "rank": 1,
-  "start_date": "2023-11-29T10:02:19Z",
-  "voting_power": 31903165146578016,
-  "voting_power_total": 261234553964856260
+  "total_count": 1,
+  "validators": [
+    {
+      "active": true,
+      "current_commission_bound": {
+        "epoch_end": 0,
+        "epoch_start": 4725,
+        "lower": 0,
+        "upper": 25000
+      },
+      "current_rate": 10000,
+      "entity_address": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
+      "entity_id": "9sAhd+Wi6tG5nAr3LwXD0y9mUKLYqfAbS2+7SZdNHB4=",
+      "escrow": {
+        "active_balance": "510451387625537252",
+        "active_shares": "409179768799490790",
+        "debonding_balance": "3665408095574550",
+        "debonding_shares": "3665408095574550",
+        "num_delegators": 10333,
+        "self_delegation_balance": "2732659347000638",
+        "self_delegation_shares": "2190510099335361"
+      },
+      "in_validator_set": true,
+      "node_id": "6wbL5/OxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA=",
+      "rank": 1,
+      "start_date": "2023-11-29T10:02:19Z",
+      "voting_power": 31903165146578016
+    }
+  ]
 }

--- a/tests/e2e_regression/eden/expected/validators.body
+++ b/tests/e2e_regression/eden/expected/validators.body
@@ -1,5 +1,10 @@
 {
   "is_total_count_clipped": false,
+  "stats": {
+    "total_delegators": 60793,
+    "total_staked_balance": "4755447159862365014",
+    "total_voting_power": 261234553964856260
+  },
   "total_count": 206,
   "validators": [
     {
@@ -26,8 +31,7 @@
       "node_id": "6wbL5/OxvFGxi55o7AxcwKmfjXbXGC1hw4lfnEZxBXA=",
       "rank": 1,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 31903165146578016,
-      "voting_power_total": 261234553964856260
+      "voting_power": 31903165146578016
     },
     {
       "active": true,
@@ -53,8 +57,7 @@
       "node_id": "ked2iuR80WQdb4g7l+PqbQKGJAvD4+KVPFwuDc5nU6M=",
       "rank": 2,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 23508310046553456,
-      "voting_power_total": 261234553964856260
+      "voting_power": 23508310046553456
     },
     {
       "active": true,
@@ -80,8 +83,7 @@
       "node_id": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
       "rank": 3,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 17597413222050748,
-      "voting_power_total": 261234553964856260
+      "voting_power": 17597413222050748
     },
     {
       "active": true,
@@ -107,8 +109,7 @@
       "node_id": "PsfFUQrXqGoFtowWZcoc8ilh8xHP94LvNYHvqQHpw1E=",
       "rank": 4,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 14409541602963356,
-      "voting_power_total": 261234553964856260
+      "voting_power": 14409541602963356
     },
     {
       "active": true,
@@ -134,8 +135,7 @@
       "node_id": "qnRAoObwndP/P9otTzQ/9Z2+vmSQ1Pch7G4tGBSTxCo=",
       "rank": 5,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 11813946657692260,
-      "voting_power_total": 261234553964856260
+      "voting_power": 11813946657692260
     },
     {
       "active": true,
@@ -161,8 +161,7 @@
       "node_id": "xHvUU4I+dQ4oKvlfe4IXoKi8OT8vdAgfszQ5ciPL6HI=",
       "rank": 6,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 6898806920230617,
-      "voting_power_total": 261234553964856260
+      "voting_power": 6898806920230617
     },
     {
       "active": true,
@@ -188,8 +187,7 @@
       "node_id": "DudLYGDVKMgh/OZ0rOsoxeCNzSxalm4bvQsrsE/H9XA=",
       "rank": 7,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 6006105120821732,
-      "voting_power_total": 261234553964856260
+      "voting_power": 6006105120821732
     },
     {
       "active": true,
@@ -215,8 +213,7 @@
       "node_id": "GbyaSlSmHP7INTdznI0NzlN0VWGrPJX5ZQqTNZqNC7o=",
       "rank": 8,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 4922201735007926,
-      "voting_power_total": 261234553964856260
+      "voting_power": 4922201735007926
     },
     {
       "active": true,
@@ -242,8 +239,7 @@
       "node_id": "HtMg7C5OOSLdjm6fCYBoLJ6lrmkthM2fVQPykOq3S9k=",
       "rank": 9,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 4822438253997837,
-      "voting_power_total": 261234553964856260
+      "voting_power": 4822438253997837
     },
     {
       "active": true,
@@ -269,8 +265,7 @@
       "node_id": "4bv9f6NqLf4+6+QII+p48KgpagFXk9PgIdefbuo2spA=",
       "rank": 10,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 4546237779496083,
-      "voting_power_total": 261234553964856260
+      "voting_power": 4546237779496083
     },
     {
       "active": true,
@@ -296,8 +291,7 @@
       "node_id": "apKOntFDXWhpOfYAn1r84IWDG2KGBBAox4usIDhZcns=",
       "rank": 11,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 4355334345360668,
-      "voting_power_total": 261234553964856260
+      "voting_power": 4355334345360668
     },
     {
       "active": true,
@@ -323,8 +317,7 @@
       "node_id": "6drUHh4qocfbBsA12qM8pTerEcbqhdaHt+v33sEr5kk=",
       "rank": 12,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3878679245689438,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3878679245689438
     },
     {
       "active": true,
@@ -350,8 +343,7 @@
       "node_id": "jVPUq8aUDKe9jawIs7wPB4NBml27ft5kICIY7SBh/yQ=",
       "rank": 13,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3776172592266215,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3776172592266215
     },
     {
       "active": true,
@@ -377,8 +369,7 @@
       "node_id": "YyvKEbFTA9HS2WL763OQ+8HMe2AWdGt3D1j0h6I0x6c=",
       "rank": 14,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3721465390830823,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3721465390830823
     },
     {
       "active": true,
@@ -404,8 +395,7 @@
       "node_id": "XCiPWblWT3n1aN2NI0vslmlfV9GOkxE2Ih2SI66ZR38=",
       "rank": 15,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3640942372791089,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3640942372791089
     },
     {
       "active": true,
@@ -431,8 +421,7 @@
       "node_id": "AFg3reZ2n4Xmz1io3+oLQz9ZkfNRkLopO1DkWZuzUCQ=",
       "rank": 16,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3620475693605702,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3620475693605702
     },
     {
       "active": true,
@@ -458,8 +447,7 @@
       "node_id": "IEkIQb2o8l0xlFIpN47FmOYcBmFch9DsZGs8OuZqQ6g=",
       "rank": 17,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3513558186372270,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3513558186372270
     },
     {
       "active": true,
@@ -485,8 +473,7 @@
       "node_id": "BZvhmvc1YZpXteI2nPhBDyC2jxi04MHEbKXB1DpTM1w=",
       "rank": 18,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3403624079219081,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3403624079219081
     },
     {
       "active": true,
@@ -512,8 +499,7 @@
       "node_id": "Y/wwhwec6KZFgmM25vKNCTw1FS71/9iv5Q2lWtFX2PA=",
       "rank": 19,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3399658712683794,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3399658712683794
     },
     {
       "active": true,
@@ -539,8 +525,7 @@
       "node_id": "4rUqFOE27urnaltMm2XqyuxcghXs4xRep3AV3mXSTt4=",
       "rank": 20,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3344314661918167,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3344314661918167
     },
     {
       "active": true,
@@ -566,8 +551,7 @@
       "node_id": "Fg9vlXWjuP7OZHhLMliDzfTOenuxtYo93VxQquFDUxw=",
       "rank": 21,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3264453677776889,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3264453677776889
     },
     {
       "active": true,
@@ -593,8 +577,7 @@
       "node_id": "ao6m4qMGefemuUiwr6GoqxaeWoX14uQ7YTxTajKADQg=",
       "rank": 22,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3260268332230039,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3260268332230039
     },
     {
       "active": true,
@@ -620,8 +603,7 @@
       "node_id": "b+6HsJ3SRI9f3eecG0bSZG/7UQzEBcJsIi4z07ytmEA=",
       "rank": 23,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3250599628987143,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3250599628987143
     },
     {
       "active": true,
@@ -647,8 +629,7 @@
       "node_id": "napBTcD5bfZJuheWQLWrfMnvr0mgdjrd93cTJzpJD1I=",
       "rank": 24,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3136898082433037,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3136898082433037
     },
     {
       "active": true,
@@ -674,8 +655,7 @@
       "node_id": "GYJsEu4Yp+CGEQVjy4owQAG6l6xEvGzcNM1xBHaEv6U=",
       "rank": 25,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3086274751464075,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3086274751464075
     },
     {
       "active": true,
@@ -701,8 +681,7 @@
       "node_id": "orWbpXiShG+xIy/BxDtokUdZwNCg3A4oNSbqkpjbvZQ=",
       "rank": 26,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 3037726616151457,
-      "voting_power_total": 261234553964856260
+      "voting_power": 3037726616151457
     },
     {
       "active": true,
@@ -728,8 +707,7 @@
       "node_id": "y6LXNa3NMtZzeXnz9GNBj9MZuSCwBvfBLkZu2YG2fU4=",
       "rank": 27,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2883968483941044,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2883968483941044
     },
     {
       "active": true,
@@ -755,8 +733,7 @@
       "node_id": "oFa261SRphbFBQ+QW6xcd9SZBMJrzsmDrYecSblNHv0=",
       "rank": 28,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2862981564313518,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2862981564313518
     },
     {
       "active": true,
@@ -782,8 +759,7 @@
       "node_id": "CPLy/FYKtIVK7JOspFi3G1Afkurqmh2tAtiDq4rnSfI=",
       "rank": 29,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2837637937700289,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2837637937700289
     },
     {
       "active": true,
@@ -809,8 +785,7 @@
       "node_id": "5GNoYx8mSk4PjcXLyi2I50Bw7n1ATsqAtttVjRzTuEY=",
       "rank": 30,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2810333352344620,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2810333352344620
     },
     {
       "active": true,
@@ -836,8 +811,7 @@
       "node_id": "dMaOtmpPbdB7ukYfXdo+ssTTCjX2Qspmi1YJIg5Hcr0=",
       "rank": 31,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2736624707230437,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2736624707230437
     },
     {
       "active": true,
@@ -863,8 +837,7 @@
       "node_id": "aJFHeID4Q7qUfMa42dRwaa9PQrZ/cVDiE3WNt4bQjo0=",
       "rank": 32,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2431770222442441,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2431770222442441
     },
     {
       "active": true,
@@ -890,8 +863,7 @@
       "node_id": "g4GC/b200mEkFXNhsOJxQKdo39DAHayAxrO+c1AhfhI=",
       "rank": 33,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2361594168466702,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2361594168466702
     },
     {
       "active": true,
@@ -917,8 +889,7 @@
       "node_id": "ITrwEekdZNqXrEzvw3GT6Q3AtHDd51f19nD2nVU/f0c=",
       "rank": 34,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2349296265173979,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2349296265173979
     },
     {
       "active": true,
@@ -944,8 +915,7 @@
       "node_id": "AZJhDCByjr/YdTvA7uFnIeYcg7iuHPGiDrJRKaEOYHA=",
       "rank": 35,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2294935242424635,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2294935242424635
     },
     {
       "active": true,
@@ -971,8 +941,7 @@
       "node_id": "6XcILTcGhjvVaWI/tRvZfUTp4huxgg6OBvFQrNmx9DY=",
       "rank": 36,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 2155088774823581,
-      "voting_power_total": 261234553964856260
+      "voting_power": 2155088774823581
     },
     {
       "active": true,
@@ -998,8 +967,7 @@
       "node_id": "3xkzy9g5wL1sqGY8cnd6A7kFuwFM4yuUt0nEJrdHNJ0=",
       "rank": 37,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1850649400116537,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1850649400116537
     },
     {
       "active": true,
@@ -1025,8 +993,7 @@
       "node_id": "AVQbWvlbKOHi3z8uibbOVl3xsCJsw2YtWG5XXdbhhpI=",
       "rank": 38,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1843773648812438,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1843773648812438
     },
     {
       "active": true,
@@ -1052,8 +1019,7 @@
       "node_id": "XanOOptLq+tmEky6Olf3dVO6HZcUJs8f6ESxIvMmO0E=",
       "rank": 39,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1824442496831759,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1824442496831759
     },
     {
       "active": true,
@@ -1079,8 +1045,7 @@
       "node_id": "IdElhqKVZCHY9Lo6222te1wSdhPPAz/OCsoSRkWrXXw=",
       "rank": 40,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1810418806792831,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1810418806792831
     },
     {
       "active": true,
@@ -1106,8 +1071,7 @@
       "node_id": "ioLADiyiFmIms+8fib3N36/TX5XEnHrs2vWcH5LxHGo=",
       "rank": 41,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1807883950508396,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1807883950508396
     },
     {
       "active": true,
@@ -1133,8 +1097,7 @@
       "node_id": "JThJEQbC1iFVbdy6nFz6mSwChY5xgnOwbWAV3igG6mE=",
       "rank": 42,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1802583845053905,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1802583845053905
     },
     {
       "active": true,
@@ -1160,8 +1123,7 @@
       "node_id": "jZ2/EOnpmPCxCfd5wrrLINNdZSPWyhIx9UqJgZ8sHYk=",
       "rank": 43,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1799447815926711,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1799447815926711
     },
     {
       "active": true,
@@ -1187,8 +1149,7 @@
       "node_id": "e5ebJbZikm11u56wEOM9Ka1uVUS1Pckgc8RGmahs8Ss=",
       "rank": 44,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1795969207510365,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1795969207510365
     },
     {
       "active": true,
@@ -1214,8 +1175,7 @@
       "node_id": "0NRs2/1SB/Zbr2Kd5RjM0+KHBrx9mbOLad8qwyQaNvQ=",
       "rank": 45,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1784309021042877,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1784309021042877
     },
     {
       "active": true,
@@ -1241,8 +1201,7 @@
       "node_id": "MnmXWIpf1hEok0rIcynmHfYR6kvWuyH6VdCJARVN5oY=",
       "rank": 46,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1753386695184028,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1753386695184028
     },
     {
       "active": true,
@@ -1268,8 +1227,7 @@
       "node_id": "ejPrx9xTpKV3GTZgthFQWf3UPMFFBseRtc0A17ak1TU=",
       "rank": 47,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1753082273426040,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1753082273426040
     },
     {
       "active": true,
@@ -1295,8 +1253,7 @@
       "node_id": "I/Vnwyi7FJdROFe64fbaqE3t55OLcUBY8hVK64VNrqc=",
       "rank": 48,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1752370798014738,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1752370798014738
     },
     {
       "active": true,
@@ -1322,8 +1279,7 @@
       "node_id": "igLfuIxxqZATg0snKVTFoeRaqrlNq5r69ofncwlUA8I=",
       "rank": 49,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1740025122401581,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1740025122401581
     },
     {
       "active": true,
@@ -1349,8 +1305,7 @@
       "node_id": "GY1goAIuGGSeVrhjhgVAp4JB0y6l3P5+TnozeBxu/kw=",
       "rank": 50,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1736509831768607,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1736509831768607
     },
     {
       "active": true,
@@ -1376,8 +1331,7 @@
       "node_id": "REB7DjPPyYCknxakN3MyAOS746YWJtgE41g9ac+oZXU=",
       "rank": 51,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1692078679396111,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1692078679396111
     },
     {
       "active": true,
@@ -1403,8 +1357,7 @@
       "node_id": "VHs9SQr/IC3ElqF1rNxFuCrkx/pWbhy46So19MQlZLE=",
       "rank": 52,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1657528755833713,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1657528755833713
     },
     {
       "active": true,
@@ -1430,8 +1383,7 @@
       "node_id": "9R8sWVuwyIoE64JXu2sdDWR6vdqFr/X9aEWvPE8G824=",
       "rank": 53,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1652774216592556,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1652774216592556
     },
     {
       "active": true,
@@ -1457,8 +1409,7 @@
       "node_id": "HZGW8QfuMUv/JEa1HqT19HrGTdJY3mWH4nogaWrWK+0=",
       "rank": 54,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1641011959901689,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1641011959901689
     },
     {
       "active": true,
@@ -1484,8 +1435,7 @@
       "node_id": "/LlzNoccjtMUbW6fXa/3KKVa6JN+qwnGQrB4u631nR8=",
       "rank": 55,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1222867035810912,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1222867035810912
     },
     {
       "active": true,
@@ -1511,8 +1461,7 @@
       "node_id": "o5GsCptt8lelHPe2vSoEEBvSosOczh+cRom2+Gouhlo=",
       "rank": 56,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1202125910888756,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1202125910888756
     },
     {
       "active": true,
@@ -1538,8 +1487,7 @@
       "node_id": "+zVbgQqOdY90Z2NQKXFByNT0OwLxj/Ho4j4qT5u2yKM=",
       "rank": 57,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1124823081342055,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1124823081342055
     },
     {
       "active": true,
@@ -1565,8 +1513,7 @@
       "node_id": "QFAWexckwRHNxkIty67NCpY8LHwlrcGp/v0ziDSlgFs=",
       "rank": 58,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1112337555150224,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1112337555150224
     },
     {
       "active": true,
@@ -1592,8 +1539,7 @@
       "node_id": "lCQsP7Rhw/EdcM2sVDXOzWcUDHx47wGJDBah4xw6c90=",
       "rank": 59,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 1015721246857602,
-      "voting_power_total": 261234553964856260
+      "voting_power": 1015721246857602
     },
     {
       "active": true,
@@ -1619,8 +1565,7 @@
       "node_id": "p7pJUBSdgF4PfgKrn8JJl4xhVZXMu9h1TfNlAU5VjBU=",
       "rank": 60,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 999968851435876,
-      "voting_power_total": 261234553964856260
+      "voting_power": 999968851435876
     },
     {
       "active": true,
@@ -1646,8 +1591,7 @@
       "node_id": "y4LZvdQ/k9RBiPLSvBHt/8GhbOVEHY/LfIdgk0iXUho=",
       "rank": 61,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 986014248909462,
-      "voting_power_total": 261234553964856260
+      "voting_power": 986014248909462
     },
     {
       "active": true,
@@ -1673,8 +1617,7 @@
       "node_id": "RClDxygiGYEFeO90jnfHAIXm2QrP5TNQ5F50N77zKY4=",
       "rank": 62,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 964873416897829,
-      "voting_power_total": 261234553964856260
+      "voting_power": 964873416897829
     },
     {
       "active": true,
@@ -1700,8 +1643,7 @@
       "node_id": "vMQ22VnjLoqniEhCIaIIMvmIBykplV4rqawcGdvFAqY=",
       "rank": 63,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 959530870979876,
-      "voting_power_total": 261234553964856260
+      "voting_power": 959530870979876
     },
     {
       "active": true,
@@ -1727,8 +1669,7 @@
       "node_id": "lTC9wxlqYTUvXSV2bJxj0w2JWGdlY6pZFIx68V/qYB4=",
       "rank": 64,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 830842870629706,
-      "voting_power_total": 261234553964856260
+      "voting_power": 830842870629706
     },
     {
       "active": true,
@@ -1754,8 +1695,7 @@
       "node_id": "GrfIMoanLXIPuS91RhqdikNLcebWN26tMM2/iIA8cAE=",
       "rank": 65,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 824083460214930,
-      "voting_power_total": 261234553964856260
+      "voting_power": 824083460214930
     },
     {
       "active": true,
@@ -1781,8 +1721,7 @@
       "node_id": "MDvOFuiehs/VbW/s0e6DTn5b4fnsteQhCVd9E7T80Hs=",
       "rank": 66,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 814960569189426,
-      "voting_power_total": 261234553964856260
+      "voting_power": 814960569189426
     },
     {
       "active": true,
@@ -1808,8 +1747,7 @@
       "node_id": "ROe9AtvfOFX6bu+5vhRCR87qYXSzp5NfELBqB3Hdgrw=",
       "rank": 67,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 807504981753224,
-      "voting_power_total": 261234553964856260
+      "voting_power": 807504981753224
     },
     {
       "active": true,
@@ -1835,8 +1773,7 @@
       "node_id": "2cCzBxxmU/xnZwBf7aEoPiKXx5JWURZrkfHHXML8bmk=",
       "rank": 68,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 793090356990377,
-      "voting_power_total": 261234553964856260
+      "voting_power": 793090356990377
     },
     {
       "active": true,
@@ -1862,8 +1799,7 @@
       "node_id": "jezrY6n61D/wD39nZKC+LpYfOZt5AN8gZ5SWu9vypD8=",
       "rank": 69,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 784409460326357,
-      "voting_power_total": 261234553964856260
+      "voting_power": 784409460326357
     },
     {
       "active": true,
@@ -1889,8 +1825,7 @@
       "node_id": "+Y5BKnMuB33ekK6AL+xbBLe1c4JECQwzIg7eAmSyrKE=",
       "rank": 70,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 772537671934977,
-      "voting_power_total": 261234553964856260
+      "voting_power": 772537671934977
     },
     {
       "active": true,
@@ -1916,8 +1851,7 @@
       "node_id": "eudq22Uwt0ciC7/BYN3TsUy+MCataTkQjwS/BBlgvJE=",
       "rank": 71,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 683756002977988,
-      "voting_power_total": 261234553964856260
+      "voting_power": 683756002977988
     },
     {
       "active": true,
@@ -1943,8 +1877,7 @@
       "node_id": "1Eh9S7bnBnYzhdMuRc8W1DtGsjgMptbRktoE7tw/HiA=",
       "rank": 72,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 622152519404739,
-      "voting_power_total": 261234553964856260
+      "voting_power": 622152519404739
     },
     {
       "active": true,
@@ -1970,8 +1903,7 @@
       "node_id": "LHA2Gbme/AReIFXmxwD9m/Ae8sZ1d2U/DFRfecT72YM=",
       "rank": 73,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 620446711414784,
-      "voting_power_total": 261234553964856260
+      "voting_power": 620446711414784
     },
     {
       "active": true,
@@ -1997,8 +1929,7 @@
       "node_id": "mRRMUc8eU8zbqUWAiHDiBeRo6wqVImqQs91TxkGjuuU=",
       "rank": 74,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 609312901985023,
-      "voting_power_total": 261234553964856260
+      "voting_power": 609312901985023
     },
     {
       "active": true,
@@ -2024,8 +1955,7 @@
       "node_id": "U7xmDzxndm9uL4qfFWau6d1dadgeH2yEP6q1L332lTE=",
       "rank": 75,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 499328776195670,
-      "voting_power_total": 261234553964856260
+      "voting_power": 499328776195670
     },
     {
       "active": true,
@@ -2051,8 +1981,7 @@
       "node_id": "jKA6PqWwftnglxywnQQPoIcb7j2HQVu7anf2i7LWU2c=",
       "rank": 76,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 439169349831084,
-      "voting_power_total": 261234553964856260
+      "voting_power": 439169349831084
     },
     {
       "active": true,
@@ -2078,8 +2007,7 @@
       "node_id": "hDQp4FhwWREN09nSGMPJAEYKeCmxG/joQivxfY3vyi8=",
       "rank": 77,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 429252784854745,
-      "voting_power_total": 261234553964856260
+      "voting_power": 429252784854745
     },
     {
       "active": true,
@@ -2105,8 +2033,7 @@
       "node_id": "kilLHKVgCJC5T62styokgO0IHWmLClT85XzFDSBCjok=",
       "rank": 78,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 356496938671611,
-      "voting_power_total": 261234553964856260
+      "voting_power": 356496938671611
     },
     {
       "active": true,
@@ -2132,8 +2059,7 @@
       "node_id": "P5PjvHDpeiFQGxh4OTaO6qXwRC0AJfhlTfwPj0ZYEzA=",
       "rank": 79,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 343968025755934,
-      "voting_power_total": 261234553964856260
+      "voting_power": 343968025755934
     },
     {
       "active": true,
@@ -2159,8 +2085,7 @@
       "node_id": "YOg6j3mfRIscs0oW+IzeiheXd8zS+6QVXZS/fPr8go4=",
       "rank": 80,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 292630573267426,
-      "voting_power_total": 261234553964856260
+      "voting_power": 292630573267426
     },
     {
       "active": true,
@@ -2186,8 +2111,7 @@
       "node_id": "ONNtkoEg0gKzrYd+ERdUz5Xq/D7S72IyCGbc6lJQcZk=",
       "rank": 81,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 271147567658254,
-      "voting_power_total": 261234553964856260
+      "voting_power": 271147567658254
     },
     {
       "active": true,
@@ -2213,8 +2137,7 @@
       "node_id": "SWzqmOU0EDxeQvko0tvQStepEdSjTdqhMQNEfoRonvI=",
       "rank": 82,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 254393212178928,
-      "voting_power_total": 261234553964856260
+      "voting_power": 254393212178928
     },
     {
       "active": true,
@@ -2240,8 +2163,7 @@
       "node_id": "GWBXv2OxowCLsRGyT/cND2TKEs9kpo4xtvr1JTsB8R0=",
       "rank": 83,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 237773260828267,
-      "voting_power_total": 261234553964856260
+      "voting_power": 237773260828267
     },
     {
       "active": true,
@@ -2267,8 +2189,7 @@
       "node_id": "5sCeNfer0j+/7H1VUAeCWphA3CDfZ2MxFA1zFVzPgPU=",
       "rank": 84,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 226540486510645,
-      "voting_power_total": 261234553964856260
+      "voting_power": 226540486510645
     },
     {
       "active": true,
@@ -2294,8 +2215,7 @@
       "node_id": "cAv9RnPhVePF291QmZNF2Jex0EFcm2Br942ve3Ifxns=",
       "rank": 85,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 178128090301763,
-      "voting_power_total": 261234553964856260
+      "voting_power": 178128090301763
     },
     {
       "active": true,
@@ -2321,8 +2241,7 @@
       "node_id": "AiYyIwAJcdc9yGoBHnP4ycPtd/N2DOR0kqVrQWlS46Y=",
       "rank": 86,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 162158568238512,
-      "voting_power_total": 261234553964856260
+      "voting_power": 162158568238512
     },
     {
       "active": true,
@@ -2348,8 +2267,7 @@
       "node_id": "0/0TJw2+i1XVYn3Z7igQSpdGoZ0cFdyI4GVcopmH2hI=",
       "rank": 87,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 118644618714317,
-      "voting_power_total": 261234553964856260
+      "voting_power": 118644618714317
     },
     {
       "active": true,
@@ -2375,8 +2293,7 @@
       "node_id": "g1N1PdE7dBT5yYyhCbVa44637hhsIpIH8EF8gFlmiIQ=",
       "rank": 88,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 51283682191636,
-      "voting_power_total": 261234553964856260
+      "voting_power": 51283682191636
     },
     {
       "active": true,
@@ -2402,8 +2319,7 @@
       "node_id": "u0ljAJgP5+HyEykOsa+tEqXdKJD41/5bxJ5tAA9eIxg=",
       "rank": 89,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 44819411114507,
-      "voting_power_total": 261234553964856260
+      "voting_power": 44819411114507
     },
     {
       "active": true,
@@ -2429,8 +2345,7 @@
       "node_id": "6iVX2oi9FANusFaQPmIDSWu3qLNE2YKMPhQeO1EhUNQ=",
       "rank": 90,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 36368794300776,
-      "voting_power_total": 261234553964856260
+      "voting_power": 36368794300776
     },
     {
       "active": true,
@@ -2456,8 +2371,7 @@
       "node_id": "pjWGVgRla8SJGvBWIP5gPPHgxsr1c2EOsUP5KJvQjgk=",
       "rank": 91,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2483,8 +2397,7 @@
       "node_id": "wdxW8Bk1hZvQANQHRCO8MzbgRsdC5c7mpLjsNYLM82I=",
       "rank": 92,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2510,8 +2423,7 @@
       "node_id": "c7ycVhiEqHbQfOdeeaj965nuxN8Hsb4BxMPbaPIipRw=",
       "rank": 93,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2537,8 +2449,7 @@
       "node_id": "lbxs4hlud9XNloIOdhJPaCahd7HtiY8QATCgGnFfCM0=",
       "rank": 94,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2564,8 +2475,7 @@
       "node_id": "RyR58ibjevY8DqFHaqDfJhe1zm0XeY83hPk78qtcUic=",
       "rank": 95,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2591,8 +2501,7 @@
       "node_id": "vBGuFf/8tdEMQPiiPggnLlWT9aCbIQgNcRM+EKh2kX0=",
       "rank": 96,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2618,8 +2527,7 @@
       "node_id": "HnLtoQyiKOkr2NMcQsQ4UH0HW8qkLRGWn4mgkDLNoEo=",
       "rank": 97,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2645,8 +2553,7 @@
       "node_id": "Kv7anzrQTWYDQRLCo1/pkMRV65HpvJCvSEjO/R8wHkc=",
       "rank": 98,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2672,8 +2579,7 @@
       "node_id": "4Tz2fSohCN3mm3I9sA6hAQMv/8nmj4ssIXKoOBnxBek=",
       "rank": 99,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2699,8 +2605,7 @@
       "node_id": "e25jqMK9FwlwuV1VPS/dkriJlYh7zKp+1H9B8xAu2LI=",
       "rank": 100,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2726,8 +2631,7 @@
       "node_id": "K5roq8kvag0dzkdauemq4PLfQG/rA4ZeItZ/op2PfGo=",
       "rank": 101,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2753,8 +2657,7 @@
       "node_id": "DGntJaRFwLUKi879qSLbt1uP3w5cE5vMAlYMispiaFE=",
       "rank": 102,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2780,8 +2683,7 @@
       "node_id": "MJc6tzSAEQOxgduime6zcs8bhlfb79AaICG1Xi7fCFA=",
       "rank": 103,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2807,8 +2709,7 @@
       "node_id": "skPNqlh8lnR83RyK2clbAscktu5jY/fWq5OzcSZL6Iw=",
       "rank": 104,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2834,8 +2735,7 @@
       "node_id": "nvzaqYTHiG3xo5C5TlfmfyvQgb5aQolfKzsVqT3T/RU=",
       "rank": 105,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2861,8 +2761,7 @@
       "node_id": "POpjxTxuw2cJsgtgzgfhrkPD3hVh2oYkHmELHonPgpQ=",
       "rank": 106,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2888,8 +2787,7 @@
       "node_id": "Kb6opWKGbJHL0LK2Lto+m5ROIAXLhIr1lxQz0/kAOUM=",
       "rank": 107,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2915,8 +2813,7 @@
       "node_id": "+7Jku1SXiunTIHYxYNu4WGNo2g3uSQh2bXych4f1fDc=",
       "rank": 108,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2942,8 +2839,7 @@
       "node_id": "5RIMVgnsN1D/HdvNxXCpE+lWH5U/SGYUrYsvhsTMbyA=",
       "rank": 109,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2969,8 +2865,7 @@
       "node_id": "lt3KIEsVunHEMDfgnekDbFFr7Y5aqXmNgbfJMzJzYDM=",
       "rank": 110,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -2996,8 +2891,7 @@
       "node_id": "Vql2WfvlHnF0delOCNiV34Gizw05hCpZfsekGav7F9I=",
       "rank": 111,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3023,8 +2917,7 @@
       "node_id": "TK0FcEOwv/hU5TI8PqWrhQiOy8VfP0vc8m7QViD4VMo=",
       "rank": 112,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3050,8 +2943,7 @@
       "node_id": "r4AL9Xu6vOR+ktf4p7q1zo8Fsei9meit9J3orlyhpak=",
       "rank": 113,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3077,8 +2969,7 @@
       "node_id": "SnJS6IlyTGeQRNuk8dFv5w0aQbyz0Cwig+QRbLOh5yk=",
       "rank": 114,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3104,8 +2995,7 @@
       "node_id": "bbkPZRl8KA//0joD1R9HPnucJ4GklCoAtUoJrincsoo=",
       "rank": 115,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3131,8 +3021,7 @@
       "node_id": "LupNjD/E7Mgn0TKmUZeQRUpNwDadUyKinseDz28px5A=",
       "rank": 116,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3158,8 +3047,7 @@
       "node_id": "vVcKIFmjqLRSp/sjKeX3yPQ3R/jf3lU2hAzXYd+4wnk=",
       "rank": 117,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3185,8 +3073,7 @@
       "node_id": "J2vFhYaht7l1B++dBUTzqubT72WfOeeBkI8rOamrgGc=",
       "rank": 118,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": true,
@@ -3212,8 +3099,7 @@
       "node_id": "MLczDReN6Kco4BF8GCI0+h1CALWxu37ZtWQNx+j3d8U=",
       "rank": 119,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3238,8 +3124,7 @@
       "in_validator_set": false,
       "rank": 120,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3264,8 +3149,7 @@
       "in_validator_set": false,
       "rank": 121,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3290,8 +3174,7 @@
       "in_validator_set": false,
       "rank": 122,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3316,8 +3199,7 @@
       "in_validator_set": false,
       "rank": 123,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3342,8 +3224,7 @@
       "in_validator_set": false,
       "rank": 124,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3368,8 +3249,7 @@
       "in_validator_set": false,
       "rank": 125,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3394,8 +3274,7 @@
       "in_validator_set": false,
       "rank": 126,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3420,8 +3299,7 @@
       "in_validator_set": false,
       "rank": 127,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3446,8 +3324,7 @@
       "in_validator_set": false,
       "rank": 128,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3472,8 +3349,7 @@
       "in_validator_set": false,
       "rank": 129,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3498,8 +3374,7 @@
       "in_validator_set": false,
       "rank": 130,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3524,8 +3399,7 @@
       "in_validator_set": false,
       "rank": 131,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3550,8 +3424,7 @@
       "in_validator_set": false,
       "rank": 132,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3576,8 +3449,7 @@
       "in_validator_set": false,
       "rank": 133,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3602,8 +3474,7 @@
       "in_validator_set": false,
       "rank": 134,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3628,8 +3499,7 @@
       "in_validator_set": false,
       "rank": 135,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3654,8 +3524,7 @@
       "in_validator_set": false,
       "rank": 136,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3680,8 +3549,7 @@
       "in_validator_set": false,
       "rank": 137,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3706,8 +3574,7 @@
       "in_validator_set": false,
       "rank": 138,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3732,8 +3599,7 @@
       "in_validator_set": false,
       "rank": 139,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3758,8 +3624,7 @@
       "in_validator_set": false,
       "rank": 140,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3784,8 +3649,7 @@
       "in_validator_set": false,
       "rank": 141,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3810,8 +3674,7 @@
       "in_validator_set": false,
       "rank": 142,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3836,8 +3699,7 @@
       "in_validator_set": false,
       "rank": 143,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3862,8 +3724,7 @@
       "in_validator_set": false,
       "rank": 144,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3888,8 +3749,7 @@
       "in_validator_set": false,
       "rank": 145,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3914,8 +3774,7 @@
       "in_validator_set": false,
       "rank": 146,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3940,8 +3799,7 @@
       "in_validator_set": false,
       "rank": 147,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3966,8 +3824,7 @@
       "in_validator_set": false,
       "rank": 148,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -3992,8 +3849,7 @@
       "in_validator_set": false,
       "rank": 149,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4018,8 +3874,7 @@
       "in_validator_set": false,
       "rank": 150,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4044,8 +3899,7 @@
       "in_validator_set": false,
       "rank": 151,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4070,8 +3924,7 @@
       "in_validator_set": false,
       "rank": 152,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4096,8 +3949,7 @@
       "in_validator_set": false,
       "rank": 153,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4122,8 +3974,7 @@
       "in_validator_set": false,
       "rank": 154,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4148,8 +3999,7 @@
       "in_validator_set": false,
       "rank": 155,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4174,8 +4024,7 @@
       "in_validator_set": false,
       "rank": 156,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4200,8 +4049,7 @@
       "in_validator_set": false,
       "rank": 157,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4226,8 +4074,7 @@
       "in_validator_set": false,
       "rank": 158,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4252,8 +4099,7 @@
       "in_validator_set": false,
       "rank": 159,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4278,8 +4124,7 @@
       "in_validator_set": false,
       "rank": 160,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4304,8 +4149,7 @@
       "in_validator_set": false,
       "rank": 161,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4330,8 +4174,7 @@
       "in_validator_set": false,
       "rank": 162,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4356,8 +4199,7 @@
       "in_validator_set": false,
       "rank": 163,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4382,8 +4224,7 @@
       "in_validator_set": false,
       "rank": 164,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4408,8 +4249,7 @@
       "in_validator_set": false,
       "rank": 165,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4434,8 +4274,7 @@
       "in_validator_set": false,
       "rank": 166,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4460,8 +4299,7 @@
       "in_validator_set": false,
       "rank": 167,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4486,8 +4324,7 @@
       "in_validator_set": false,
       "rank": 168,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4512,8 +4349,7 @@
       "in_validator_set": false,
       "rank": 169,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4538,8 +4374,7 @@
       "in_validator_set": false,
       "rank": 170,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4564,8 +4399,7 @@
       "in_validator_set": false,
       "rank": 171,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4590,8 +4424,7 @@
       "in_validator_set": false,
       "rank": 172,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4616,8 +4449,7 @@
       "in_validator_set": false,
       "rank": 173,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4642,8 +4474,7 @@
       "in_validator_set": false,
       "rank": 174,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4668,8 +4499,7 @@
       "in_validator_set": false,
       "rank": 175,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4694,8 +4524,7 @@
       "in_validator_set": false,
       "rank": 176,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4720,8 +4549,7 @@
       "in_validator_set": false,
       "rank": 177,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4746,8 +4574,7 @@
       "in_validator_set": false,
       "rank": 178,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4772,8 +4599,7 @@
       "in_validator_set": false,
       "rank": 179,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4798,8 +4624,7 @@
       "in_validator_set": false,
       "rank": 180,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4824,8 +4649,7 @@
       "in_validator_set": false,
       "rank": 181,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4850,8 +4674,7 @@
       "in_validator_set": false,
       "rank": 182,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4876,8 +4699,7 @@
       "in_validator_set": false,
       "rank": 183,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4902,8 +4724,7 @@
       "in_validator_set": false,
       "rank": 184,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4928,8 +4749,7 @@
       "in_validator_set": false,
       "rank": 185,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4954,8 +4774,7 @@
       "in_validator_set": false,
       "rank": 186,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -4980,8 +4799,7 @@
       "in_validator_set": false,
       "rank": 187,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5006,8 +4824,7 @@
       "in_validator_set": false,
       "rank": 188,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5032,8 +4849,7 @@
       "in_validator_set": false,
       "rank": 189,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5058,8 +4874,7 @@
       "in_validator_set": false,
       "rank": 190,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5084,8 +4899,7 @@
       "in_validator_set": false,
       "rank": 191,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5110,8 +4924,7 @@
       "in_validator_set": false,
       "rank": 192,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5136,8 +4949,7 @@
       "in_validator_set": false,
       "rank": 193,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5162,8 +4974,7 @@
       "in_validator_set": false,
       "rank": 194,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5188,8 +4999,7 @@
       "in_validator_set": false,
       "rank": 195,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5214,8 +5024,7 @@
       "in_validator_set": false,
       "rank": 196,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5240,8 +5049,7 @@
       "in_validator_set": false,
       "rank": 197,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5266,8 +5074,7 @@
       "in_validator_set": false,
       "rank": 198,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5292,8 +5099,7 @@
       "in_validator_set": false,
       "rank": 199,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     },
     {
       "active": false,
@@ -5318,8 +5124,7 @@
       "in_validator_set": false,
       "rank": 200,
       "start_date": "2023-11-29T10:02:19Z",
-      "voting_power": 0,
-      "voting_power_total": 261234553964856260
+      "voting_power": 0
     }
   ]
 }


### PR DESCRIPTION
Moves `voting_power_total` to a sibling struct (ValidatorsStats) in ValidatorList. Also adds the total number of delegators and the total staked amount in the network to the new ValidatorsStats.

The total number of delegators/staked amount is required for the dashboard view in the mocks.