### PR TITLE
storage: add index for efficient fetching of events emitted by a specific contract

### DIFF
--- a/.changelog/808.feature.md
+++ b/.changelog/808.feature.md
@@ -1,0 +1,1 @@
+storage: add index for fetching events emitted by a specific contract

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -181,6 +181,11 @@ CREATE INDEX ix_runtime_events_nft_transfers ON chain.runtime_events (runtime, (
         type = 'evm.log' AND
         evm_log_signature = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' AND
         jsonb_array_length(body -> 'topics') = 4;
+-- Added in 07_runtime_events_evm_contracts_events.up.sql
+-- Index used for fetching events emitted by a specific contract.
+-- CREATE INDEX ix_runtime_events_evm_contract_events ON chain.runtime_events (runtime, (body ->> 'address'), evm_log_signature, round)
+--     WHERE
+--         type = 'evm.log';
 
 -- Roothash messages are small structures that a runtime can send to
 -- communicate with the consensus layer. They are agreed upon for each runtime

--- a/storage/migrations/07_runtime_events_evm_contracts_events.up.sql
+++ b/storage/migrations/07_runtime_events_evm_contracts_events.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- Index used for fetching all events of a specific type, of a specific contract (sorted by round).
+-- For example listing all ERC20 Transfers of a specific token.
+CREATE INDEX IF NOT EXISTS ix_runtime_events_evm_specific_contract_events ON chain.runtime_events (runtime, (body ->> 'address'), evm_log_signature, round)
+    WHERE
+        type = 'evm.log';
+
+COMMIT;

--- a/tests/e2e_regression/eden/expected/emerald_transfer_events_of_token.body
+++ b/tests/e2e_regression/eden/expected/emerald_transfer_events_of_token.body
@@ -1,0 +1,4006 @@
+{
+  "events": [
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABF6MuPaAfAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "20150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABF6MuPaAfAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "20150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABF6MuPaAfAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "20150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHLLmnx5bzAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "132350000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHLLmnx5bzAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "132350000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHLLmnx5bzAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "132350000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHpXZDr2DZAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "141050000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyOROWdSClAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "926450000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGyqnggrXeHEQ=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "ac4f3c492c59135ecb40f6aa7a020d822af048b78c9b39bfdcbe5aa2b8ca4af4",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "4847650397430629669956"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060278,
+      "timestamp": "2023-12-12T10:00:46Z",
+      "tx_hash": "58664d4aac5cd63f898098c4deb79e62da22f88d9120d5834410e3958b0615d6",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9JiUHmZCgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "8cbbcc844b54ce4ae0d2b81c1dd7c84bc2fcde4a99afcf2148a6c504f1328d2b",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "17625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060174,
+      "timestamp": "2023-12-12T09:50:30Z",
+      "tx_hash": "e4ca140d8dda64cc85e97f018fe28ac7e83b64a85fcfd90ff554f8a3213bb757",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9JiUHmZCgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "8cbbcc844b54ce4ae0d2b81c1dd7c84bc2fcde4a99afcf2148a6c504f1328d2b",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "17625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060174,
+      "timestamp": "2023-12-12T09:50:30Z",
+      "tx_hash": "e4ca140d8dda64cc85e97f018fe28ac7e83b64a85fcfd90ff554f8a3213bb757",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9JiUHmZCgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "8cbbcc844b54ce4ae0d2b81c1dd7c84bc2fcde4a99afcf2148a6c504f1328d2b",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "17625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060174,
+      "timestamp": "2023-12-12T09:50:30Z",
+      "tx_hash": "e4ca140d8dda64cc85e97f018fe28ac7e83b64a85fcfd90ff554f8a3213bb757",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGsCwM1MvRgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "8cbbcc844b54ce4ae0d2b81c1dd7c84bc2fcde4a99afcf2148a6c504f1328d2b",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "123375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060174,
+      "timestamp": "2023-12-12T09:50:30Z",
+      "tx_hash": "e4ca140d8dda64cc85e97f018fe28ac7e83b64a85fcfd90ff554f8a3213bb757",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADeos/7GGLhxA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9Uk+qUDRLOhZT4G6srt9TtgdSeg=",
+          "AAAAAAAAAAAAAAAAP/LEM4LwJ/smug0fYG29wB+zXBM="
+        ]
+      },
+      "eth_tx_hash": "484cda34223200b37f9c764e620c1f3075c754e96b9e451d4f3066cb2b98c86d",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf5493ea940d12ce8594f81bab2bb7d4ed81d49e8"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x3ff2c43382f027fb26ba0d1f606dbdc01fb35c13"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "64170454000000010000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060127,
+      "timestamp": "2023-12-12T09:45:54Z",
+      "tx_hash": "8656e5ef17fe3b2b10136217b2cb200fbc8df309bb96180b8ce628afcf0102c5",
+      "tx_index": 2,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABTREg17FgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "278e5ff0624a0ed313c2a0ce0ea0811ddf98700e3ee1258326b96081bf3098f0",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "89b78e79bd47f24fb448ece4cf4844be7b9d0b145d66ebcc04460bd2e64ce03e",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABTREg17FgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "278e5ff0624a0ed313c2a0ce0ea0811ddf98700e3ee1258326b96081bf3098f0",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "89b78e79bd47f24fb448ece4cf4844be7b9d0b145d66ebcc04460bd2e64ce03e",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABTREg17FgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "278e5ff0624a0ed313c2a0ce0ea0811ddf98700e3ee1258326b96081bf3098f0",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "89b78e79bd47f24fb448ece4cf4844be7b9d0b145d66ebcc04460bd2e64ce03e",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJG3fl5dmgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "278e5ff0624a0ed313c2a0ce0ea0811ddf98700e3ee1258326b96081bf3098f0",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "89b78e79bd47f24fb448ece4cf4844be7b9d0b145d66ebcc04460bd2e64ce03e",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUD1GHqNMvSl4o=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw="
+        ]
+      },
+      "eth_tx_hash": "2927c04df0f8f5b55e565c2f128bc081d5d6a999c6b7fbdb0c582545a924c9e8",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "23682476417090615154570"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "f08fdfeac6743e16164b3d10118f03ec3caacbd741bec5bbc45b22680d1a44a1",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUD1GHqNMvSl4o=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "2927c04df0f8f5b55e565c2f128bc081d5d6a999c6b7fbdb0c582545a924c9e8",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "23682476417090615154570"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060033,
+      "timestamp": "2023-12-12T09:36:42Z",
+      "tx_hash": "f08fdfeac6743e16164b3d10118f03ec3caacbd741bec5bbc45b22680d1a44a1",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACvNQKcIU6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "2e3c801eb444780f57b8e98391aae03a64dff4ef483906e996a8e00aff65b8be",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "50500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "f53d78e36f43d0ad78309623918528dbeaeaaaeeacccf55616f5c371f3925488",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACvNQKcIU6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "2e3c801eb444780f57b8e98391aae03a64dff4ef483906e996a8e00aff65b8be",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "50500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "f53d78e36f43d0ad78309623918528dbeaeaaaeeacccf55616f5c371f3925488",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACvNQKcIU6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "2e3c801eb444780f57b8e98391aae03a64dff4ef483906e996a8e00aff65b8be",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "50500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "f53d78e36f43d0ad78309623918528dbeaeaaaeeacccf55616f5c371f3925488",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATKcxJE6SWAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "2e3c801eb444780f57b8e98391aae03a64dff4ef483906e996a8e00aff65b8be",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "353500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "f53d78e36f43d0ad78309623918528dbeaeaaaeeacccf55616f5c371f3925488",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABHE139HhBId4=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw=",
+          "AAAAAAAAAAAAAAAAeGNy60IOmJBXITpHKSFmOPKDY4w="
+        ]
+      },
+      "eth_tx_hash": "c7c84f1cc0f44d08a349c03d0fe12c4ac5a18d4d61fdbb284dd8d55b71462635",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x786372eb420e989057213a4729216638f283638c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "20486162171851514334"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "7203fb63e41d1396931ee7f9769603ea34e68e6352c03a9d29fe089186bda0df",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAPtsKEIAYsGU=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "c7c84f1cc0f44d08a349c03d0fe12c4ac5a18d4d61fdbb284dd8d55b71462635",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "16532811914959994269797"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "7203fb63e41d1396931ee7f9769603ea34e68e6352c03a9d29fe089186bda0df",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOBWyiCBPhZ0kM=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw="
+        ]
+      },
+      "eth_tx_hash": "c7c84f1cc0f44d08a349c03d0fe12c4ac5a18d4d61fdbb284dd8d55b71462635",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "16553298077131845784131"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8060030,
+      "timestamp": "2023-12-12T09:36:24Z",
+      "tx_hash": "7203fb63e41d1396931ee7f9769603ea34e68e6352c03a9d29fe089186bda0df",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAACJiq8SR/pQB20=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAYyF6wWAPszejt6cFM9xxhw5raMw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "4d54428654774cda5e74231285fef593fa56168e4e6ce9fb932d696c4a34eea3",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x63217ac1600fb337a3b7a70533dc71870e6b68cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2537197164296718518125"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059896,
+      "timestamp": "2023-12-12T09:23:04Z",
+      "tx_hash": "620ee00f819c26e6ffd2de5289a236406b7f07dfdbeb4258110a25d04a9ed2c5",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADb4E6uZBhgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "fe67c82355374a09a632012751f48d3a723a6798eb4fc40e3ca0c0930e6aff9f",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "63375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059895,
+      "timestamp": "2023-12-12T09:22:58Z",
+      "tx_hash": "70ea78963713ecab9ac07e1ad3c71ed6128e0deccf23e243664aa858389c83ab",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADb4E6uZBhgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "fe67c82355374a09a632012751f48d3a723a6798eb4fc40e3ca0c0930e6aff9f",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "63375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059895,
+      "timestamp": "2023-12-12T09:22:58Z",
+      "tx_hash": "70ea78963713ecab9ac07e1ad3c71ed6128e0deccf23e243664aa858389c83ab",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADb4E6uZBhgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "fe67c82355374a09a632012751f48d3a723a6798eb4fc40e3ca0c0930e6aff9f",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "63375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059895,
+      "timestamp": "2023-12-12T09:22:58Z",
+      "tx_hash": "70ea78963713ecab9ac07e1ad3c71ed6128e0deccf23e243664aa858389c83ab",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYDIibEvKqgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "fe67c82355374a09a632012751f48d3a723a6798eb4fc40e3ca0c0930e6aff9f",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "443625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059895,
+      "timestamp": "2023-12-12T09:22:58Z",
+      "tx_hash": "70ea78963713ecab9ac07e1ad3c71ed6128e0deccf23e243664aa858389c83ab",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARD1b+pd9uAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "516630b2a78c163e12af5a403dbb850b4decd6a2ec6c0b2b3d7de789dfad5a97",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "314700000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059890,
+      "timestamp": "2023-12-12T09:22:28Z",
+      "tx_hash": "cf69cc6b337ca802ed5f2aa40ddef76dd205de74a9873bdf93b049e880c0eea4",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARD1b+pd9uAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "516630b2a78c163e12af5a403dbb850b4decd6a2ec6c0b2b3d7de789dfad5a97",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "314700000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059890,
+      "timestamp": "2023-12-12T09:22:28Z",
+      "tx_hash": "cf69cc6b337ca802ed5f2aa40ddef76dd205de74a9873bdf93b049e880c0eea4",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARD1b+pd9uAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "516630b2a78c163e12af5a403dbb850b4decd6a2ec6c0b2b3d7de789dfad5a97",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "314700000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059890,
+      "timestamp": "2023-12-12T09:22:28Z",
+      "tx_hash": "cf69cc6b337ca802ed5f2aa40ddef76dd205de74a9873bdf93b049e880c0eea4",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB3a2D2iRwCAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "516630b2a78c163e12af5a403dbb850b4decd6a2ec6c0b2b3d7de789dfad5a97",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2202900000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059890,
+      "timestamp": "2023-12-12T09:22:28Z",
+      "tx_hash": "cf69cc6b337ca802ed5f2aa40ddef76dd205de74a9873bdf93b049e880c0eea4",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAE4YqO/4XZP7FgA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAtcuy87XTpyqIr2w3OVeaGNUjV1U=",
+          "AAAAAAAAAAAAAAAA9Uk+qUDRLOhZT4G6srt9TtgdSeg="
+        ]
+      },
+      "eth_tx_hash": "d12ba74226dc94955f812cd45f224a494eee41ade0ffb806ce23c1e0ffa920c1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xb5cbb2f3b5d3a72a88af6c3739579a18d5235755"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xf5493ea940d12ce8594f81bab2bb7d4ed81d49e8"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "368799480742999960000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059883,
+      "timestamp": "2023-12-12T09:21:47Z",
+      "tx_hash": "7f9c82d18976d3de2325fc2f3d4f6ade3a33aea353c298d5e2389120ffbe0be7",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACFOg0jE8AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "33a82febf23db1149f6be3d9681d190c00115ffdd1c68e7d8af5264073c23b57",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "600000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059875,
+      "timestamp": "2023-12-12T09:21:00Z",
+      "tx_hash": "305a9c38b31f51ea8523a5da2cd9866dde63fd0a480bf1ab9897ee5f87823c37",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACFOg0jE8AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "33a82febf23db1149f6be3d9681d190c00115ffdd1c68e7d8af5264073c23b57",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "600000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059875,
+      "timestamp": "2023-12-12T09:21:00Z",
+      "tx_hash": "305a9c38b31f51ea8523a5da2cd9866dde63fd0a480bf1ab9897ee5f87823c37",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACFOg0jE8AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "33a82febf23db1149f6be3d9681d190c00115ffdd1c68e7d8af5264073c23b57",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "600000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059875,
+      "timestamp": "2023-12-12T09:21:00Z",
+      "tx_hash": "305a9c38b31f51ea8523a5da2cd9866dde63fd0a480bf1ab9897ee5f87823c37",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOkllv1ikAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "33a82febf23db1149f6be3d9681d190c00115ffdd1c68e7d8af5264073c23b57",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "4200000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059875,
+      "timestamp": "2023-12-12T09:21:00Z",
+      "tx_hash": "305a9c38b31f51ea8523a5da2cd9866dde63fd0a480bf1ab9897ee5f87823c37",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAALP80W+a46ZCAs=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAf1YsphKFTrkeybo0//CASLDpWUU=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "33a82febf23db1149f6be3d9681d190c00115ffdd1c68e7d8af5264073c23b57",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x7f562ca612854eb91ec9ba34fff08048b0e95945"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "13280738615490940307467"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059875,
+      "timestamp": "2023-12-12T09:21:00Z",
+      "tx_hash": "305a9c38b31f51ea8523a5da2cd9866dde63fd0a480bf1ab9897ee5f87823c37",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABsqpYmqAKBN2w=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAYyF6wWAPszejt6cFM9xxhw5raMw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "ce7ea5144153e6fc15ea7a20e373e615b899f773d4775c745981f212c5ab8b95",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x63217ac1600fb337a3b7a70533dc71870e6b68cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2004540414696624306028"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059865,
+      "timestamp": "2023-12-12T09:20:01Z",
+      "tx_hash": "9e54c19a321d1a8817c90803a17001b3ae46e4fd08fc19117d42c42fc08ac261",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0NxXQv2hAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "89a583767beef44cb0b78accd2f97f89ac544b2e738fa328c9292b0faeffc45c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "15050000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "16eca579d3582337c05a999a847b8885ed9374404b939023ce9991e05764fe08",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHdZVm9sXAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "89a583767beef44cb0b78accd2f97f89ac544b2e738fa328c9292b0faeffc45c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "16eca579d3582337c05a999a847b8885ed9374404b939023ce9991e05764fe08",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHdZVm9sXAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "89a583767beef44cb0b78accd2f97f89ac544b2e738fa328c9292b0faeffc45c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "16eca579d3582337c05a999a847b8885ed9374404b939023ce9991e05764fe08",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHdZVm9sXAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "89a583767beef44cb0b78accd2f97f89ac544b2e738fa328c9292b0faeffc45c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2150000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "16eca579d3582337c05a999a847b8885ed9374404b939023ce9991e05764fe08",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAABkF4Lm94RaAqCM=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw=",
+          "AAAAAAAAAAAAAAAAtcuy87XTpyqIr2w3OVeaGNUjV1U="
+        ]
+      },
+      "eth_tx_hash": "89a583767beef44cb0b78accd2f97f89ac544b2e738fa328c9292b0faeffc45c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb5cbb2f3b5d3a72a88af6c3739579a18d5235755"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "118167588974819308251171"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "16eca579d3582337c05a999a847b8885ed9374404b939023ce9991e05764fe08",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk8qLzxaHB+m0k=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "bb9ea7d2c6761dfe217e7f7d51394d21b588e2f5d0dfb3d47d2ba219356906e5",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "43620261848774239755081"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059863,
+      "timestamp": "2023-12-12T09:19:49Z",
+      "tx_hash": "8c9a2847a0622dcf0d10341196e5d281e4618786ba9bcd79143d35c01edb7613",
+      "tx_index": 2,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5iQ0ix5kWAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAt1mAPucIdVnrYBpJOcLV2nZoOFo="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb759803ee7087559eb601a4939c2d5da7668385a"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1061340000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5iQ0ix5kWAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAt1mAPucIdVnrYBpJOcLV2nZoOFo=",
+          "AAAAAAAAAAAAAAAAjZzJ7hGq+GWRPe7JOe6y3Hg4q3s="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xb759803ee7087559eb601a4939c2d5da7668385a"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x8d9cc9ee11aaf865913deec939eeb2dc7838ab7b"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1061340000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIOCZyrsy6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "151620000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIOCZyrsy6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "151620000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIOCZyrsy6AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "151620000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAALP80W+a46ZCAs=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAjZzJ7hGq+GWRPe7JOe6y3Hg4q3s=",
+          "AAAAAAAAAAAAAAAAf1YsphKFTrkeybo0//CASLDpWUU="
+        ]
+      },
+      "eth_tx_hash": "4798cf33c6555a95b09b673ae1f297f9d312efe2e821da594dddd5ff158b3302",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x8d9cc9ee11aaf865913deec939eeb2dc7838ab7b"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7f562ca612854eb91ec9ba34fff08048b0e95945"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "13280738615490940307467"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059848,
+      "timestamp": "2023-12-12T09:18:22Z",
+      "tx_hash": "3e6a1126964a085b82d527fa50402cec2d7b7216d3233f323c4554c9a971da71",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgqHHMACAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "9b590b9208c16d08a936e414c484262d97a09a74ebedc6c9489f1fbfe56120bb",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1300000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "4c5267438401c82a6b3fe711c08a8d416d08bec2ec7fd4199b495d6f1a5a7f80",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgqHHMACAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "9b590b9208c16d08a936e414c484262d97a09a74ebedc6c9489f1fbfe56120bb",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1300000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "4c5267438401c82a6b3fe711c08a8d416d08bec2ec7fd4199b495d6f1a5a7f80",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgqHHMACAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "9b590b9208c16d08a936e414c484262d97a09a74ebedc6c9489f1fbfe56120bb",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1300000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "4c5267438401c82a6b3fe711c08a8d416d08bec2ec7fd4199b495d6f1a5a7f80",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfkmxyUAOAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "9b590b9208c16d08a936e414c484262d97a09a74ebedc6c9489f1fbfe56120bb",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "9100000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "4c5267438401c82a6b3fe711c08a8d416d08bec2ec7fd4199b495d6f1a5a7f80",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAABGiREVoG+CB79Q=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw=",
+          "AAAAAAAAAAAAAAAAtcuy87XTpyqIr2w3OVeaGNUjV1U="
+        ]
+      },
+      "eth_tx_hash": "9b590b9208c16d08a936e414c484262d97a09a74ebedc6c9489f1fbfe56120bb",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb5cbb2f3b5d3a72a88af6c3739579a18d5235755"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "83273522201361828147156"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "4c5267438401c82a6b3fe711c08a8d416d08bec2ec7fd4199b495d6f1a5a7f80",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaZu7aAd+wOP3Q=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw="
+        ]
+      },
+      "eth_tx_hash": "909836475a24f415614614dda7967c0b6d4d0b3297e33734d1a3957271f5519c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "31170076880278836363124"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "a6990cb127ab87f35d0e28b40b0ebf03ccf5e835765656d9e46140faeb874ae7",
+      "tx_index": 4,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaZu7aAd+wOP3Q=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "909836475a24f415614614dda7967c0b6d4d0b3297e33734d1a3957271f5519c",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "31170076880278836363124"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "a6990cb127ab87f35d0e28b40b0ebf03ccf5e835765656d9e46140faeb874ae7",
+      "tx_index": 4,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE8fb/CeRir4=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ=",
+          "AAAAAAAAAAAAAAAAeGNy60IOmJBXITpHKSFmOPKDY4w="
+        ]
+      },
+      "eth_tx_hash": "8fe2e688c40a9124ed1e52db0c53de03dac7dbe70e90780bb98a3c38044acac1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x786372eb420e989057213a4729216638f283638c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1425349683128142526"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "cd32a6cc695350a589ba5e49441d60ba515f878d15b0ccfadaf39f8ba4b8ad5a",
+      "tx_index": 7,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLLGYnw8XzVz4=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "8fe2e688c40a9124ed1e52db0c53de03dac7dbe70e90780bb98a3c38044acac1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1386705093835302852414"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "cd32a6cc695350a589ba5e49441d60ba515f878d15b0ccfadaf39f8ba4b8ad5a",
+      "tx_index": 7,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLQC4Dv+2E4fw=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAYyF6wWAPszejt6cFM9xxhw5raMw=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ="
+        ]
+      },
+      "eth_tx_hash": "8fe2e688c40a9124ed1e52db0c53de03dac7dbe70e90780bb98a3c38044acac1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x63217ac1600fb337a3b7a70533dc71870e6b68cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1388130443518430994940"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059820,
+      "timestamp": "2023-12-12T09:15:37Z",
+      "tx_hash": "cd32a6cc695350a589ba5e49441d60ba515f878d15b0ccfadaf39f8ba4b8ad5a",
+      "tx_index": 7,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8vOfxsVAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "df778d0316ba9706e5764200bfb0518af97a17acb26bf4b521d866fac2a9f8ce",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "850000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8679409c28e443771a24df6e4a8072bb1ad18da879a90d4660cde8bd6fb73c05",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8vOfxsVAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "df778d0316ba9706e5764200bfb0518af97a17acb26bf4b521d866fac2a9f8ce",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "850000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8679409c28e443771a24df6e4a8072bb1ad18da879a90d4660cde8bd6fb73c05",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8vOfxsVAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "df778d0316ba9706e5764200bfb0518af97a17acb26bf4b521d866fac2a9f8ce",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "850000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8679409c28e443771a24df6e4a8072bb1ad18da879a90d4660cde8bd6fb73c05",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUpKleb2TAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "df778d0316ba9706e5764200bfb0518af97a17acb26bf4b521d866fac2a9f8ce",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "5950000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8679409c28e443771a24df6e4a8072bb1ad18da879a90d4660cde8bd6fb73c05",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAABGvdI4m/hPlToQ=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw=",
+          "AAAAAAAAAAAAAAAAtcuy87XTpyqIr2w3OVeaGNUjV1U="
+        ]
+      },
+      "eth_tx_hash": "df778d0316ba9706e5764200bfb0518af97a17acb26bf4b521d866fac2a9f8ce",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb5cbb2f3b5d3a72a88af6c3739579a18d5235755"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "83516809114910930062980"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8679409c28e443771a24df6e4a8072bb1ad18da879a90d4660cde8bd6fb73c05",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAakwIZsODARuTE=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw="
+        ]
+      },
+      "eth_tx_hash": "95863f3aff08148ca93d08f5c4137228a8a01a4d4f277c16ca71ef8b01ce40f1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "31373337819996979575089"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "11ac91c31681bdcc9768d70ac3a210a18f709d34ba487edeb7f17d3266744574",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAakwIZsODARuTE=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAm14+5GnW9X8qfExgvniKDK97UXw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "95863f3aff08148ca93d08f5c4137228a8a01a4d4f277c16ca71ef8b01ce40f1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x9b5e3ee469d6f57f2a7c4c60be788a0caf7b517c"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "31373337819996979575089"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "11ac91c31681bdcc9768d70ac3a210a18f709d34ba487edeb7f17d3266744574",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI0Gn0HiXfvQw=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAYyF6wWAPszejt6cFM9xxhw5raMw=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "9078c44d2059da61a5a96ff15204957041df720c5d096f55e8638a610e948958",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x63217ac1600fb337a3b7a70533dc71870e6b68cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "162591755432441658636"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059794,
+      "timestamp": "2023-12-12T09:13:04Z",
+      "tx_hash": "8401c060b7162da2dda9e8fcc868becbe7b51676d0ef970d6977fb9475fbc0b9",
+      "tx_index": 3,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwOa4WsnuAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "89ae0663e5c725283a7c4e758f3e4b5f1b38ce96b861d69cd1437766842d6bc1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "13900000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "729171f8c7f6c8e3036640981e7489036f340499c00c34d25cd57e1bbe5bca6f",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwOa4WsnuAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "89ae0663e5c725283a7c4e758f3e4b5f1b38ce96b861d69cd1437766842d6bc1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "13900000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "729171f8c7f6c8e3036640981e7489036f340499c00c34d25cd57e1bbe5bca6f",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwOa4WsnuAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "89ae0663e5c725283a7c4e758f3e4b5f1b38ce96b861d69cd1437766842d6bc1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "13900000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "729171f8c7f6c8e3036640981e7489036f340499c00c34d25cd57e1bbe5bca6f",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFRk8Ke4WCAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "89ae0663e5c725283a7c4e758f3e4b5f1b38ce96b861d69cd1437766842d6bc1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "97300000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "729171f8c7f6c8e3036640981e7489036f340499c00c34d25cd57e1bbe5bca6f",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAABHAN9avP8o+Di0=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw=",
+          "AAAAAAAAAAAAAAAAtcuy87XTpyqIr2w3OVeaGNUjV1U="
+        ]
+      },
+      "eth_tx_hash": "89ae0663e5c725283a7c4e758f3e4b5f1b38ce96b861d69cd1437766842d6bc1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb5cbb2f3b5d3a72a88af6c3739579a18d5235755"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "83826028666941815524909"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "729171f8c7f6c8e3036640981e7489036f340499c00c34d25cd57e1bbe5bca6f",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSAjowyKai6o=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ=",
+          "AAAAAAAAAAAAAAAAeGNy60IOmJBXITpHKSFmOPKDY4w="
+        ]
+      },
+      "eth_tx_hash": "b611dbf61e302f0da0fc9406c8b449d25266f63a97804696aee23d6034a45fe1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x786372eb420e989057213a4729216638f283638c"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "23637398569050868650"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "a683ec75ee1604dbf0dff484d1799193e76d7df36e24106c6faef016d9b082bd",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPE9/qhrB881NE=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ=",
+          "AAAAAAAAAAAAAAAAlBSUpWFk6gTXn5hn3dsN11SmJcw="
+        ]
+      },
+      "eth_tx_hash": "b611dbf61e302f0da0fc9406c8b449d25266f63a97804696aee23d6034a45fe1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x941494a56164ea04d79f9867dddb0dd754a625cc"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "17800530059288184149201"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "a683ec75ee1604dbf0dff484d1799193e76d7df36e24106c6faef016d9b082bd",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPGQAOKb0HXYHs=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA0gdsIw/lJXI0Tdc5T7UNgoDDkNE=",
+          "AAAAAAAAAAAAAAAA9rfVunUKJDVnKuErsNt+pJiaGzQ="
+        ]
+      },
+      "eth_tx_hash": "b611dbf61e302f0da0fc9406c8b449d25266f63a97804696aee23d6034a45fe1",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xd2076c230fe52572344dd7394fb50d8280c390d1"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xf6b7d5ba750a2435672ae12bb0db7ea4989a1b34"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "17824167457857235017851"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059777,
+      "timestamp": "2023-12-12T09:11:25Z",
+      "tx_hash": "a683ec75ee1604dbf0dff484d1799193e76d7df36e24106c6faef016d9b082bd",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqEyY5ToUtYI=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAt1mAPucIdVnrYBpJOcLV2nZoOFo=",
+          "AAAAAAAAAAAAAAAAL0BATeZthYvu4soOhDdttLXM9tk="
+        ]
+      },
+      "eth_tx_hash": "f3709cf284988396c32758bba5c7c88c2f4a9c311e2b20e6fef902bdd6f2c759",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xb759803ee7087559eb601a4939c2d5da7668385a"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x2f40404de66d858beee2ca0e84376db4b5ccf6d9"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "49020724154310374786"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059718,
+      "timestamp": "2023-12-12T09:05:27Z",
+      "tx_hash": "da16e29cbd7896bc99cbf106be0ff8af76ede31e794120cbb34618ff7f9f4fa0",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOa33Wq+3oAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "f3709cf284988396c32758bba5c7c88c2f4a9c311e2b20e6fef902bdd6f2c759",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "266000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059718,
+      "timestamp": "2023-12-12T09:05:27Z",
+      "tx_hash": "da16e29cbd7896bc99cbf106be0ff8af76ede31e794120cbb34618ff7f9f4fa0",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOa33Wq+3oAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "f3709cf284988396c32758bba5c7c88c2f4a9c311e2b20e6fef902bdd6f2c759",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "266000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059718,
+      "timestamp": "2023-12-12T09:05:27Z",
+      "tx_hash": "da16e29cbd7896bc99cbf106be0ff8af76ede31e794120cbb34618ff7f9f4fa0",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOa33Wq+3oAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "f3709cf284988396c32758bba5c7c88c2f4a9c311e2b20e6fef902bdd6f2c759",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "266000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059718,
+      "timestamp": "2023-12-12T09:05:27Z",
+      "tx_hash": "da16e29cbd7896bc99cbf106be0ff8af76ede31e794120cbb34618ff7f9f4fa0",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABk8HDes4FYAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAt1mAPucIdVnrYBpJOcLV2nZoOFo="
+        ]
+      },
+      "eth_tx_hash": "f3709cf284988396c32758bba5c7c88c2f4a9c311e2b20e6fef902bdd6f2c759",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xb759803ee7087559eb601a4939c2d5da7668385a"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1862000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059718,
+      "timestamp": "2023-12-12T09:05:27Z",
+      "tx_hash": "da16e29cbd7896bc99cbf106be0ff8af76ede31e794120cbb34618ff7f9f4fa0",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2Ncmtxd6gAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9Uk+qUDRLOhZT4G6srt9TtgdSeg=",
+          "AAAAAAAAAAAAAAAAyQtNcDko299Si59W1N5A2kNnA4o="
+        ]
+      },
+      "eth_tx_hash": "0aaaae3c0c97c88af6072ab64cc1f096756709c0a414a239f7e69fd2adfa36bd",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf5493ea940d12ce8594f81bab2bb7d4ed81d49e8"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xc90b4d703928dbdf528b9f56d4de40da4367038a"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "1000000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059672,
+      "timestamp": "2023-12-12T09:00:56Z",
+      "tx_hash": "13b937ace08e9410cdc5c827b6e3d607c67361f1f392b7cdaa1b58b372547813",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnhDedmdtCAAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9Uk+qUDRLOhZT4G6srt9TtgdSeg=",
+          "AAAAAAAAAAAAAAAAyQtNcDko299Si59W1N5A2kNnA4o="
+        ]
+      },
+      "eth_tx_hash": "34ac4670e172fa644af4580649604e3875c7892a280d31de79ccf031b2ee9e9a",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf5493ea940d12ce8594f81bab2bb7d4ed81d49e8"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xc90b4d703928dbdf528b9f56d4de40da4367038a"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "500000000000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059665,
+      "timestamp": "2023-12-12T09:00:16Z",
+      "tx_hash": "8458259a31c919a50e1d8a4ebfaa90f2f2196686fa8ff2a863953407336e6b42",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGsbhyV3ULRHhgA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAA9Uk+qUDRLOhZT4G6srt9TtgdSeg=",
+          "AAAAAAAAAAAAAAAAyQtNcDko299Si59W1N5A2kNnA4o="
+        ]
+      },
+      "eth_tx_hash": "c46484ec7cc5893982dda662da2c8fa2f1c0bd29b4b90a1a33ac5625b86e2984",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0xf5493ea940d12ce8594f81bab2bb7d4ed81d49e8"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xc90b4d703928dbdf528b9f56d4de40da4367038a"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "505801014077999960000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059659,
+      "timestamp": "2023-12-12T08:59:40Z",
+      "tx_hash": "95f14375b24f221229580ce2a4eb1d3cd4b6b91a4e7faf07593d75bac2b666ba",
+      "tx_index": 1,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2pM9jYxnAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "189a9ef816190c64ac1bdebe3656e80c6b6d50c0de26bcc98d92eaf67e955f73",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "15750000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059626,
+      "timestamp": "2023-12-12T08:56:26Z",
+      "tx_hash": "9d4eeb3247ec2e281a4a964f57812f73aaa26f39e2e577d352d641a9a1cb9dfa",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHzmbFDihAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "189a9ef816190c64ac1bdebe3656e80c6b6d50c0de26bcc98d92eaf67e955f73",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2250000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059626,
+      "timestamp": "2023-12-12T08:56:26Z",
+      "tx_hash": "9d4eeb3247ec2e281a4a964f57812f73aaa26f39e2e577d352d641a9a1cb9dfa",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHzmbFDihAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "189a9ef816190c64ac1bdebe3656e80c6b6d50c0de26bcc98d92eaf67e955f73",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2250000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059626,
+      "timestamp": "2023-12-12T08:56:26Z",
+      "tx_hash": "9d4eeb3247ec2e281a4a964f57812f73aaa26f39e2e577d352d641a9a1cb9dfa",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHzmbFDihAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "189a9ef816190c64ac1bdebe3656e80c6b6d50c0de26bcc98d92eaf67e955f73",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "2250000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059626,
+      "timestamp": "2023-12-12T08:56:26Z",
+      "tx_hash": "9d4eeb3247ec2e281a4a964f57812f73aaa26f39e2e577d352d641a9a1cb9dfa",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAErrGk3ZpdgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "1236665f6cd38fe7b525f3555d979d838f52b8968d1be7406b1a9e058a5600d9",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "86375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059608,
+      "timestamp": "2023-12-12T08:54:41Z",
+      "tx_hash": "38aca614fb30af7ad9939021fae4f335233aa9be3997a17711508a4976e93e94",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAErrGk3ZpdgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "1236665f6cd38fe7b525f3555d979d838f52b8968d1be7406b1a9e058a5600d9",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "86375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059608,
+      "timestamp": "2023-12-12T08:54:41Z",
+      "tx_hash": "38aca614fb30af7ad9939021fae4f335233aa9be3997a17711508a4976e93e94",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAErrGk3ZpdgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAulBIGP3Y09ui74/ZtPTVxxrR0dM="
+        ]
+      },
+      "eth_tx_hash": "1236665f6cd38fe7b525f3555d979d838f52b8968d1be7406b1a9e058a5600d9",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xba504818fdd8d3dba2ef8fd9b4f4d5c71ad1d1d3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "86375000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059608,
+      "timestamp": "2023-12-12T08:54:41Z",
+      "tx_hash": "38aca614fb30af7ad9939021fae4f335233aa9be3997a17711508a4976e93e94",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgxtuCDziOgAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "1236665f6cd38fe7b525f3555d979d838f52b8968d1be7406b1a9e058a5600d9",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "604625000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059608,
+      "timestamp": "2023-12-12T08:54:41Z",
+      "tx_hash": "38aca614fb30af7ad9939021fae4f335233aa9be3997a17711508a4976e93e94",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcRUQu+X42AAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAA5ju+TvKb/8QPpq4zfKLlMsmjAiQ="
+        ]
+      },
+      "eth_tx_hash": "e28e735dc4657171187198c04f9f59dd8cc3fe680231b3690ab8e58517cfffd2",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xe63bbe4ef29bffc40fa6ae337ca2e532c9a30224"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "521500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059499,
+      "timestamp": "2023-12-12T08:43:54Z",
+      "tx_hash": "52550cac1860ca77a5b9561ace37b783df6cc50e829a109358afc73694aebaca",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECeUrSDaaAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAdkO9YOj9cDLtP2VAh1CQzP75o30="
+        ]
+      },
+      "eth_tx_hash": "e28e735dc4657171187198c04f9f59dd8cc3fe680231b3690ab8e58517cfffd2",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0x7643bd60e8fd7032ed3f6540875090ccfef9a37d"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "74500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059499,
+      "timestamp": "2023-12-12T08:43:54Z",
+      "tx_hash": "52550cac1860ca77a5b9561ace37b783df6cc50e829a109358afc73694aebaca",
+      "tx_index": 0,
+      "type": "evm.log"
+    },
+    {
+      "body": {
+        "address": "8Cs+Q3MEiSEFmSUSU592lCOlFcs=",
+        "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECeUrSDaaAAA=",
+        "topics": [
+          "3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=",
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "AAAAAAAAAAAAAAAAu/gtzn1H7ueBDO9hhfQBQ/RgcOM="
+        ]
+      },
+      "eth_tx_hash": "e28e735dc4657171187198c04f9f59dd8cc3fe680231b3690ab8e58517cfffd2",
+      "evm_log_name": "Transfer",
+      "evm_log_params": [
+        {
+          "evm_type": "address",
+          "name": "from",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "evm_type": "address",
+          "name": "to",
+          "value": "0xbbf82dce7d47eee7810cef6185f40143f46070e3"
+        },
+        {
+          "evm_type": "uint256",
+          "name": "value",
+          "value": "74500000000000000000"
+        }
+      ],
+      "evm_token": {
+        "decimals": 18,
+        "symbol": "YUZU",
+        "type": "ERC20"
+      },
+      "round": 8059499,
+      "timestamp": "2023-12-12T08:43:54Z",
+      "tx_hash": "52550cac1860ca77a5b9561ace37b783df6cc50e829a109358afc73694aebaca",
+      "tx_index": 0,
+      "type": "evm.log"
+    }
+  ],
+  "is_total_count_clipped": false,
+  "total_count": 108
+}

--- a/tests/e2e_regression/eden/expected/emerald_transfer_events_of_token.headers
+++ b/tests/e2e_regression/eden/expected/emerald_transfer_events_of_token.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Transfer-Encoding: chunked
+

--- a/tests/e2e_regression/eden/test_cases.sh
+++ b/tests/e2e_regression/eden/test_cases.sh
@@ -23,6 +23,7 @@ testCases=(
   'emerald_tx                         /v1/emerald/transactions/ec1173a69272c67f126f18012019d19cd25199e831f9417b6206fb7844406f9d'
   'emerald_failed_tx                  /v1/emerald/transactions/35fdc8261dd81be8187c858aa9a623085494baf0565d414f48562a856147c093'
   'emerald_events_by_nft              /v1/emerald/events?contract_address=oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx&nft_id=1'
+  'emerald_transfer_events_of_token   /v1/emerald/events?evm_log_signature=ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef&contract_address=0xf02b3e437304892105992512539F769423a515Cb'
   'emerald_token                      /v1/emerald/evm_tokens/oasis1qpgcp5jzlgk4hcenaj2x82rqk8rrve2keyuc8aaf'
   'emerald_token_eth                  /v1/emerald/evm_tokens/0x21C718C22D52d0F3a789b752D4c2fD5908a8A733'
   'emerald_token_holders              /v1/emerald/evm_tokens/oasis1qpgcp5jzlgk4hcenaj2x82rqk8rrve2keyuc8aaf/holders'


### PR DESCRIPTION
Part of: https://github.com/oasisprotocol/nexus/issues/804

This will enable efficient querying of all transfers of a specific ERC20 token. This is needed for the Transfer tab in the tokens details page (https://explorer.oasis.io/mainnet/sapphire/token/0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8). See issue description for some more details.

Creating the index on the live instance might take some time, so ideally, the index is created CONCURENTLY sometime before deployment to prevent the migration from blocking the deployment.


Note: This doesn't resolve the inefficient accounts-related query, which is also mentioned in the issue. That one will require a separate (likely more significant) change.

TODO: 
- [x] add a test case for the newly supported query
- [x] I applied the index on labs staging mainnet deployment and confirmed the queries are now fast, e.g. (https://nexus.oasis.io/v1/sapphire/events?offset=0&limit=10&type=evm.log&evm_log_signature=ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef&contract_events=0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8)
- [x] Also applied the index to labs production mainnet 
- [x] prod testnet
- [x] staging testnet