### PR TITLE
runtime: store NULL error module/code when no error

### DIFF
--- a/.changelog/748.feature.md
+++ b/.changelog/748.feature.md
@@ -1,0 +1,1 @@
+runtime: store NULL error module/code when no error

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -298,15 +298,15 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			evmEncryptedResultNonce = &transactionData.EVMEncrypted.ResultNonce
 			evmEncryptedResultData = &transactionData.EVMEncrypted.ResultData
 		}
-		var error_module string
-		var error_code uint32
-		var error_message *string
-		var error_message_raw *string
+		var errorModule *string
+		var errorCode *uint32
+		var errorMessage *string
+		var errorMessageRaw *string
 		if transactionData.Error != nil {
-			error_module = transactionData.Error.Module
-			error_code = transactionData.Error.Code
-			error_message = transactionData.Error.Message
-			error_message_raw = transactionData.Error.RawMessage
+			errorModule = &transactionData.Error.Module
+			errorCode = &transactionData.Error.Code
+			errorMessage = transactionData.Error.Message
+			errorMessageRaw = transactionData.Error.RawMessage
 		}
 		batch.Queue(
 			queries.RuntimeTransactionInsert,
@@ -335,10 +335,10 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			evmEncryptedResultNonce,
 			evmEncryptedResultData,
 			transactionData.Success,
-			error_module,
-			error_code,
-			error_message_raw,
-			error_message,
+			errorModule,
+			errorCode,
+			errorMessageRaw,
+			errorMessage,
 		)
 
 		if transactionData.ContractCandidate != nil {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1488,6 +1488,7 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 		var toPreimageContextIdentifier *string
 		var toPreimageContextVersion *int
 		var toPreimageData []byte
+		var errorCode *uint32
 		if err := res.rows.Scan(
 			&t.Round,
 			&t.Index,
@@ -1525,7 +1526,7 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 			&t.EvmFnName,
 			&t.EvmFnParams,
 			&t.Error.Module,
-			&t.Error.Code,
+			&errorCode,
 			&t.Error.Message,
 			&t.Error.RevertParams,
 		); err != nil {
@@ -1537,6 +1538,8 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 		// information, so empty this stuff out.
 		if t.Success == nil || *t.Success {
 			t.Error = nil
+		} else if errorCode != nil {
+			t.Error.Code = *errorCode
 		}
 		if encryptionEnvelopeFormat != nil { // a rudimentary check to determine if the tx was encrypted
 			encryptionEnvelope.Format = *encryptionEnvelopeFormat


### PR DESCRIPTION
in fact the database allows NULL in these columns already, but a part of the analyzer fills in ""/0 

- allow inserting NULL
- no corrections to existing records
- rename variables to follow variable naming style
- no change to api.....................