### PR TITLE
storage: nil out transaction .Error on unknown result

### DIFF
--- a/.changelog/704.bugfix.md
+++ b/.changelog/704.bugfix.md
@@ -1,0 +1,1 @@
+storage: nil out transaction .Error on unknown result

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1531,7 +1531,11 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 		); err != nil {
 			return nil, wrapError(err)
 		}
-		if t.Success != nil && *t.Success {
+		// If success field is unset (i.e. encrypted "Unknown" result) or
+		// successful, some database versions have non-null error module/code
+		// from when the analyzer would insert ""/0 instead. There's no error
+		// information, so empty this stuff out.
+		if t.Success == nil || *t.Success {
 			t.Error = nil
 		}
 		if encryptionEnvelopeFormat != nil { // a rudimentary check to determine if the tx was encrypted


### PR DESCRIPTION
Unknown -> .Success = nil -> .Error = nil
Ok -> .Success = common.Ptr(true) -> .Error = nil
Failed -> .Success = common.Ptr(false) -> .Error not nil

is my understanding for today

fixes #704, unexpeced non-nil .Error