### PR TITLE
server: cancel the request context on timeout

### DIFF
--- a/.changelog/821.feature.md
+++ b/.changelog/821.feature.md
@@ -1,0 +1,4 @@
+server: Enforce request timeouts using `http.TimeoutHandler`
+
+The request timeout is configurable via the `server.request_timeout` field.
+By default, it is set to 10 seconds.

--- a/config/config.go
+++ b/config/config.go
@@ -586,6 +586,10 @@ type ServerConfig struct {
 	// Source is the configuration for accessing oasis-node(s) and chain
 	// information.
 	Source *SourceConfig `koanf:"source"`
+
+	// RequestTimeout is the timeout for requests to the storage backend.
+	// If unset, the default timeout is used.
+	RequestTimeout *time.Duration `koanf:"request_timeout"`
 }
 
 // Validate validates the server configuration.


### PR DESCRIPTION
Added `ContextTimeoutMiddleware` to enforce request context timeout and ensure proper cancellation of timed-out requests. This ensures that the context for requests exceeding the defined timeout limit are properly canceled.

I noticed cases like the one below, where request takes 15 seconds:
```json
{"caller":"middleware.go:77","latency":"14.69731168s","latency_bin":">1000ms","level":"info","module":"api","msg":"ending request","query_params":"limit=10&offset=0","query_path":"/v1/sapphire/evm_tokens","request_id":"3fecdf6b-ad74-42f0-8cfc-52ba0787f05a","status_code":200,"ts":"2024-12-05T08:37:32.086384228Z"}
```

Note that the server logs show a 200 OK status, but the response is not delivered to the client. Instead, the client receives an EOF since the [configured server timeout is reached](https://github.com/oasisprotocol/nexus/blob/ca4ef6dc4be3f322762b7b59b1df14531514a92f/cmd/api/api.go#L202-L203), while the server continues processing the request. 

Ref upstream issue: https://github.com/golang/go/issues/59602