### PR TITLE
api/consensus/events: Include timestamp

### DIFF
--- a/.changelog/823.feature.md
+++ b/.changelog/823.feature.md
@@ -1,0 +1,1 @@
+api/consensus/events: Include timestamp in response

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1810,6 +1810,12 @@ components:
             relates.
             Present only for events of type `roothash.*` except for
             `roothash.execution_discrepancy` before Eden.
+        timestamp:
+          type: string
+          format: date-time
+          description: |
+            The second-granular consensus time of this event's block.
+          example: *iso_timestamp_1
         type:
           allOf: [$ref: '#/components/schemas/ConsensusEventType']
           description: The type of the event.

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -482,6 +482,7 @@ func (c *StorageClient) Events(ctx context.Context, p apiTypes.GetConsensusEvent
 			&e.RoothashRuntimeRound,
 			&e.Type,
 			&e.Body,
+			&e.Timestamp,
 		); err != nil {
 			return nil, wrapError(err)
 		}

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -106,8 +106,9 @@ const (
 			OFFSET $9::bigint`
 
 	Events = `
-		SELECT tx_block, tx_index, tx_hash, roothash_runtime_id, roothash_runtime, roothash_runtime_round, type, body
+		SELECT tx_block, tx_index, tx_hash, roothash_runtime_id, roothash_runtime, roothash_runtime_round, type, body, b.time
 			FROM chain.events
+			LEFT JOIN chain.blocks b ON tx_block = b.height
 			WHERE ($1::bigint IS NULL OR tx_block = $1::bigint) AND
 					($2::integer IS NULL OR tx_index = $2::integer) AND
 					($3::text IS NULL OR tx_hash = $3::text) AND

--- a/tests/e2e_regression/damask/expected/events.body
+++ b/tests/e2e_regression/damask/expected/events.body
@@ -7,6 +7,7 @@
         "from": "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5",
         "to": "oasis1qrmufhkkyyf79s5za2r8yga9gnk4t446dcy3a5zm"
       },
+      "timestamp": "2022-04-11T12:44:14Z",
       "type": "staking.transfer"
     },
     {
@@ -16,6 +17,7 @@
         "from": "oasis1qrqnh093w0pv8asfmc37pyal6yn2h4cnwvdqtzm0",
         "to": "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5"
       },
+      "timestamp": "2022-04-11T12:44:08Z",
       "tx_hash": "4defe2afa3abbd4668958e360e184c73381e8b99ebb8082b911f6b28c811da97",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -27,6 +29,7 @@
         "from": "oasis1qrqnh093w0pv8asfmc37pyal6yn2h4cnwvdqtzm0",
         "to": "oasis1qz068qtggv6kdstymnvqm46rpv6p6tk6pueffdqu"
       },
+      "timestamp": "2022-04-11T12:44:08Z",
       "tx_hash": "4defe2afa3abbd4668958e360e184c73381e8b99ebb8082b911f6b28c811da97",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -38,6 +41,7 @@
         "from": "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5",
         "to": "oasis1qps7mh7usg7u4t35ujr0l8dxjs2ly2swhu9v0mr0"
       },
+      "timestamp": "2022-04-11T12:44:08Z",
       "type": "staking.transfer"
     },
     {
@@ -47,6 +51,7 @@
         "from": "oasis1qrqnh093w0pv8asfmc37pyal6yn2h4cnwvdqtzm0",
         "to": "oasis1qz068qtggv6kdstymnvqm46rpv6p6tk6pueffdqu"
       },
+      "timestamp": "2022-04-11T12:43:05Z",
       "tx_hash": "b40bd05e4f7f0f9700b9934449019ecc340a8af8f505cdebc5adcf3d265c2660",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -93,6 +98,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:40:11Z",
       "tx_hash": "d80b7c0d96ea7dee3ad7f6d144f6aa751a974978e639d38232a0254b6ed6d716",
       "tx_index": 0,
       "type": "registry.node"
@@ -104,6 +110,7 @@
         "from": "oasis1qrqnh093w0pv8asfmc37pyal6yn2h4cnwvdqtzm0",
         "to": "oasis1qrqnh093w0pv8asfmc37pyal6yn2h4cnwvdqtzm0"
       },
+      "timestamp": "2022-04-11T12:38:50Z",
       "tx_hash": "a116e6343d076569695f0a7a539e38990dcd1c553e94ce3149821673e7f6a07c",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -140,6 +147,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:37:52Z",
       "tx_hash": "17bc56f2d5c362d28303c3ea73ed7e1e85acdbfb6c8f1b35f1a991374556122d",
       "tx_index": 0,
       "type": "registry.node"
@@ -176,6 +184,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:34:59Z",
       "tx_hash": "e501b3cd5a1e7a4e9e6b65763dcc6b180b1e083af22cde183c081432a886106d",
       "tx_index": 0,
       "type": "registry.node"
@@ -212,6 +221,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:33:54Z",
       "tx_hash": "67c66a9cd792ea8efb2cd95a8925ba3418971efe88b5294c26e0b8c2eedf3f8b",
       "tx_index": 0,
       "type": "registry.node"
@@ -258,6 +268,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:28:14Z",
       "tx_hash": "ebc441454909b068fd6cd76945d07f8d88a2b4c444c2a96d25345500ad5fba84",
       "tx_index": 0,
       "type": "registry.node"
@@ -310,6 +321,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:28:14Z",
       "tx_hash": "a8f8b74bcdeac961afd7d17c658e031f1b8bbe6ac6182531819c27c6e891ab56",
       "tx_index": 1,
       "type": "registry.node"
@@ -346,6 +358,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:25:03Z",
       "tx_hash": "c5a190d203f85f6f4be04e01e90b32ed05fe91b2182714b29fee52caeb983c25",
       "tx_index": 0,
       "type": "registry.node"
@@ -392,6 +405,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:19:10Z",
       "tx_hash": "7f0d67b40505ebd08640b317a98bd71792fa222c83288f4d1d1abb1f5a6aeaca",
       "tx_index": 0,
       "type": "registry.node"
@@ -406,6 +420,7 @@
         "escrow": "oasis1qz72lvk2jchk0fjrz7u2swpazj3t5p0edsdv7sf8",
         "owner": "oasis1qqmrw7p0srp2kfpacdr4aslac6sv3rgmy5a2dulj"
       },
+      "timestamp": "2022-04-11T12:18:00Z",
       "tx_hash": "aa8ae4c5f498afca3480ee52796761ec74011f90eac866c5eeb2927359f8a277",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -442,6 +457,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:15:53Z",
       "tx_hash": "c1f6d56a80e763ec661568f2c9af5467bca8a31015277bdced0e53692482a74b",
       "tx_index": 0,
       "type": "registry.node"
@@ -478,6 +494,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:14:49Z",
       "tx_hash": "b627c8f147ee2b8a07310883b1d2cbf14d56750ab1739096933b3b0fbd69fe8f",
       "tx_index": 0,
       "type": "registry.node"
@@ -530,6 +547,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:14:09Z",
       "tx_hash": "d0c61ba39bb7f981b1fdc9eede425d1b29de285be1251e235f155ce8da271270",
       "tx_index": 0,
       "type": "registry.node"
@@ -544,6 +562,7 @@
         "escrow": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
         "owner": "oasis1qzaq5lcxzu7ct60tx993nfy9qw5xavjhgu57w90x"
       },
+      "timestamp": "2022-04-11T12:11:43Z",
       "tx_hash": "4314d4785f2fe82f461ca613689c10cd38bb5cfecac0ca01f175b97ef31e79f0",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -596,6 +615,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:10:57Z",
       "tx_hash": "4a3d995d60d2031c9d022d2617ace1e17d0d29922986c5c12c9715dd83589599",
       "tx_index": 0,
       "type": "registry.node"
@@ -648,6 +668,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:10:33Z",
       "tx_hash": "f7656525a615815638727ed9f3699bca2531145049f51344d4214bd4c7d83c56",
       "tx_index": 0,
       "type": "registry.node"
@@ -700,6 +721,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:10:33Z",
       "tx_hash": "52ff4f5efa98160d77489a1fed170ad623289595590ec9cbf42103713540a895",
       "tx_index": 1,
       "type": "registry.node"
@@ -736,6 +758,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:24Z",
       "tx_hash": "0852cef026fcde50afefaa12a91e154cbf10f80296056afac4dbc859a5a52a7b",
       "tx_index": 0,
       "type": "registry.node"
@@ -772,6 +795,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:24Z",
       "tx_hash": "21ff29bcb4b468ecad129f5cc07a30eeba3f3c8f463b5fb370644ef3b550e4fb",
       "tx_index": 1,
       "type": "registry.node"
@@ -808,6 +832,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:24Z",
       "tx_hash": "10eff49cc06a4460b4758fc80ea49b4c72b27c744a9573f1a9f4bd2711b97b18",
       "tx_index": 2,
       "type": "registry.node"
@@ -844,6 +869,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:24Z",
       "tx_hash": "6f74a54f87e19a2cdcdebdae91c2ad6c73cf7491ae773106e70f0798c9080d26",
       "tx_index": 3,
       "type": "registry.node"
@@ -890,6 +916,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:24Z",
       "tx_hash": "cc8ed0c7c4959977e22514d3879caed7da5151a6f05abdfa4b6d5fdbbd995522",
       "tx_index": 4,
       "type": "registry.node"
@@ -926,6 +953,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:18Z",
       "tx_hash": "f77f145a8b1d1136167d0e0b97fec94496c164a79b08a57ea0e472b70afb2c54",
       "tx_index": 0,
       "type": "registry.node"
@@ -974,6 +1002,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:18Z",
       "tx_hash": "0d371cbb4faa53c3b04082011c72706d1d6acc07cc81a0120572d0c0b7d32e87",
       "tx_index": 1,
       "type": "registry.node"
@@ -1011,6 +1040,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:12Z",
       "tx_hash": "e47aab5cbe2a980e4bd71459fa8066491cc8661cdadeaa3c6c256167fafb931a",
       "tx_index": 0,
       "type": "registry.node"
@@ -1047,6 +1077,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:12Z",
       "tx_hash": "34c8b874070b056771b887b497290a3550ad8b257c6735fcea659ff4b25aafbf",
       "tx_index": 1,
       "type": "registry.node"
@@ -1083,6 +1114,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:06Z",
       "tx_hash": "0aa6c14b6a8aa31c9e3addd2f92c42e2dff1f7d77749a773f4e70aed50d6416c",
       "tx_index": 0,
       "type": "registry.node"
@@ -1119,6 +1151,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:06Z",
       "tx_hash": "249cf3ba735738f1845143d96feb2c06ee28af748c9bf1bc8dc304b678e09609",
       "tx_index": 1,
       "type": "registry.node"
@@ -1171,6 +1204,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:06Z",
       "tx_hash": "a537f1f549cb77a4aa1d6abfc5dcb9ca17705250749b13a974e46a11451aa239",
       "tx_index": 2,
       "type": "registry.node"
@@ -1219,6 +1253,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:01Z",
       "tx_hash": "55eb02526b365dc10384aeecda74524eb618f27806ec30e5f430ce070ccadbc6",
       "tx_index": 0,
       "type": "registry.node"
@@ -1265,6 +1300,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:01Z",
       "tx_hash": "c05e319546b57c0276eae79c3eb02fe794184de68f17a5c99464f35cee2cc14f",
       "tx_index": 1,
       "type": "registry.node"
@@ -1301,6 +1337,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:01Z",
       "tx_hash": "306164db4b95856699014d7ad666b89c8f146719bfe0f9c798c2167ab09ef02d",
       "tx_index": 2,
       "type": "registry.node"
@@ -1337,6 +1374,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:09:01Z",
       "tx_hash": "353b2a3eafa9f52d85bbef916e8e6b8fee9b714129ca2de83f56849faec860d9",
       "tx_index": 3,
       "type": "registry.node"
@@ -1373,6 +1411,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:55Z",
       "tx_hash": "1e69d7958f1e5dde1d57f4f722de0897959063de5af4067bf145ad78321280a9",
       "tx_index": 0,
       "type": "registry.node"
@@ -1425,6 +1464,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:55Z",
       "tx_hash": "7a291ae8ab51483f5e3e395c243deec2b7a3e74a477d877c7aff743dfa7cf374",
       "tx_index": 1,
       "type": "registry.node"
@@ -1461,6 +1501,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:55Z",
       "tx_hash": "65fd253cd23d753c70ed99419e5661c1c9cf77a4d8b762639950f7ee27d950b3",
       "tx_index": 2,
       "type": "registry.node"
@@ -1507,6 +1548,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:55Z",
       "tx_hash": "056f25b4bb3520907bca25ec9ee07f131c9d956f0274871073fd1a8a1aaa115b",
       "tx_index": 3,
       "type": "registry.node"
@@ -1543,6 +1585,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:55Z",
       "tx_hash": "dadd0642cce4c2dbf60293ae72a6d17b43cb2cdbf4be22919c7b37d1724c5cbd",
       "tx_index": 4,
       "type": "registry.node"
@@ -1579,6 +1622,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:49Z",
       "tx_hash": "dbe2e00b82bb9801b7d4577272fe750983c31e8746f9229ee5fa71ab3aa3d280",
       "tx_index": 0,
       "type": "registry.node"
@@ -1615,6 +1659,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:49Z",
       "tx_hash": "b5ed4e6e745601fb25a2ca0dce8e1fc82bf6100b300c9eace188ab052fcb0d57",
       "tx_index": 1,
       "type": "registry.node"
@@ -1651,6 +1696,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:49Z",
       "tx_hash": "637d5a92a05813b0155b5c8c5924b17b05b36eb19b79425b8fa28fad80a04b7f",
       "tx_index": 2,
       "type": "registry.node"
@@ -1697,6 +1743,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:49Z",
       "tx_hash": "c596d4d6475b7c077b8aa3ec7b35a221d90cf1af6a14d95940cf976a93a46157",
       "tx_index": 3,
       "type": "registry.node"
@@ -1743,6 +1790,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:49Z",
       "tx_hash": "dae70442177f476e89a76d7b5251fbddf9b2175ecd0d845e1d93f13afc3fbf3d",
       "tx_index": 4,
       "type": "registry.node"
@@ -1779,6 +1827,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "47043bae94c03b720f2d259ddb4b7a958faee9330956a153491b3cb1e74b9d26",
       "tx_index": 0,
       "type": "registry.node"
@@ -1827,6 +1876,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "c1267e671f5c1094f2121fd7f13367ceba2e601e0271cbd67fff91b1e48c9100",
       "tx_index": 1,
       "type": "registry.node"
@@ -1863,6 +1913,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "891ae449d4cb5abd7a24b681896259bb71aa04cbcc2b0bd7bcbc9b6d732f9e12",
       "tx_index": 2,
       "type": "registry.node"
@@ -1899,6 +1950,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "f6d87f0997cece308f48207d4087b03d62f6f82ece117c492fdbdeb44cc0d9ad",
       "tx_index": 3,
       "type": "registry.node"
@@ -1951,6 +2003,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "25299f9de8b9bcd232c0809788a7c02661d4b66eba3557be961d9be09aa39024",
       "tx_index": 4,
       "type": "registry.node"
@@ -1987,6 +2040,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:43Z",
       "tx_hash": "a503452db11bc5fe6542d14d8b4c955a7a560c2581079e9028ae020400a1aa10",
       "tx_index": 5,
       "type": "registry.node"
@@ -2023,6 +2077,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "c7688b81886192274020f3764e9451dfd8b0ca425da03c1314455fdaeed6f4ce",
       "tx_index": 0,
       "type": "registry.node"
@@ -2069,6 +2124,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "f75abaed277705d0ff7db7679ada041e5bd403a505ba716d26d2c6b59f440d84",
       "tx_index": 1,
       "type": "registry.node"
@@ -2105,6 +2161,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "2628bd04157ccbde66ccfb4abbb11cd8db5abf0601841b937c69b1d3824d5342",
       "tx_index": 2,
       "type": "registry.node"
@@ -2141,6 +2198,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "e3eb1ea937865f90209906353acde8185ee640f34b8ba2c4f8d14814eb917a2d",
       "tx_index": 3,
       "type": "registry.node"
@@ -2187,6 +2245,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "ddacf6d435539e00e7abc62968d4402872b2bd67cced51ceb4662eec2702618b",
       "tx_index": 4,
       "type": "registry.node"
@@ -2223,6 +2282,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:37Z",
       "tx_hash": "877a6a7b291f183f26cb0bd2221f8db82964e227444792f2dd7e8773070be62e",
       "tx_index": 5,
       "type": "registry.node"
@@ -2269,6 +2329,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:31Z",
       "tx_hash": "07336f80156e340dc2c279fb3c178def7dae988c10b1607a8f89d1d85687ae20",
       "tx_index": 0,
       "type": "registry.node"
@@ -2305,6 +2366,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:31Z",
       "tx_hash": "f9b073205713980125f21de7f3701029a84ab35ab1d9fe4c0bdbe1ac45faa1cf",
       "tx_index": 1,
       "type": "registry.node"
@@ -2351,6 +2413,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "65df5f73861b7cc90ca75ebc79e361d1dcaa960b3527d289ea7b7c25412ca944",
       "tx_index": 0,
       "type": "registry.node"
@@ -2387,6 +2450,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "832f9f459943a0e888854dc3a8dd7fedd19f47d72918c61d946944242b09a0a2",
       "tx_index": 1,
       "type": "registry.node"
@@ -2433,6 +2497,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "8b5cbc80dbbacab0489f2df07302ba984b7417739bbc9dffaa2a33b4f9aabeaa",
       "tx_index": 2,
       "type": "registry.node"
@@ -2469,6 +2534,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "c93ce61fdf27ed5570b9095aad095f02422ed3e01869d669297001d052b9246e",
       "tx_index": 3,
       "type": "registry.node"
@@ -2515,6 +2581,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "50725bc8eb07a7b1aa91c25619d49e37e8ee338f37d34e9de9cff2097b20159d",
       "tx_index": 4,
       "type": "registry.node"
@@ -2552,6 +2619,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:26Z",
       "tx_hash": "3addfb6f73a0f772dff2d9072628edc18c28b39226a40ee5e584a437aeb8daab",
       "tx_index": 5,
       "type": "registry.node"
@@ -2588,6 +2656,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:20Z",
       "tx_hash": "7e383398196b6ce7f4a86b40ba0e2c1d431a4f91788e3f2a487d8ff16cf74a48",
       "tx_index": 0,
       "type": "registry.node"
@@ -2624,6 +2693,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:20Z",
       "tx_hash": "4ebd49e81407777f785a3df3dbdabc2b862429c2922d7764cbe505d8446dd50c",
       "tx_index": 1,
       "type": "registry.node"
@@ -2672,6 +2742,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:20Z",
       "tx_hash": "ab910428949b792839278d843fed887cec27bda88e981ac26f54dd941c871965",
       "tx_index": 2,
       "type": "registry.node"
@@ -2720,6 +2791,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:20Z",
       "tx_hash": "25f97fe4499f045c186291c5220e58b3926e827c8bdb189b37db9f1558725875",
       "tx_index": 3,
       "type": "registry.node"
@@ -2756,6 +2828,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "455207f1d6a7d6b961097294bf13262b413580294263e7f40ef5fa328bac9da7",
       "tx_index": 0,
       "type": "registry.node"
@@ -2792,6 +2865,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "7e612e583dd418635db43edde2e2eb8942d071a187b7e729b56bca78a22b6eae",
       "tx_index": 1,
       "type": "registry.node"
@@ -2828,6 +2902,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "ef54af058c1b690973e2de5e22958633fa91c173c05ca82068baeb8ef129bf3c",
       "tx_index": 2,
       "type": "registry.node"
@@ -2864,6 +2939,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "53ecfb3f7154db95a3d85590405da70a61d34d6bcd3757ab224614de54152636",
       "tx_index": 3,
       "type": "registry.node"
@@ -2900,6 +2976,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "28ccccfda3b590a95d4a8b788103697fad46f9b6bdb60d2722e35822db9dfb64",
       "tx_index": 4,
       "type": "registry.node"
@@ -2936,6 +3013,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "fc4c7f7ab12ff69a0b7338ad9a0e8e6cfeefc90b198d0fd56a7e2667dfbc34ae",
       "tx_index": 5,
       "type": "registry.node"
@@ -2973,6 +3051,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:14Z",
       "tx_hash": "51db9d780c4438702cf2ade658f48bea9134cf776bbd8476a5c6b4fec76c2ae5",
       "tx_index": 6,
       "type": "registry.node"
@@ -3019,6 +3098,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "4e69a94f6572a74d0760c676b74a98aa8f43bc4eb1b452032f875f84984ae222",
       "tx_index": 0,
       "type": "registry.node"
@@ -3065,6 +3145,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "17cf40082d310bc857e1d96e3c6471e3af73618a8f9f64497b28c7b82d4417df",
       "tx_index": 1,
       "type": "registry.node"
@@ -3101,6 +3182,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "fa66bd24835ab0b6acd3ab2dec7265f5d0f35868b57622b4b01813090a7eac4f",
       "tx_index": 2,
       "type": "registry.node"
@@ -3142,6 +3224,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "3d45b1a7aa3d8ec25e17b847b2749a0b464b8e6be7fc4d9923262eff8bca3569",
       "tx_index": 3,
       "type": "registry.node"
@@ -3194,6 +3277,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "8a948670d43821020430d5e750b762058f31f33ef0cb6df691786be5f30c7560",
       "tx_index": 4,
       "type": "registry.node"
@@ -3206,6 +3290,7 @@
         "beneficiary": "oasis1qzvlg0grjxwgjj58tx2xvmv26era6t2csqn22pte",
         "owner": "oasis1qzwt3w0ucve0ytzzyv3y72pcl7wlsd3nygdqdhac"
       },
+      "timestamp": "2022-04-11T12:08:08Z",
       "tx_hash": "6990487a171f9106dc7cfefe15fb5be45240ca26fb3c113a6fe6be75fabf235d",
       "tx_index": 5,
       "type": "staking.allowance_change"
@@ -3242,6 +3327,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:02Z",
       "tx_hash": "b9037f0442073996144c209d3f5b6fcf331364dc609aed592a28d03efa488478",
       "tx_index": 0,
       "type": "registry.node"
@@ -3278,6 +3364,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:02Z",
       "tx_hash": "d1569eeeebdb10a8f444f1743b13348b2e80abe768c97d5908dcb4998f9fe144",
       "tx_index": 1,
       "type": "registry.node"
@@ -3314,6 +3401,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:02Z",
       "tx_hash": "9d80e00c9096d408faf48fb2f63fed4ea147c21a08a9b2f1c888e370d1a3450a",
       "tx_index": 2,
       "type": "registry.node"
@@ -3360,6 +3448,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:08:02Z",
       "tx_hash": "a66e27c7eca15b8c1b29b858af6ee6a0a55bd2582f24810ac2072ac2d7d8bf2e",
       "tx_index": 3,
       "type": "registry.node"
@@ -3396,6 +3485,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:56Z",
       "tx_hash": "cb394289c0e014d9edb3ebc1154e3c7abc1ec01185e2fb813a555080784f1157",
       "tx_index": 0,
       "type": "registry.node"
@@ -3432,6 +3522,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:56Z",
       "tx_hash": "1f8eaded76d37526bab98982907331474e7b7d388882ac260ed2735e558e81b3",
       "tx_index": 1,
       "type": "registry.node"
@@ -3478,6 +3569,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:56Z",
       "tx_hash": "b90e2518499ba84fb6f3fa031643f6f27629816c21d8afc1b28f28491906f319",
       "tx_index": 2,
       "type": "registry.node"
@@ -3514,6 +3606,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:56Z",
       "tx_hash": "1dc69d8a7a6861f4c3d2259ee2abdccf5d5949193af486ca9b1e4e7c0a0f3866",
       "tx_index": 3,
       "type": "registry.node"
@@ -3550,6 +3643,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:56Z",
       "tx_hash": "4d8b7b8d5cf33d52f2129c8c57c982bcfad854ec830c151b5131b7192398a57f",
       "tx_index": 4,
       "type": "registry.node"
@@ -3586,6 +3680,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "a280187d2584f46d9a24cf912ae1087f5945e8f59643270fb0d0fe44d0dba56f",
       "tx_index": 0,
       "type": "registry.node"
@@ -3622,6 +3717,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "906c371ebaa2ebdbc0ff7db7da405012ff229cffcc23980b1ed265f8ca71d54f",
       "tx_index": 1,
       "type": "registry.node"
@@ -3658,6 +3754,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "ff9fe3ed316563671b14a7ff4aa4ff3d062c492f182e48b203a6aacc6bffcf20",
       "tx_index": 2,
       "type": "registry.node"
@@ -3694,6 +3791,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "fff818ccd9c8818c3520c66db87e89be5d209f8638effee8c1425ee14f849aaf",
       "tx_index": 3,
       "type": "registry.node"
@@ -3730,6 +3828,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "d6d1c21b30379f0a4725f26f1382ef21dafdfe760e7733b8adfe3a3c0922a5a1",
       "tx_index": 4,
       "type": "registry.node"
@@ -3766,6 +3865,7 @@
           }
         }
       },
+      "timestamp": "2022-04-11T12:07:50Z",
       "tx_hash": "456ebd64bf89fa0bc556d8eb719956bb00e7ad3560b29bc57e571d3bd940f70b",
       "tx_index": 5,
       "type": "registry.node"

--- a/tests/e2e_regression/eden/expected/events.body
+++ b/tests/e2e_regression/eden/expected/events.body
@@ -7,6 +7,7 @@
         "from": "oasis1qzrycs7qhh455dj0nwzfd3y5um4m7f2p75yksjvh",
         "to": "oasis1qqv9tknl8afkxkzszwl80g3wz80f2w8u0g502ewc"
       },
+      "timestamp": "2023-11-29T18:09:59Z",
       "tx_hash": "142d43e5194b738ab2223f8d0b42326fab06edd714a8cefc59a078b89b5de057",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -21,6 +22,7 @@
         "escrow": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
         "owner": "oasis1qzlzqkwxdeasv6asnpylepxtth8w796xxgssp97j"
       },
+      "timestamp": "2023-11-29T18:09:19Z",
       "tx_hash": "e04b0ac53f004a1123d04dab1d36e184841e986e0f6f0bac277403fa98f3dc60",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -33,6 +35,7 @@
         "new_shares": "19415587977047",
         "owner": "oasis1qzyf6wvfjv9aa97zg4r505cpemmjgjnlgs8zpcm0"
       },
+      "timestamp": "2023-11-29T18:07:48Z",
       "tx_hash": "be44411f4d6297cba3a63306a5f46e123150f4f327c452488b1f57f599e87694",
       "tx_index": 0,
       "type": "staking.escrow.add"
@@ -83,6 +86,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T18:07:25Z",
       "tx_hash": "db00ac1ea4a863557e88b23c16d63fd8909b69b240e5bee3d8c41e37aba41056",
       "tx_index": 0,
       "type": "registry.node"
@@ -126,6 +130,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T18:05:48Z",
       "tx_hash": "7f905dbe9a695d6d63f0c92f0463551c2a2da0163b31b710986b7998d1bd64ab",
       "tx_index": 0,
       "type": "registry.node"
@@ -169,6 +174,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T18:04:12Z",
       "tx_hash": "752d2bd5c1ff62856c14da66ae21bf284a1266c20f39891ba8530f520b16ccc2",
       "tx_index": 0,
       "type": "registry.node"
@@ -235,6 +241,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T18:02:18Z",
       "tx_hash": "9435cb778639a94f6a72be128e0320a8df7995b0c68914b082eef6412cb8cee5",
       "tx_index": 0,
       "type": "registry.node"
@@ -249,6 +256,7 @@
         "escrow": "oasis1qq0xmq7r0z9sdv02t5j9zs7en3n6574gtg8v9fyt",
         "owner": "oasis1qp2u0t3xwhuq3du80k36xg4r04ew5zag6yr6frwg"
       },
+      "timestamp": "2023-11-29T18:00:41Z",
       "tx_hash": "4bca66ca7081be1d858035689b612cf5493afab9f01438c031884c147750dc29",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -263,6 +271,7 @@
         "escrow": "oasis1qq3xrq0urs8qcffhvmhfhz4p0mu7ewc8rscnlwxe",
         "owner": "oasis1qz68nze7d2hqkjgy445z0hzvpy0weswjkgg4efza"
       },
+      "timestamp": "2023-11-29T17:59:44Z",
       "tx_hash": "2d2b592be3c69dd51c8a36d7a49e6c98fb4f2a50b7b1ff5a33431976b16a1d81",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -306,6 +315,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:59:04Z",
       "tx_hash": "95a5b2972ca8c72bbc897fc6d94022a1549a72842583e6eb5c27634268eb6ad4",
       "tx_index": 0,
       "type": "registry.node"
@@ -342,6 +352,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:58:36Z",
       "tx_hash": "4e73e4e737d8c508752c0644ee8df6ecf9b932e5c5e9510ecd5f1ea13be70a90",
       "tx_index": 0,
       "type": "registry.node"
@@ -356,6 +367,7 @@
         "escrow": "oasis1qqekv2ymgzmd8j2s2u7g0hhc7e77e654kvwqtjwm",
         "owner": "oasis1qqn2s2y7uwfx22fwgurlncf3t2rlvvatfc8ps08f"
       },
+      "timestamp": "2023-11-29T17:58:02Z",
       "tx_hash": "287774c818ada4bfaacca20a56b1cdc5c405688006764d797d449d7229961474",
       "tx_index": 0,
       "type": "staking.escrow.debonding_start"
@@ -406,6 +418,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:56:10Z",
       "tx_hash": "6acf2e0fed20297a22f0cf25b590fd2fbab46ae5482433ad0ba19e2021df7d9f",
       "tx_index": 0,
       "type": "registry.node"
@@ -449,6 +462,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:58Z",
       "tx_hash": "717a7b025865f222a985ad234d0a8e0c4da1cfeccc9ffc6a37225ff733b94e74",
       "tx_index": 0,
       "type": "registry.node"
@@ -492,6 +506,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:58Z",
       "tx_hash": "aaac9a46e31474bf5235ac693f8fd89f24d833090949046df892111ebc92d561",
       "tx_index": 1,
       "type": "registry.node"
@@ -535,6 +550,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:58Z",
       "tx_hash": "4478edbac08ecc5899a28d47b42dd3f7dfdae2d9eaff27e52856006f32397248",
       "tx_index": 2,
       "type": "registry.node"
@@ -571,6 +587,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:41Z",
       "tx_hash": "9d6cf783842c1b54690901b981a3536e900867e2c3aa7985a0570a9ae9cfddf8",
       "tx_index": 0,
       "type": "registry.node"
@@ -607,6 +624,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:30Z",
       "tx_hash": "75ed5bf7481197a3e6b49a060ec5c019afe8d5bff1f7fb11fa732b35b09f2d46",
       "tx_index": 0,
       "type": "registry.node"
@@ -618,6 +636,7 @@
         "from": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5",
         "to": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv"
       },
+      "timestamp": "2023-11-29T17:55:30Z",
       "tx_hash": "f5ebd2503d74e5f1b885805b115f97692002d71abc2abd5781cbf43fabf06039",
       "tx_index": 1,
       "type": "staking.transfer"
@@ -684,6 +703,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:24Z",
       "tx_hash": "9147cd24744f09c081c1bc00be15503a94f7f449e69f8ecafe3b3970269632be",
       "tx_index": 0,
       "type": "registry.node"
@@ -750,6 +770,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:55:07Z",
       "tx_hash": "ee1ddca063880f803aaee70e4deebd5973385b9519be980fdce8ccd771eb78a0",
       "tx_index": 0,
       "type": "registry.node"
@@ -761,6 +782,7 @@
         "from": "oasis1qrd2fcg229qtzpztpgp78z03hjcjuanr5y8dr8pq",
         "to": "oasis1qq0fe6n4nhykr8w9psgerfcrqvy4atq425jrfnyt"
       },
+      "timestamp": "2023-11-29T17:53:13Z",
       "tx_hash": "1aaab13919b6340510d2fc74d0761f288673074c794b02b71afaa5b79451e931",
       "tx_index": 1,
       "type": "staking.transfer"
@@ -827,6 +849,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:51:41Z",
       "tx_hash": "df6c8f85849e1b09149af22a4f6ae93aa31c07ffb59f34cb2c629baed7209b86",
       "tx_index": 0,
       "type": "registry.node"
@@ -870,6 +893,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:50:33Z",
       "tx_hash": "5f3a49623e13588491f13f7a5cb04798d2a44601e47733885721a0740bef3a55",
       "tx_index": 0,
       "type": "registry.node"
@@ -881,6 +905,7 @@
         "from": "oasis1qrd2fcg229qtzpztpgp78z03hjcjuanr5y8dr8pq",
         "to": "oasis1qzyf6wvfjv9aa97zg4r505cpemmjgjnlgs8zpcm0"
       },
+      "timestamp": "2023-11-29T17:49:02Z",
       "tx_hash": "96566db06b13df71d8104a7207a3da695f78325903affed58b422c9a6d497cae",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -924,6 +949,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:48:40Z",
       "tx_hash": "8b02981270c48f20bef114d6f2e1e7dca1fa53d15d1fe58d087ca801640c178d",
       "tx_index": 0,
       "type": "registry.node"
@@ -967,6 +993,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:48:11Z",
       "tx_hash": "fa73d47cee85d4d4d52af24890ee4dd150c687addeadf955c19cb07de8fb8947",
       "tx_index": 0,
       "type": "registry.node"
@@ -1010,6 +1037,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:48:00Z",
       "tx_hash": "4438074d3b635e9590d1cced7554e9dd7b883099dcc31926a123efd25c6e73a5",
       "tx_index": 0,
       "type": "registry.node"
@@ -1021,6 +1049,7 @@
         "from": "oasis1qzyf6wvfjv9aa97zg4r505cpemmjgjnlgs8zpcm0",
         "to": "oasis1qrd2fcg229qtzpztpgp78z03hjcjuanr5y8dr8pq"
       },
+      "timestamp": "2023-11-29T17:47:43Z",
       "tx_hash": "3c27aa650edbb1550743ffeb722c6bf845850ac935b10111a88911d3bf842b44",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -1064,6 +1093,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:47:14Z",
       "tx_hash": "6c23e141b1134bc5634ee2e498a36d04fea41cc992ec1fd599c25c768d2975da",
       "tx_index": 0,
       "type": "registry.node"
@@ -1075,6 +1105,7 @@
         "from": "oasis1qrd2fcg229qtzpztpgp78z03hjcjuanr5y8dr8pq",
         "to": "oasis1qzyf6wvfjv9aa97zg4r505cpemmjgjnlgs8zpcm0"
       },
+      "timestamp": "2023-11-29T17:46:23Z",
       "tx_hash": "bb64a82ac38425c0ad6fabc964a46e92ab1950ff386929193983b0e8204b2a60",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -1087,6 +1118,7 @@
         "new_shares": "1519645003597",
         "owner": "oasis1qqthsryzpzsgav9cf6cmhtxhv0p7kpt4dcs8gp6a"
       },
+      "timestamp": "2023-11-29T17:46:17Z",
       "tx_hash": "06b0c3e68f71bf92bdf967d986fe87a05b69cee0bd4dc47b8fe88249b9de5adb",
       "tx_index": 0,
       "type": "staking.escrow.add"
@@ -1137,6 +1169,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:46:00Z",
       "tx_hash": "06ffacb637d503785b5bb6fddad2ddeb29a9d72e8a37add3bb1a74c46aa2270a",
       "tx_index": 0,
       "type": "registry.node"
@@ -1173,6 +1206,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:45:43Z",
       "tx_hash": "d4742faf175eac52d08e991d2b222da8010ccc7865b58c943d72c1d7dc68024d",
       "tx_index": 0,
       "type": "registry.node"
@@ -1185,6 +1219,7 @@
         "new_shares": "1605611256976",
         "owner": "oasis1qqthsryzpzsgav9cf6cmhtxhv0p7kpt4dcs8gp6a"
       },
+      "timestamp": "2023-11-29T17:45:32Z",
       "tx_hash": "216a7fba64087134fe283dbbc163900ef05a510813873a4e0ebd65e4efa80283",
       "tx_index": 0,
       "type": "staking.escrow.add"
@@ -1236,6 +1271,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:45:03Z",
       "tx_hash": "10c41c166f47eecbe99e9635517f6272b932924db553f3119e3343da28da1215",
       "tx_index": 0,
       "type": "registry.node"
@@ -1279,6 +1315,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:43:44Z",
       "tx_hash": "33192433cc07b7fd31ade8fba6bce8470937346db09052b712ee9664097688cc",
       "tx_index": 0,
       "type": "registry.node"
@@ -1315,6 +1352,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:43:44Z",
       "tx_hash": "9759d29ad55660864d70a61cec1f40af4ba9b97fe66aae7ffa48738e66e97744",
       "tx_index": 1,
       "type": "registry.node"
@@ -1358,6 +1396,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:43:21Z",
       "tx_hash": "82ee3b9842b1e6e1179e8fd3410f44f8f925db2a3762d055e9bfd794017eba05",
       "tx_index": 0,
       "type": "registry.node"
@@ -1370,6 +1409,7 @@
         "new_shares": "1647037706009",
         "owner": "oasis1qqthsryzpzsgav9cf6cmhtxhv0p7kpt4dcs8gp6a"
       },
+      "timestamp": "2023-11-29T17:42:53Z",
       "tx_hash": "2ca80d5f4472d449abec7d1f06c374208838c27015c156e27cbebe1e2647cff5",
       "tx_index": 0,
       "type": "staking.escrow.add"
@@ -1406,6 +1446,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:42:30Z",
       "tx_hash": "7f6ba260695e96a25193387c5379bf48a760674d9e9d43831474d39bd5c22b75",
       "tx_index": 0,
       "type": "registry.node"
@@ -1418,6 +1459,7 @@
         "new_shares": "1519249200867",
         "owner": "oasis1qqthsryzpzsgav9cf6cmhtxhv0p7kpt4dcs8gp6a"
       },
+      "timestamp": "2023-11-29T17:41:39Z",
       "tx_hash": "1e58d4c994aa48603485c314c144a2a3aac7857c48b1c7023275cc4335b62187",
       "tx_index": 1,
       "type": "staking.escrow.add"
@@ -1484,6 +1526,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:41:16Z",
       "tx_hash": "0da240fb6029ea361fbb3e8904d459e2ccf55a9fa0d94039983fc992525cbbba",
       "tx_index": 1,
       "type": "registry.node"
@@ -1496,6 +1539,7 @@
         "new_shares": "1498526019602",
         "owner": "oasis1qqthsryzpzsgav9cf6cmhtxhv0p7kpt4dcs8gp6a"
       },
+      "timestamp": "2023-11-29T17:40:19Z",
       "tx_hash": "bfc41076808dddf8c78f73717369c81c8ebe466e026302fb20e04cdf3904aa95",
       "tx_index": 0,
       "type": "staking.escrow.add"
@@ -1507,6 +1551,7 @@
         "from": "oasis1qzrycs7qhh455dj0nwzfd3y5um4m7f2p75yksjvh",
         "to": "oasis1qqv9tknl8afkxkzszwl80g3wz80f2w8u0g502ewc"
       },
+      "timestamp": "2023-11-29T17:39:00Z",
       "tx_hash": "57f2a498e91dd594b011a7ab1ed1578abb1b32d0925d3f917b5ae85f552c76ce",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -1518,6 +1563,7 @@
         "from": "oasis1qqv9tknl8afkxkzszwl80g3wz80f2w8u0g502ewc",
         "to": "oasis1qzrycs7qhh455dj0nwzfd3y5um4m7f2p75yksjvh"
       },
+      "timestamp": "2023-11-29T17:39:00Z",
       "tx_hash": "4013e7930e90d0ec0ec7311e97946fd8572000c7c9d4bf82db4787fc0020094a",
       "tx_index": 1,
       "type": "staking.transfer"
@@ -1569,6 +1615,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:38:48Z",
       "tx_hash": "6624bcb61e2e311c774be3bc46e46c654e1e906f144f2d96fe689142d90506da",
       "tx_index": 0,
       "type": "registry.node"
@@ -1580,6 +1627,7 @@
         "from": "oasis1qp0pnt30vjr4uk3szcwvnxfteffwpvlqyudrqg7z",
         "to": "oasis1qpvwrl0l4zndtq652n4mh9n6h05mfpfrdse7nxjm"
       },
+      "timestamp": "2023-11-29T17:38:25Z",
       "tx_hash": "d28c90d1d17508af035d9eb05ade6da6cb95d6c99e1fb90891506da363e6b913",
       "tx_index": 0,
       "type": "staking.transfer"
@@ -1623,6 +1671,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:38:02Z",
       "tx_hash": "cb4123790a024dd950d7aaa1b4bac521cd9c77844fca2623a8acd7ebeb5eada1",
       "tx_index": 0,
       "type": "registry.node"
@@ -1673,6 +1722,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:37:51Z",
       "tx_hash": "ba9972c6a0dd195c547879f4473f86de99864703a5e8c0e4b93a5e7852acfea4",
       "tx_index": 0,
       "type": "registry.node"
@@ -1723,6 +1773,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:37:45Z",
       "tx_hash": "8cd139698bbdfea848bc4b158263c5626e2e7def28bf25ff301538c8c46bae4c",
       "tx_index": 0,
       "type": "registry.node"
@@ -1766,6 +1817,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:36:32Z",
       "tx_hash": "0ab99a11acaa1d97483d02bf4ce1832a6b3ea7cbb993b796d1bf518ba0b1e690",
       "tx_index": 0,
       "type": "registry.node"
@@ -1840,6 +1892,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:35:18Z",
       "tx_hash": "30feb340597cebb04b2050a2ae79c4f383ff5817d070293b0da232fdcb73a343",
       "tx_index": 0,
       "type": "registry.node"
@@ -1883,6 +1936,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:55Z",
       "tx_hash": "ede2a4e0e7aefb76ef7c25add1668f42abf38e71109fd5d35e4ccc3b93287505",
       "tx_index": 0,
       "type": "registry.node"
@@ -1919,6 +1973,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:55Z",
       "tx_hash": "b87f586fe749bc6838baf4d0e15dfd47abe9ee03c2ed67b16bec665150843127",
       "tx_index": 1,
       "type": "registry.node"
@@ -1955,6 +2010,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:55Z",
       "tx_hash": "0d422ce917be73e0ebb6c4e69f3c35ae7992299c1dddbebc2ed3b434ad415ca4",
       "tx_index": 2,
       "type": "registry.node"
@@ -1991,6 +2047,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:49Z",
       "tx_hash": "614593179cd5304b1c18f28e2b52709cd7386d0e0e6558886a24fd68a8c2457c",
       "tx_index": 0,
       "type": "registry.node"
@@ -2027,6 +2084,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:49Z",
       "tx_hash": "9db9070966d02afe886d27a766049796fa886f7a646cd18a696b30e1f797928e",
       "tx_index": 1,
       "type": "registry.node"
@@ -2063,6 +2121,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:44Z",
       "tx_hash": "93d6282e4fd4a5d2bbbbfdb37b1ad17c136a77277f2ead373a3d72b35abc268a",
       "tx_index": 0,
       "type": "registry.node"
@@ -2099,6 +2158,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:44Z",
       "tx_hash": "955047ea6caad0072547704e216a97bec87a7c9cdd0d8acdb460dc32baaa618f",
       "tx_index": 1,
       "type": "registry.node"
@@ -2135,6 +2195,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:44Z",
       "tx_hash": "e5f7d2ee8c2e0e32d84b26c92d47e8816e70abbc3cae5af9a6857fc55b7619e6",
       "tx_index": 2,
       "type": "registry.node"
@@ -2171,6 +2232,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:38Z",
       "tx_hash": "d7f3bf5a2434031d64f647abd4e266464508820c17b959eb9d4d56f6237817d9",
       "tx_index": 0,
       "type": "registry.node"
@@ -2207,6 +2269,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:38Z",
       "tx_hash": "4bf9a38b8a5a0b1203407ea9377593e1187acc04594ac0abc5e1c7b9b8f15762",
       "tx_index": 1,
       "type": "registry.node"
@@ -2243,6 +2306,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:38Z",
       "tx_hash": "bcfae9979ad714aaab5c7ded3bc4a5f6f702820b9452c81da29447c6c57bd725",
       "tx_index": 2,
       "type": "registry.node"
@@ -2279,6 +2343,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:38Z",
       "tx_hash": "4472f2ce5655a5933fb188f16ae990ba1d7335a1014c918cb1f6d3920a489ca7",
       "tx_index": 3,
       "type": "registry.node"
@@ -2315,6 +2380,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:32Z",
       "tx_hash": "bf3bc90299d7e7d44bf2440bbc83440f1ffe078eb8c00a617809286bd99855f8",
       "tx_index": 0,
       "type": "registry.node"
@@ -2351,6 +2417,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:27Z",
       "tx_hash": "b55265e124b8d56e96385e16b0178eebbe05a8b5371e79e22682a7d36bd02a00",
       "tx_index": 0,
       "type": "registry.node"
@@ -2387,6 +2454,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:27Z",
       "tx_hash": "146ad7b5f6a55f504449268bb8fc0d1a841faae2af6dcae90c46f13b81966d36",
       "tx_index": 1,
       "type": "registry.node"
@@ -2423,6 +2491,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:27Z",
       "tx_hash": "04b8673ddc3b7d9e4b6dc2a96a4a6afa6560e8f51042f9e20fc55df27dde5430",
       "tx_index": 2,
       "type": "registry.node"
@@ -2459,6 +2528,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:27Z",
       "tx_hash": "7ec83da1790324b3167bfd88823fa6fc4bf564cd76fb0c57a33b9fbc1c593bc3",
       "tx_index": 3,
       "type": "registry.node"
@@ -2495,6 +2565,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:27Z",
       "tx_hash": "7fa20a6e2178a8a1044859572c295485b63678ba23f0ad832dbdd24c3851f5d3",
       "tx_index": 4,
       "type": "registry.node"
@@ -2538,6 +2609,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:21Z",
       "tx_hash": "b222826b278e89154e3ab3caffc149e7533a68066498cf4cba1cc0165674ec50",
       "tx_index": 0,
       "type": "registry.node"
@@ -2574,6 +2646,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:21Z",
       "tx_hash": "190b12bb45e552182d1f182952c659732deec06980f90a214b7a494194c345b9",
       "tx_index": 1,
       "type": "registry.node"
@@ -2610,6 +2683,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:21Z",
       "tx_hash": "0903d45619a320cc1a878eda38d3ff7f7868a3cd453211cf3d1a3e05b6db3ead",
       "tx_index": 2,
       "type": "registry.node"
@@ -2660,6 +2734,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:21Z",
       "tx_hash": "bf11756a0fb1626eb30c88d4e610295ef2fa6c834df381438095b7d8dc0cd0df",
       "tx_index": 3,
       "type": "registry.node"
@@ -2696,6 +2771,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:15Z",
       "tx_hash": "bebf99b70cac935cdf6ed3b4b7a95ad735a3031e5c95ed3017370a9098b885f1",
       "tx_index": 0,
       "type": "registry.node"
@@ -2732,6 +2808,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:15Z",
       "tx_hash": "af7dd63830e47e15506cd6accc22e200000686143f3008b700283aff1f28ee5a",
       "tx_index": 1,
       "type": "registry.node"
@@ -2775,6 +2852,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:15Z",
       "tx_hash": "3bac7d908548e33f21b3cdc880441c4db2647eac3dd89864534b17977874baaf",
       "tx_index": 2,
       "type": "registry.node"
@@ -2825,6 +2903,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:15Z",
       "tx_hash": "9efacbb5760d6d5a9ddeae294c52ea0eb31d521ea923f190ead36ab01e36330b",
       "tx_index": 3,
       "type": "registry.node"
@@ -2861,6 +2940,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:10Z",
       "tx_hash": "bb5b041c1872d2661019eb1b66ecfc3553ebcdcc05c949848451ef1a5c2ca0dd",
       "tx_index": 0,
       "type": "registry.node"
@@ -2897,6 +2977,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:04Z",
       "tx_hash": "9534dd53aad84b5f0d0a7f1b9711a7a07b9e7225a030f6e68c83aa49fde8f7a5",
       "tx_index": 0,
       "type": "registry.node"
@@ -2940,6 +3021,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:04Z",
       "tx_hash": "5ccd4262d0af7205c93b5e2cb7e050c921e91d30ac638e6f2f9a79772227cc7c",
       "tx_index": 1,
       "type": "registry.node"
@@ -2983,6 +3065,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:04Z",
       "tx_hash": "f19fc31e0506e258efc42842cb920b95445d7aea7520240d0e1114e75be6b3bd",
       "tx_index": 2,
       "type": "registry.node"
@@ -3019,6 +3102,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:34:04Z",
       "tx_hash": "e638f6a6e917619482b4acc12f25ce52dc8f0b8fed2acda8ed86a6305e685167",
       "tx_index": 3,
       "type": "registry.node"
@@ -3055,6 +3139,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:58Z",
       "tx_hash": "f0375e47ea5440d6ca0d0b19efa9d92fccb5a9162be66162821232577531c2cd",
       "tx_index": 0,
       "type": "registry.node"
@@ -3091,6 +3176,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:58Z",
       "tx_hash": "61fea249b8e6949c5aafe901ec4f64f391c78cd94416f39d106a64f2a8627125",
       "tx_index": 1,
       "type": "registry.node"
@@ -3127,6 +3213,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:58Z",
       "tx_hash": "e72d2e2743ee6f24b157a8999a2103353c154305dee990a3a386f43a9cee27d2",
       "tx_index": 2,
       "type": "registry.node"
@@ -3163,6 +3250,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:52Z",
       "tx_hash": "119bd4cdd4a6e6f13bc42a09946bb7f6827ca204c503aa8c2d55284d311501a2",
       "tx_index": 0,
       "type": "registry.node"
@@ -3206,6 +3294,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:52Z",
       "tx_hash": "977916948c31bff88aba010247cd011290a033947b3783343fc1d19d84ac52d6",
       "tx_index": 1,
       "type": "registry.node"
@@ -3242,6 +3331,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:52Z",
       "tx_hash": "2a3e92e933aeab58b1d87dcb59decb607a6b7d87e8b47581652abb80d90ae810",
       "tx_index": 2,
       "type": "registry.node"
@@ -3278,6 +3368,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:47Z",
       "tx_hash": "ae85e41ebe1f00566c8d416556fd2d37ff3ce350116393843492bbfd1d2da727",
       "tx_index": 0,
       "type": "registry.node"
@@ -3314,6 +3405,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:47Z",
       "tx_hash": "d5a7eb0fdc690d3722d6aff4a44062b39bf921a59c9781cdd486673b7d42153e",
       "tx_index": 1,
       "type": "registry.node"
@@ -3350,6 +3442,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:47Z",
       "tx_hash": "61bdcdc522d2a7ba4a8ba1da1d816c971712c37e59e359e725674ac4a5936b40",
       "tx_index": 2,
       "type": "registry.node"
@@ -3393,6 +3486,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:47Z",
       "tx_hash": "3a449b1eea3375b5f37de367be1ac5b5a190bce995b0ea45fcf0cc325c1325e6",
       "tx_index": 3,
       "type": "registry.node"
@@ -3429,6 +3523,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "e43b9f622b623502334f3fe0da45598933d2d5a2bbf08120fb8a0f6133b1ea92",
       "tx_index": 0,
       "type": "registry.node"
@@ -3465,6 +3560,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "bf6c33142262f6485de4fd0be1a93b220845fbbabf731b07a8dcb5ff9b0ff783",
       "tx_index": 1,
       "type": "registry.node"
@@ -3501,6 +3597,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "8f1b7c4148d75f250f93a1fee3ea072ea5bb4b0c4a3b1873836476388621840d",
       "tx_index": 2,
       "type": "registry.node"
@@ -3537,6 +3634,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "41a00e92c255b8ba5dce3ce2c68748962039edfedfddc9de4701659d720c463d",
       "tx_index": 3,
       "type": "registry.node"
@@ -3573,6 +3671,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "63b42ad80b1626814e050bc3c53e8521a73027dcdb240d6a19ac1a71e5d84065",
       "tx_index": 4,
       "type": "registry.node"
@@ -3616,6 +3715,7 @@
           }
         }
       },
+      "timestamp": "2023-11-29T17:33:41Z",
       "tx_hash": "40800328cf4bd8e2522e1df18621fbe32f09d8361231c27b5a3032230ada198f",
       "tx_index": 5,
       "type": "registry.node"


### PR DESCRIPTION
Having events timestamps is useful; it also unifies the API with runtime events, which already contain timestamps.

TODO:
- [x] update E2E tests