### PR TITLE
add 2021 testnet to api constructors

### DIFF
--- a/.changelog/797.bugfix.md
+++ b/.changelog/797.bugfix.md
@@ -1,0 +1,1 @@
+api: add 2021 testnet constructor

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -49,6 +49,7 @@ var APIConstructors = map[string]APIConstructor{
 	"cobalt": cobaltAPIConstructor,
 	"eden":   edenAPIConstructor,
 	// testnet
+	"2021-04-13": cobaltAPIConstructor,
 	"2022-03-03": damaskAPIConstructor,
 	"2023-10-12": edenAPIConstructor,
 }


### PR DESCRIPTION
Per report from @uscinski 

We've been deploying archive nodes on OPF side. So far we have Testnet gRPC 2022-03-03 and 2021-04-13. We tried to run Nexus analyzer that includes these both archive nodes. But Nexus crashes with the following error:

```
{"caller":"analyzer.go:130","error":"error creating consensus client: instantiating history consensus API lite: historical API for archive 2021-04-13 not implemented","level":"error","module":"nexus","msg":"service failed to start","ts":"2024-11-07T10:48:25.841983708Z"}
```

To me it looks like Nexus lacks implementation of the historical API and therefore cannot work with the said node. Is this correct or do we need to configure it differently (both Nexus and gRPC node)? We also tried to include only the 2022-03-03  archive node and so far looks good.