### PR TITLE
Release followup updates

### DIFF
--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -15,6 +15,10 @@ on:
       - CHANGELOG.md
   workflow_dispatch:  # manual; for debugging workflow before merging branch into `main`
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build-docker:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+*'
 
 permissions:
+  packages: write
   contents: write
 
 jobs:

--- a/analyzer/util/util.go
+++ b/analyzer/util/util.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	timeoutUpperBound = 60 * time.Second
+	timeoutUpperBound = 60 * time.Minute
 	// SHA256 of empty string.
 	// oasis-core tags event that are not associated with any real transactions.
 	// For example, the DebondingStart escrow event.


### PR DESCRIPTION
- Since we added configurable max backoff timeout, we should increase the internal upper bound as well: https://github.com/oasisprotocol/nexus/pull/837
- Fix release action permissions