### PR TITLE
Add ERC721 and ERC20 to hardcoded named accounts

### DIFF
--- a/.changelog/798.trivial.md
+++ b/.changelog/798.trivial.md
@@ -1,0 +1,1 @@
+Add ERC-721 and ERC-20 to hardcoded named accounts

--- a/account-names/readme.txt
+++ b/account-names/readme.txt
@@ -1,5 +1,1 @@
-This directory contains lists of data for known addresses, to be used by Explorer (and other other frontends) to display names and such.
-
-Source is https://docs.google.com/spreadsheets/d/1F9CuAqjo4BT8W8JMvogZk-20SO5TgFd8SojgZr2zFCE/edit?usp=sharing
-
-(Downloaded and converted on the 30th of April, 2024.)
+DEPRECATED: Use named-accounts. Folder will be removed once new version of Explorer is released.

--- a/named-addresses/mainnet_consensus.json
+++ b/named-addresses/mainnet_consensus.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qrmufhkkyyf79s5za2r8yga9gnk4t446dcy3a5zm",
+        "Description": "This account contains tokens allocated for staking rewards."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5",
+        "Description": "This account collects transaction fees of each consensus block that are distributed among the validators."
+    },
+    {
+        "Name": "Governance Escrow",
+        "Address": "oasis1qp65laz8zsa9a305wxeslpnkh9x4dv2h2qhjz0ec",
+        "Description": "Contains deposited tokens required for confirming governance transactions."
+    },
+    {
+        "Name": "Burn Address",
+        "Address": "oasis1qzq8u7xs328puu2jy524w3fygzs63rv3u5967970",
+        "Description": "Reserved address for all irreversibly burnt tokens."
+    },
+    {
+        "Name": "Sapphire",
+        "Address": "oasis1qrd3mnzhhgst26hsp96uf45yhq6zlax0cuzdgcfc",
+        "Description": "Address of the Sapphire account on consensus."
+    },
+    {
+        "Name": "Emerald",
+        "Address": "oasis1qzvlg0grjxwgjj58tx2xvmv26era6t2csqn22pte",
+        "Description": "Address of the Emerald account on consensus."
+    },
+    {
+        "Name": "Cipher",
+        "Address": "oasis1qrnu9yhwzap7rqh6tdcdcpz0zf86hwhycchkhvt8",
+        "Description": "Address of the Cipher account on consensus."
+    }
+]

--- a/named-addresses/mainnet_emerald.json
+++ b/named-addresses/mainnet_emerald.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    }
+]

--- a/named-addresses/mainnet_sapphire.json
+++ b/named-addresses/mainnet_sapphire.json
@@ -33,5 +33,65 @@
         "Name": "Subcall Precompile",
         "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
         "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    },
+    {
+        "Name": "Rosy",
+        "Address": "oasis1qrysq46guu3lug3mge6vgg7mrtthfuqnucq7rnp0",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "illumineX Token",
+        "Address": "oasis1qzhxwvks20f6fng566rzcs98t65qjnp4pgd5mnvl",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "RA1L",
+        "Address": "oasis1qzvys6j3vpe8sq7az60z3p24xtcxdxyaccjndpdt",
+        "Description": "ERC721"
+    },
+    {
+        "Name": "NFTrout",
+        "Address": "oasis1qpwe6h0hw6s0x4skujhznld065300p83wgxnvu0n",
+        "Description": "ERC721"
+    },
+    {
+        "Name": "Ocean Token",
+        "Address": "oasis1qr43dvghx4a75vndjcsg2r9ct2xqftwrgcnt5tge",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "Wrapped ROSE",
+        "Address": "oasis1qpdgv5nv2dhxp4q897cgag6kgnm9qs0dccwnckuu",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "wstROSE",
+        "Address": "oasis1qr2ta7ussnps40fnmp58p04cwn7yvr56eqepa7xh",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "stROSE",
+        "Address": "oasis1qplsw278vcrs6kcam9ffu43dp5wqvdelqvw9gf68",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "The 4th Pillar Token",
+        "Address": "oasis1qrtw0g3ufn29tk3t9s8rxx6mvsep33qd9szzgmct",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "Bridged USDC",
+        "Address": "oasis1qr7y034j2srpxq90w20al600a52es8g3xylhvrl6",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "RAKESH VILLAGE",
+        "Address": "oasis1qqx805qqxneftz67ywqjs47u23cd8lcjusl3wcrs",
+        "Description": "ERC20"
+    },
+    {
+        "Name": "NEBY",
+        "Address": "oasis1qr5mh6qpl9ql3d202jgk5845eyaggjhjevv9x90k",
+        "Description": "ERC20"
     }
 ]

--- a/named-addresses/mainnet_sapphire.json
+++ b/named-addresses/mainnet_sapphire.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    }
+]

--- a/named-addresses/readme.txt
+++ b/named-addresses/readme.txt
@@ -1,0 +1,5 @@
+This directory contains lists of data for known addresses, to be used by Explorer (and other other frontends) to display names and such.
+
+Contains:
+- Reserved Addresses (https://docs.google.com/spreadsheets/d/1F9CuAqjo4BT8W8JMvogZk-20SO5TgFd8SojgZr2zFCE/edit?usp=sharing)
+- Known and reputable ERC-20 and ERC-721 tokens

--- a/named-addresses/testnet_consensus.json
+++ b/named-addresses/testnet_consensus.json
@@ -1,0 +1,52 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qrmufhkkyyf79s5za2r8yga9gnk4t446dcy3a5zm",
+        "Description": "This account contains tokens allocated for staking rewards."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5",
+        "Description": "This account collects transaction fees of each consensus block that are distributed among the validators."
+    },
+    {
+        "Name": "Governance Escrow",
+        "Address": "oasis1qp65laz8zsa9a305wxeslpnkh9x4dv2h2qhjz0ec",
+        "Description": "Contains deposited tokens required for confirming governance transactions."
+    },
+    {
+        "Name": "Burn Address",
+        "Address": "oasis1qzq8u7xs328puu2jy524w3fygzs63rv3u5967970",
+        "Description": "Reserved address for all irreversibly burnt tokens."
+    },
+    {
+        "Name": "Faucet Address",
+        "Address": "oasis1qzna6nq9kuktjmxx2s84z38eysqyts84jc9lgdg2",
+        "Description": "This account contains TEST tokens distributed by the faucet."
+    },
+    {
+        "Name": "Sapphire",
+        "Address": "oasis1qqczuf3x6glkgjuf0xgtcpjjw95r3crf7y2323xd",
+        "Description": "Address of the Sapphire account on consensus."
+    },
+    {
+        "Name": "Emerald",
+        "Address": "oasis1qr629x0tg9gm5fyhedgs9lw5eh3d8ycdnsxf0run",
+        "Description": "Address of the Emerald account on consensus."
+    },
+    {
+        "Name": "Cipher",
+        "Address": "oasis1qqdn25n5a2jtet2s5amc7gmchsqqgs4j0qcg5k0t",
+        "Description": "Address of the Cipher account on consensus."
+    },
+    {
+        "Name": "Pontus-X Testnet",
+        "Address": "oasis1qrg6c89655pmdxeel08qkngs02jnrfll5v9c508v",
+        "Description": "Address of the Pontus-X Testnet account on consensus."
+    },
+    {
+        "Name": "Pontus-X Devnet",
+        "Address": "oasis1qr02702pr8ecjuff2z3es254pw9xl6z2yg9qcc6c",
+        "Description": "Address of the Pontus-X Devnet account on consensus."
+    }
+]

--- a/named-addresses/testnet_emerald.json
+++ b/named-addresses/testnet_emerald.json
@@ -1,0 +1,42 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    },
+    {
+        "Name": "Faucet Address",
+        "Address": "oasis1qzna6nq9kuktjmxx2s84z38eysqyts84jc9lgdg2",
+        "Description": "This account contains TEST tokens distributed by the faucet."
+    }
+]

--- a/named-addresses/testnet_sapphire.json
+++ b/named-addresses/testnet_sapphire.json
@@ -1,0 +1,42 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    },
+    {
+        "Name": "Faucet Address",
+        "Address": "oasis1qzna6nq9kuktjmxx2s84z38eysqyts84jc9lgdg2",
+        "Description": "This account contains TEST tokens distributed by the faucet."
+    }
+]


### PR DESCRIPTION
In Explorer we want to show token names instead of contract addresses in multiple places

- moved hardcoded addresses to `named-accounts` 
- split paratime files into runtime specific