### PR TITLE
analyzer: configurable MaxBackoffTimeout

### DIFF
--- a/.changelog/837.feature.md
+++ b/.changelog/837.feature.md
@@ -1,0 +1,1 @@
+analyzers: add configurable `MaxBackoffTimeout`

--- a/analyzer/item/item_test.go
+++ b/analyzer/item/item_test.go
@@ -40,7 +40,7 @@ const (
 		GRANT SELECT ON ALL TABLES IN SCHEMA analysis TO PUBLIC`
 
 	testItemInsert = `
-		INSERT INTO analysis.item_analyzer_test(id) 
+		INSERT INTO analysis.item_analyzer_test(id)
 			VALUES ($1)`
 
 	testItemCounts = `
@@ -54,6 +54,7 @@ var testItemBasedConfig = &config.ItemBasedAnalyzerConfig{
 	StopIfQueueEmptyFor: time.Second,
 	Interval:            0, // use backoff
 	InterItemDelay:      0,
+	MaxBackoffTime:      0,
 }
 
 type mockItem struct {

--- a/analyzer/validatorstakinghistory/validatorstakinghistory.go
+++ b/analyzer/validatorstakinghistory/validatorstakinghistory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -53,6 +54,12 @@ func NewAnalyzer(
 	logger *log.Logger,
 ) (analyzer.Analyzer, error) {
 	logger = logger.With("analyzer", validatorHistoryAnalyzerName)
+
+	if cfg.MaxBackoffTime == 0 {
+		// Once caught up we will receive work only after epochs are finalized,
+		// so increase the maximum backoff timeout a bit.
+		cfg.MaxBackoffTime = 5 * time.Minute
+	}
 
 	// Find the epoch corresponding to startHeight.
 	if startHeight > math.MaxInt64 {

--- a/config/config.go
+++ b/config/config.go
@@ -487,6 +487,11 @@ type ItemBasedAnalyzerConfig struct {
 	// new goroutines to process items within a batch. This is useful for cases where
 	// processItem() makes out of band requests to rate limited resources.
 	InterItemDelay time.Duration `koanf:"inter_item_delay"`
+
+	// MaxBackoffTime determines the maximum backoff time the analyzer will use when
+	// processing items. This is useful for cases where the expected analyzer cadence
+	// is different from the consensus block time (e.g. 6 seconds).
+	MaxBackoffTime time.Duration `koanf:"max_backoff_time"`
 }
 
 type EvmTokensAnalyzerConfig struct {

--- a/tests/e2e_regression/damask/e2e_config_2.yml
+++ b/tests/e2e_regression/damask/e2e_config_2.yml
@@ -20,7 +20,7 @@ analysis:
     evm_contract_code_emerald:     { stop_if_queue_empty_for: 1s }
     evm_abi_emerald:               { stop_if_queue_empty_for: 10s } # Give evm_contract_verifier time to fetch ABIs first. The 10s has been enough in practice, but might need to be tuned in the future, espcially if the caching proxy has an empty cache.
     evm_contract_verifier_emerald: { stop_if_queue_empty_for: 1s, sourcify_server_url: http://localhost:9191 }
-    validator_staking_history:     { from: 8_048_956, stop_if_queue_empty_for: 1s }
+    validator_staking_history:     { from: 8_048_956, stop_if_queue_empty_for: 1s, max_backoff_time: 6s }
     # Some non-block analyzers are not tested in e2e regressions.
     # They are largely not worth the trouble as they do not interact with rest of the system much.
     # metadata_registry: {} # Awkward to inject mock registry responses.

--- a/tests/e2e_regression/eden/e2e_config_2.yml
+++ b/tests/e2e_regression/eden/e2e_config_2.yml
@@ -20,7 +20,7 @@ analysis:
     evm_contract_code_emerald:     { stop_if_queue_empty_for: 1s }
     evm_abi_emerald:               { stop_if_queue_empty_for: 10s } # Give evm_contract_verifier time to fetch ABIs first. The 10s has been enough in practice, but might need to be tuned in the future, espcially if the caching proxy has an empty cache.
     evm_contract_verifier_emerald: { stop_if_queue_empty_for: 1s, sourcify_server_url: http://localhost:9191 }
-    validator_staking_history:     { from: 16_817_956, stop_if_queue_empty_for: 1s }
+    validator_staking_history:     { from: 16_817_956, stop_if_queue_empty_for: 1s, max_backoff_time: 6s }
     # Some non-block analyzers are not tested in e2e regressions.
     # They are largely not worth the trouble as they do not interact with rest of the system much.
     # metadata_registry: {} # Awkward to inject mock registry responses.

--- a/tests/e2e_regression/edenfast/e2e_config_2.yml
+++ b/tests/e2e_regression/edenfast/e2e_config_2.yml
@@ -20,7 +20,7 @@ analysis:
     evm_contract_code_emerald:     { stop_if_queue_empty_for: 1s }
     evm_abi_emerald:               { stop_if_queue_empty_for: 10s } # Give evm_contract_verifier time to fetch ABIs first. The 10s has been enough in practice, but might need to be tuned in the future, espcially if the caching proxy has an empty cache.
     evm_contract_verifier_emerald: { stop_if_queue_empty_for: 1s, sourcify_server_url: http://localhost:9191 }
-    validator_staking_history:     { from: 16_817_956, stop_if_queue_empty_for: 1s }
+    validator_staking_history:     { from: 16_817_956, stop_if_queue_empty_for: 1s, max_backoff_time: 6s }
     # Some non-block analyzers are not tested in e2e regressions.
     # They are largely not worth the trouble as they do not interact with rest of the system much.
     # metadata_registry: {} # Awkward to inject mock registry responses.


### PR DESCRIPTION
This adds a configurable `MaxBackoffTime` to analyzers. This is useful for analyzers such as `validatorstakinghistory`, where once caught up, we only expect new work on epoch transitions and don't need to query every 6 seconds.

Additional note: the queries for fetching `validatorstakinghistory` work are not the most efficient (take ~2 seconds). I noticed this because these queries are currently using a lot of the database's CPUs—even if there's no work to be done. The idea is that with the `MaxBackoffTime` change, we don't need to bloat the DB with additional indexes and just be smarter about how frequently we do the queries.

Alternatives considered:
- We could manually update the deployment configuration for `validatorstakinghistory` to use a "fixed-interval" once caught up. But if the analyzer falls behind (for whatever reason. e.g. node downtime etc) we would need manual intervention again to update the config. With implemented solution it should recover automatically and use a shorter timeout if there's more work to do.

- "Epoch"-aware Item analyzer. If the ItemAnalyzer would be aware of epochs, it could then know when to call the analyzer if it is caught up. However this solution would require more (non-trivial) work to implement, which doesn't seem worth for this specific case. 