### PR TITLE
config/server: clean-up chainName and reuse source config

### DIFF
--- a/.changelog/766.feature.md
+++ b/.changelog/766.feature.md
@@ -1,0 +1,18 @@
+config/server: clean-up chainName and reuse source config
+
+Required config change:
+
+Old:
+
+```yaml
+server:
+  chain_name: mainnet
+```
+
+New:
+
+```yaml
+server:
+  source:
+    chain_name: mainnet
+```

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -120,22 +120,22 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	referenceSwaps := map[common.Runtime]config.ReferenceSwap{}
+
+	// Runtime clients.
 	runtimeClients := make(map[common.Runtime]nodeapi.RuntimeApiLite)
 	var networkConfig *sdkConfig.Network
-	if cfg.Source != nil {
-		referenceSwaps = cfg.Source.ReferenceSwaps()
-		networkConfig = cfg.Source.SDKNetwork()
-		apiRuntimes := []common.Runtime{common.RuntimeEmerald, common.RuntimeSapphire, common.RuntimePontusxTest, common.RuntimePontusxDev}
-		for _, runtime := range apiRuntimes {
-			client, err2 := source.NewRuntimeClient(ctx, cfg.Source, runtime)
-			if err2 != nil {
-				logger.Warn("unable to instantiate runtime client for api server", "runtime", runtime, "err", err2)
-			}
-			runtimeClients[runtime] = client
+	referenceSwaps := cfg.Source.ReferenceSwaps()
+	networkConfig = cfg.Source.SDKNetwork()
+	apiRuntimes := []common.Runtime{common.RuntimeEmerald, common.RuntimeSapphire, common.RuntimePontusxTest, common.RuntimePontusxDev}
+	for _, runtime := range apiRuntimes {
+		client, err2 := source.NewRuntimeClient(ctx, cfg.Source, runtime)
+		if err2 != nil {
+			logger.Warn("unable to instantiate runtime client for api server", "runtime", runtime, "err", err2)
 		}
+		runtimeClients[runtime] = client
 	}
-	client, err := storage.NewStorageClient(cfg.ChainName, backing, referenceSwaps, runtimeClients, networkConfig, logger)
+
+	client, err := storage.NewStorageClient(*cfg.Source, backing, referenceSwaps, runtimeClients, networkConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -23,7 +23,8 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_name: mainnet
+  source:
+    chain_name: mainnet
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://rwuser:password@nexus-postgres:5432/indexer?sslmode=disable

--- a/config/local-dev.yml
+++ b/config/local-dev.yml
@@ -26,7 +26,6 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -22,6 +22,9 @@ type HistoryRuntimeApiLite struct {
 }
 
 func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkPT *sdkConfig.ParaTime, nodes map[string]*config.ArchiveConfig, fastStartup bool, runtime common.Runtime) (*HistoryRuntimeApiLite, error) {
+	if history == nil {
+		return nil, fmt.Errorf("history config not provided")
+	}
 	apis := map[string]nodeapi.RuntimeApiLite{}
 	for _, record := range history.Records {
 		if archiveConfig, ok := nodes[record.ArchiveName]; ok {

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -22,7 +22,10 @@ analysis:
     migrations: file:///storage/migrations
 
 server:
-  chain_name: localnet  # unused
+  source:
+    custom_chain:
+      history: {}
+      sdk_network: {}
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://indexer:password@nexus-postgres:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/damask/e2e_config_1.yml
+++ b/tests/e2e_regression/damask/e2e_config_1.yml
@@ -33,7 +33,8 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_name: mainnet
+  source:
+    chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://api:password@localhost:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/damask/expected/emerald_contract_account.body
+++ b/tests/e2e_regression/damask/expected/emerald_contract_account.body
@@ -3,8 +3,8 @@
   "balances": [
     {
       "balance": "0",
-      "token_decimals": 0,
-      "token_symbol": ""
+      "token_decimals": 18,
+      "token_symbol": "ROSE"
     }
   ],
   "evm_balances": [],

--- a/tests/e2e_regression/eden/e2e_config_1.yml
+++ b/tests/e2e_regression/eden/e2e_config_1.yml
@@ -37,7 +37,8 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_name: mainnet
+  source:
+    chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://api:password@localhost:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/edenfast/e2e_config_1.yml
+++ b/tests/e2e_regression/edenfast/e2e_config_1.yml
@@ -46,7 +46,8 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_name: mainnet
+  source:
+    chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://api:password@localhost:5432/indexer?sslmode=disable


### PR DESCRIPTION
The server config had a (legacy?) `chain_name` field, which was only used in one place - to determine the runtime ID from the runtime name in the `API/runtime/status` endpoint. This was a bit of a kludge and didn't support custom networks.

The server config already contains the `SourceConfig` section, which supports both Default and Custom networks, so let's use that to determine the runtime ID.

Note needed change to configs is the following:

Old:
```yaml
server:
  chain_name: mainnet
```

New:
```yaml
server:
  source:
    chain_name: mainnet
```

If the deployment already had the `server.source` configured, then just removing the existing `server.chain_name` is ok.