### PR TITLE
Andrew7234/default fee symbol

### DIFF
--- a/.changelog/739.bugfix.md
+++ b/.changelog/739.bugfix.md
@@ -1,0 +1,4 @@
+post 0.3.2 fixes
+
+api: filters out old rofl txs that were not parsed properly during a 2 week span in early july
+db: retroactively updates the runtime tx fee denom to default to ''.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,6 @@ The format is inspired by [Keep a Changelog].
 - Vendor oasis-core v24.0
   ([#716](https://github.com/oasisprotocol/nexus/issues/716))
 
-
 ## 0.3.1 (2024-05-27)
 
 ### Features

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -485,7 +485,8 @@ const (
 			($3::text IS NULL OR txs.tx_hash = $3::text OR txs.tx_eth_hash = $3::text) AND
 			($4::text IS NULL OR rel.account_address = $4::text) AND
 			($5::timestamptz IS NULL OR txs.timestamp >= $5::timestamptz) AND
-			($6::timestamptz IS NULL OR txs.timestamp < $6::timestamptz)
+			($6::timestamptz IS NULL OR txs.timestamp < $6::timestamptz) AND
+			(signer0.signer_address IS NOT NULL) -- HACK: excludes malformed transactions that do not have the required fields
 		ORDER BY txs.round DESC, txs.tx_index DESC
 		LIMIT $7::bigint
 		OFFSET $8::bigint

--- a/storage/migrations/25_runtime_tx_denoms.up.sql
+++ b/storage/migrations/25_runtime_tx_denoms.up.sql
@@ -4,6 +4,6 @@ ALTER TABLE chain.runtime_transactions
     ADD COLUMN amount_symbol TEXT;
 
 ALTER TABLE chain.runtime_transactions
-    ADD COLUMN fee_symbol TEXT;
+    ADD COLUMN fee_symbol TEXT NOT NULL DEFAULT ''; -- Will be populated after reindex
 
 COMMIT;

--- a/storage/migrations/30_default_symbol.up.sql
+++ b/storage/migrations/30_default_symbol.up.sql
@@ -1,9 +1,0 @@
-BEGIN;
-
-UPDATE chain.runtime_transactions SET fee_symbol = '' WHERE fee_symbol IS NULL; -- Will be populated on reindex.
-
-ALTER TABLE chain.runtime_transactions ALTER COLUMN fee_symbol SET NOT NULL;
-
-ALTER TABLE chain.runtime_transactions ALTER COLUMN fee_symbol SET DEFAULT '';
-
-COMMIT;

--- a/storage/migrations/30_default_symbol.up.sql
+++ b/storage/migrations/30_default_symbol.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE chain.runtime_transactions SET fee_symbol = '' WHERE fee_symbol IS NULL; -- Will be populated on reindex.
+
+ALTER TABLE chain.runtime_transactions ALTER COLUMN fee_symbol SET NOT NULL;
+
+ALTER TABLE chain.runtime_transactions ALTER COLUMN fee_symbol SET DEFAULT '';
+
+COMMIT;


### PR DESCRIPTION
After deploying release v0.3.2, queries to the runtime `/transactions` endpoint were failing due to a required field that was missing a default. This PR adds that default by retroactively modifying the original migration; it has been already applied manually in production mainnet, production testnet, and staging testnet. Staging mainnet will not be upgraded until this fix is merged; at which point it will be directly upgraded using the updated migration. 

Also includes a temporary fix to filter out old rofl transactions that were unable to be parsed by old versions of Nexus. These txs previously would cause the entire query to fail. This kludge will be removed after the full reindex.