### PR TITLE
storage: optimize RuntimeEvmVerifiedContractEvents query

### DIFF
--- a/.changelog/838.feature.md
+++ b/.changelog/838.feature.md
@@ -1,0 +1,4 @@
+Optimize `RuntimeEvmVerifiedContractEvents` query
+
+Optimizes the query by switching DECODE to ENCODE for address comparison
+to leverage existing indexes on `chain.runtime_events` table.

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -1143,7 +1143,7 @@ var (
     JOIN chain.runtime_events as evs ON
       evs.type = 'evm.log' AND
       evs.runtime = abi_contracts.runtime AND
-      decode(body->>'address', 'base64') = preimages.address_data
+      body->>'address' = encode(preimages.address_data, 'base64')
     WHERE
       (evs.abi_parsed_at IS NULL OR evs.abi_parsed_at < abi_contracts.verification_info_downloaded_at)
     LIMIT $2`


### PR DESCRIPTION
Optimize `RuntimeEvmVerifiedContractEvents` query by switching DECODE to ENCODE for address comparison to leverage existing indexes on `chain.runtime_events`.

The query benefits a bit by partially using  `ix_runtime_events_evm_specific_contract_events`.