### PR TITLE
track staking events history; add staking rewards to validator history

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -272,6 +272,10 @@ var (
     INSERT INTO chain.events (type, body, tx_block, tx_hash, tx_index, related_accounts, roothash_runtime_id, roothash_runtime, roothash_runtime_round)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 
+	ConsensusEscrowEventInsert = `
+    INSERT INTO history.escrow_events (tx_block, epoch, type, delegatee, delegator, shares, amount, debonding_amount)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)`
+
 	ConsensusRoothashMessageScheduleUpsert = `
     INSERT INTO chain.roothash_messages
       (runtime, round, message_index, type, body, related_accounts)
@@ -523,6 +527,13 @@ var (
 	ValidatorBalanceInsert = `
     INSERT INTO history.validators (id, epoch, escrow_balance_active, escrow_balance_debonding, escrow_total_shares_active, escrow_total_shares_debonding, num_delegators)
       VALUES ($1, $2, $3, $4, $5, $6, $7)`
+
+	ValidatorStakingRewardUpdate = `
+    UPDATE history.validators
+    SET staking_rewards = $3
+    WHERE 
+      id = $1 AND
+      epoch = $2`
 
 	EpochValidatorsUpdate = `
     UPDATE chain.epochs

--- a/storage/migrations/33_staking_rewards.up.sql
+++ b/storage/migrations/33_staking_rewards.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE history.validators
+    ADD COLUMN staking_rewards UINT_NUMERIC;
+
+CREATE TABLE history.escrow_events
+(
+  tx_block UINT63 NOT NULL,
+  epoch UINT63 NOT NULL,
+  type TEXT NOT NULL,
+  delegatee oasis_addr NOT NULL REFERENCES chain.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  delegator oasis_addr NOT NULL REFERENCES chain.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  shares    UINT_NUMERIC,
+  amount UINT_NUMERIC,
+  debonding_amount UINT_NUMERIC -- for slashing events
+);
+
+COMMIT;


### PR DESCRIPTION
This PR includes a chunk of the changes necessary for staking rewards that would be nice to include in the upcoming reindex release. There are two changes:
- runtime analyzer now tracks staking event history in fast-sync mode
- validator history analyzer now tracks per-validator staking rewards.

