### PR TITLE
api/runtime/transactions: Add signers field to response

### DIFF
--- a/.changelog/885.feature.md
+++ b/.changelog/885.feature.md
@@ -1,0 +1,4 @@
+api/runtime/transactions: Add signers field to response
+
+Signers contain information about the transaction signers. Existing sender_0,
+sender_0_eth and nonce_0 fields are deprecated and will be removed in future.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2914,7 +2914,7 @@ components:
     RuntimeTransaction:
       type: object
       # NOTE: Not guaranteed to be present: eth_hash, to, amount.
-      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, fee_symbol, charged_fee, gas_limit, gas_used, size]
+      required: [round, index, timestamp, hash, signers, sender_0, nonce_0, fee, fee_symbol, charged_fee, gas_limit, gas_used, size]
       properties:
         round:
           type: integer
@@ -2942,24 +2942,34 @@ components:
             The Ethereum cryptographic hash of this transaction's encoding.
             Absent for non-Ethereum-format transactions.
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
+        signers:
+          type: array
+          items:
+            allOf: [$ref: '#/components/schemas/RuntimeTransactionSigner']
+          description: The signers of this transaction.
         sender_0:
           allOf: [$ref: '#/components/schemas/Address']
+          deprecated: true
           description: |
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
             However, the great majority of transactions only have a single signer in practice.
-            Retrieving the other signers is currently not supported by this API.
-          # NOTE: To expose the other signers, use the transaction_signers table.
+            DEPRECATED: This field will be removed in the future in favor of the signers field.
           example: oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd
         sender_0_eth:
           type: string
+          deprecated: true
           description: |
             The Ethereum address of this transaction's 0th signer.
+            DEPRECATED: This field will be removed in the future in favor of the signers field.
           example: *eth_address_1
         nonce_0:
           type: integer
           format: uint64
-          description: The nonce used with this transaction's 0th signer, to prevent replay.
+          deprecated: true
+          description: |
+            The nonce used with this transaction's 0th signer, to prevent replay.
+            DEPRECATED: This field will be removed in the future in favor of the signers field.
           example: 114194
         fee:
           type: string
@@ -3128,6 +3138,26 @@ components:
           type: string
           format: byte
           description: The base64-encoded encrypted result data.
+
+    RuntimeTransactionSigner:
+      type: object
+      required: [address, nonce]
+      properties:
+        address:
+          allOf: [$ref: '#/components/schemas/Address']
+          description: |
+            The Oasis address of the transaction signer.
+          example: oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd
+        address_eth:
+          type: string
+          description: |
+            The Ethereum address of this transaction signer.
+          example: *eth_address_1
+        nonce:
+          type: integer
+          format: uint64
+          description: The transaction signer nonce.
+          example: 114194
 
     RuntimeAccount:
       type: object

--- a/tests/e2e_regression/eden/expected/emerald_failed_tx.body
+++ b/tests/e2e_regression/eden/expected/emerald_failed_tx.body
@@ -27,6 +27,13 @@
       "round": 8059465,
       "sender_0": "oasis1qr9ak7ck2fs3pscs635gapk96ncl02yyxggrqgq5",
       "sender_0_eth": "0x7274e8a2F8C599a1265651037e0da68C5ECa06bD",
+      "signers": [
+        {
+          "address": "oasis1qr9ak7ck2fs3pscs635gapk96ncl02yyxggrqgq5",
+          "address_eth": "0x7274e8a2F8C599a1265651037e0da68C5ECa06bD",
+          "nonce": 31228
+        }
+      ],
       "size": 205,
       "success": false,
       "timestamp": "2023-12-12T08:40:35Z",

--- a/tests/e2e_regression/eden/expected/emerald_tx.body
+++ b/tests/e2e_regression/eden/expected/emerald_tx.body
@@ -23,6 +23,13 @@
       "round": 8060338,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063641
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:06:38Z",

--- a/tests/e2e_regression/eden/expected/emerald_txs.body
+++ b/tests/e2e_regression/eden/expected/emerald_txs.body
@@ -23,6 +23,13 @@
       "round": 8060338,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063641
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:06:38Z",
@@ -50,6 +57,13 @@
       "round": 8060336,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063640
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:06:26Z",
@@ -77,6 +91,13 @@
       "round": 8060334,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063639
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:06:15Z",
@@ -104,6 +125,12 @@
       "nonce_0": 201377,
       "round": 8060332,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201377
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T10:06:03Z",
@@ -131,6 +158,13 @@
       "round": 8060332,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063638
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:06:03Z",
@@ -158,6 +192,13 @@
       "round": 8060330,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343084
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T10:05:51Z",
@@ -185,6 +226,13 @@
       "round": 8060330,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063637
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:05:51Z",
@@ -212,6 +260,13 @@
       "round": 8060328,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063636
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:05:40Z",
@@ -239,6 +294,13 @@
       "round": 8060326,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063635
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:05:28Z",
@@ -266,6 +328,13 @@
       "round": 8060324,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063634
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:05:16Z",
@@ -292,6 +361,13 @@
       "round": 8060323,
       "sender_0": "oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l",
       "sender_0_eth": "0xA3BD5b36659781AF4729c95c19003924ca3EF966",
+      "signers": [
+        {
+          "address": "oasis1qzlqgyqp2fjla8r6rf5k3dd0k0qada9n5vyu4h3l",
+          "address_eth": "0xA3BD5b36659781AF4729c95c19003924ca3EF966",
+          "nonce": 3
+        }
+      ],
       "size": 430,
       "success": true,
       "timestamp": "2023-12-12T10:05:11Z",
@@ -319,6 +395,13 @@
       "round": 8060322,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063633
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:05:05Z",
@@ -346,6 +429,13 @@
       "round": 8060320,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063632
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:04:53Z",
@@ -374,6 +464,13 @@
       "round": 8060319,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199119
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T10:04:47Z",
@@ -400,6 +497,13 @@
       "round": 8060318,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063631
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:04:41Z",
@@ -427,6 +531,13 @@
       "round": 8060317,
       "sender_0": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
       "sender_0_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+      "signers": [
+        {
+          "address": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
+          "address_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+          "nonce": 350001
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T10:04:35Z",
@@ -454,6 +565,13 @@
       "round": 8060316,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063630
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:04:29Z",
@@ -481,6 +599,13 @@
       "round": 8060314,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063629
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:04:18Z",
@@ -508,6 +633,13 @@
       "round": 8060312,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063628
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:04:06Z",
@@ -535,6 +667,13 @@
       "round": 8060310,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063627
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:03:54Z",
@@ -562,6 +701,13 @@
       "round": 8060308,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063626
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:03:43Z",
@@ -589,6 +735,12 @@
       "nonce_0": 201376,
       "round": 8060306,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201376
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T10:03:31Z",
@@ -616,6 +768,13 @@
       "round": 8060306,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063625
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:03:31Z",
@@ -643,6 +802,13 @@
       "round": 8060305,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343083
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T10:03:25Z",
@@ -670,6 +836,13 @@
       "round": 8060304,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063624
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:03:19Z",
@@ -697,6 +870,13 @@
       "round": 8060302,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063623
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:03:07Z",
@@ -725,6 +905,13 @@
       "round": 8060300,
       "sender_0": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
       "sender_0_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+      "signers": [
+        {
+          "address": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
+          "address_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+          "nonce": 217
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T10:02:55Z",
@@ -751,6 +938,13 @@
       "round": 8060300,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063622
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:02:55Z",
@@ -778,6 +972,13 @@
       "round": 8060298,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063621
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:02:44Z",
@@ -805,6 +1006,13 @@
       "round": 8060296,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063620
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:02:32Z",
@@ -832,6 +1040,13 @@
       "round": 8060294,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063619
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:02:20Z",
@@ -860,6 +1075,13 @@
       "round": 8060293,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199118
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T10:02:14Z",
@@ -886,6 +1108,13 @@
       "round": 8060292,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063618
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:02:08Z",
@@ -913,6 +1142,13 @@
       "round": 8060292,
       "sender_0": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
       "sender_0_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+      "signers": [
+        {
+          "address": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
+          "address_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+          "nonce": 350000
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T10:02:08Z",
@@ -940,6 +1176,13 @@
       "round": 8060290,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063617
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:01:57Z",
@@ -967,6 +1210,13 @@
       "round": 8060288,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063616
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:01:45Z",
@@ -994,6 +1244,13 @@
       "round": 8060286,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063615
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:01:33Z",
@@ -1021,6 +1278,13 @@
       "round": 8060284,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063614
+        }
+      ],
       "size": 135,
       "success": true,
       "timestamp": "2023-12-12T10:01:21Z",
@@ -1048,6 +1312,13 @@
       "round": 8060282,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063613
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:01:10Z",
@@ -1075,6 +1346,12 @@
       "nonce_0": 201375,
       "round": 8060281,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201375
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T10:01:04Z",
@@ -1102,6 +1379,13 @@
       "round": 8060280,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063612
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:00:58Z",
@@ -1129,6 +1413,13 @@
       "round": 8060279,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343082
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T10:00:52Z",
@@ -1155,6 +1446,13 @@
       "round": 8060278,
       "sender_0": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
       "sender_0_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+      "signers": [
+        {
+          "address": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
+          "address_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+          "nonce": 216
+        }
+      ],
       "size": 431,
       "success": true,
       "timestamp": "2023-12-12T10:00:46Z",
@@ -1182,6 +1480,13 @@
       "round": 8060278,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063611
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:00:46Z",
@@ -1209,6 +1514,13 @@
       "round": 8060276,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063610
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:00:34Z",
@@ -1236,6 +1548,13 @@
       "round": 8060274,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063609
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:00:23Z",
@@ -1263,6 +1582,13 @@
       "round": 8060272,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063608
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T10:00:11Z",
@@ -1290,6 +1616,12 @@
       "nonce_0": 6,
       "round": 8060270,
       "sender_0": "oasis1qr5vpvmhxgymefgxx66mn5heayeyec69xgvzr5p9",
+      "signers": [
+        {
+          "address": "oasis1qr5vpvmhxgymefgxx66mn5heayeyec69xgvzr5p9",
+          "nonce": 6
+        }
+      ],
       "size": 292,
       "success": true,
       "timestamp": "2023-12-12T09:59:59Z",
@@ -1317,6 +1649,13 @@
       "round": 8060270,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063607
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:59Z",
@@ -1344,6 +1683,13 @@
       "round": 8060268,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063606
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:47Z",
@@ -1372,6 +1718,13 @@
       "round": 8060268,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199117
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:59:47Z",
@@ -1398,6 +1751,13 @@
       "round": 8060266,
       "sender_0": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
       "sender_0_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+      "signers": [
+        {
+          "address": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
+          "address_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+          "nonce": 349999
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:59:36Z",
@@ -1425,6 +1785,13 @@
       "round": 8060266,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063605
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:36Z",
@@ -1452,6 +1819,13 @@
       "round": 8060264,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063604
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:24Z",
@@ -1479,6 +1853,13 @@
       "round": 8060262,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063603
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:12Z",
@@ -1506,6 +1887,13 @@
       "round": 8060260,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063602
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:59:00Z",
@@ -1533,6 +1921,13 @@
       "round": 8060258,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063601
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:58:48Z",
@@ -1560,6 +1955,13 @@
       "round": 8060256,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063600
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:58:36Z",
@@ -1587,6 +1989,12 @@
       "nonce_0": 201374,
       "round": 8060255,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201374
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T09:58:30Z",
@@ -1614,6 +2022,13 @@
       "round": 8060254,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063599
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:58:24Z",
@@ -1641,6 +2056,13 @@
       "round": 8060254,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343081
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:58:24Z",
@@ -1668,6 +2090,13 @@
       "round": 8060252,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063598
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:58:12Z",
@@ -1695,6 +2124,13 @@
       "round": 8060250,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063597
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:58:00Z",
@@ -1722,6 +2158,13 @@
       "round": 8060248,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063596
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:57:49Z",
@@ -1749,6 +2192,13 @@
       "round": 8060246,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063595
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:57:37Z",
@@ -1776,6 +2226,13 @@
       "round": 8060244,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063594
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:57:26Z",
@@ -1804,6 +2261,13 @@
       "round": 8060243,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199116
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:57:20Z",
@@ -1830,6 +2294,13 @@
       "round": 8060242,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063593
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:57:13Z",
@@ -1857,6 +2328,13 @@
       "round": 8060241,
       "sender_0": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
       "sender_0_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+      "signers": [
+        {
+          "address": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
+          "address_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+          "nonce": 349998
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:57:07Z",
@@ -1884,6 +2362,13 @@
       "round": 8060240,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063592
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:57:02Z",
@@ -1911,6 +2396,13 @@
       "round": 8060238,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063591
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:56:50Z",
@@ -1938,6 +2430,13 @@
       "round": 8060236,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063590
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:56:38Z",
@@ -1965,6 +2464,13 @@
       "round": 8060234,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063589
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:56:27Z",
@@ -1992,6 +2498,13 @@
       "round": 8060232,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063588
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:56:15Z",
@@ -2019,6 +2532,12 @@
       "nonce_0": 201373,
       "round": 8060230,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201373
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T09:56:03Z",
@@ -2046,6 +2565,13 @@
       "round": 8060230,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063587
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:56:03Z",
@@ -2073,6 +2599,13 @@
       "round": 8060228,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343080
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:55:52Z",
@@ -2100,6 +2633,13 @@
       "round": 8060228,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063586
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:55:52Z",
@@ -2126,6 +2666,13 @@
       "round": 8060227,
       "sender_0": "oasis1qpuwytx7fzjcgfqtj7d9ltufgdwgu882pvngwlwt",
       "sender_0_eth": "0x1168304a1309d93935ffb2FC644FA31B8C923Ab1",
+      "signers": [
+        {
+          "address": "oasis1qpuwytx7fzjcgfqtj7d9ltufgdwgu882pvngwlwt",
+          "address_eth": "0x1168304a1309d93935ffb2FC644FA31B8C923Ab1",
+          "nonce": 7657
+        }
+      ],
       "size": 1232,
       "success": true,
       "timestamp": "2023-12-12T09:55:46Z",
@@ -2153,6 +2700,13 @@
       "round": 8060226,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063585
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:55:40Z",
@@ -2180,6 +2734,13 @@
       "round": 8060224,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063584
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:55:28Z",
@@ -2207,6 +2768,13 @@
       "round": 8060222,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063583
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:55:17Z",
@@ -2234,6 +2802,13 @@
       "round": 8060220,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063582
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:55:05Z",
@@ -2261,6 +2836,13 @@
       "round": 8060218,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063581
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:54:53Z",
@@ -2289,6 +2871,13 @@
       "round": 8060217,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199115
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:54:47Z",
@@ -2315,6 +2904,13 @@
       "round": 8060216,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063580
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:54:41Z",
@@ -2342,6 +2938,13 @@
       "round": 8060215,
       "sender_0": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
       "sender_0_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+      "signers": [
+        {
+          "address": "oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd",
+          "address_eth": "0xd8A2Ae03f6Edd58999a0F1005db7a6532F2AA79e",
+          "nonce": 349997
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:54:35Z",
@@ -2369,6 +2972,13 @@
       "round": 8060214,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063579
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:54:29Z",
@@ -2396,6 +3006,13 @@
       "round": 8060212,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063578
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:54:18Z",
@@ -2423,6 +3040,13 @@
       "round": 8060210,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063577
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:54:06Z",
@@ -2450,6 +3074,13 @@
       "round": 8060208,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063576
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:53:54Z",
@@ -2477,6 +3108,13 @@
       "round": 8060206,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063575
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:53:42Z",
@@ -2504,6 +3142,12 @@
       "nonce_0": 201372,
       "round": 8060204,
       "sender_0": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+      "signers": [
+        {
+          "address": "oasis1qzypxmt5xg8039329zvre7hxe7kn0vxfugsknqtw",
+          "nonce": 201372
+        }
+      ],
       "size": 294,
       "success": true,
       "timestamp": "2023-12-12T09:53:30Z",
@@ -2531,6 +3175,13 @@
       "round": 8060204,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063574
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:53:30Z",
@@ -2558,6 +3209,13 @@
       "round": 8060203,
       "sender_0": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
       "sender_0_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+      "signers": [
+        {
+          "address": "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq",
+          "address_eth": "0x397370CB06F1DdC3d8b6391539fed6Cbe2Fe5F95",
+          "nonce": 343079
+        }
+      ],
       "size": 144,
       "success": true,
       "timestamp": "2023-12-12T09:53:23Z",
@@ -2585,6 +3243,13 @@
       "round": 8060202,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063573
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:53:17Z",
@@ -2612,6 +3277,13 @@
       "round": 8060200,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063572
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:53:06Z",
@@ -2639,6 +3311,13 @@
       "round": 8060198,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063571
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:52:53Z",
@@ -2666,6 +3345,13 @@
       "round": 8060196,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063570
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:52:42Z",
@@ -2693,6 +3379,13 @@
       "round": 8060194,
       "sender_0": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
       "sender_0_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+      "signers": [
+        {
+          "address": "oasis1qzchk9eh0n4p2raym2e6cyvegrjumxl3lqkfhztr",
+          "address_eth": "0xCB2412a993f406eFf10a74011410a4F35e3549E3",
+          "nonce": 3063569
+        }
+      ],
       "size": 136,
       "success": true,
       "timestamp": "2023-12-12T09:52:30Z",

--- a/tests/e2e_regression/eden/expected/emerald_txs_by_method.body
+++ b/tests/e2e_regression/eden/expected/emerald_txs_by_method.body
@@ -24,6 +24,13 @@
       "round": 8060319,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199119
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T10:04:47Z",
@@ -51,6 +58,13 @@
       "round": 8060300,
       "sender_0": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
       "sender_0_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+      "signers": [
+        {
+          "address": "oasis1qrws9mk3jrs2tylw25rsh0euwh7lsvv2p55y8pkw",
+          "address_eth": "0x15693CE71D0838fA95F059Bd0382D564b64f08b8",
+          "nonce": 217
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T10:02:55Z",
@@ -78,6 +92,13 @@
       "round": 8060293,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199118
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T10:02:14Z",
@@ -105,6 +126,13 @@
       "round": 8060268,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199117
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:59:47Z",
@@ -132,6 +160,13 @@
       "round": 8060243,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199116
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:57:20Z",
@@ -159,6 +194,13 @@
       "round": 8060217,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199115
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:54:47Z",
@@ -186,6 +228,13 @@
       "round": 8060180,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199114
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:51:06Z",
@@ -213,6 +262,13 @@
       "round": 8060154,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199113
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:48:33Z",
@@ -240,6 +296,13 @@
       "round": 8060128,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199112
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:46:00Z",
@@ -267,6 +330,13 @@
       "round": 8060103,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199111
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:43:33Z",
@@ -294,6 +364,13 @@
       "round": 8060077,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199110
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:41:01Z",
@@ -321,6 +398,13 @@
       "round": 8060052,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199109
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:38:33Z",
@@ -348,6 +432,13 @@
       "round": 8060026,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199108
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:36:01Z",
@@ -375,6 +466,13 @@
       "round": 8060001,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199107
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:33:33Z",
@@ -402,6 +500,13 @@
       "round": 8059976,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199106
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:31:05Z",
@@ -429,6 +534,13 @@
       "round": 8059952,
       "sender_0": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
       "sender_0_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+      "signers": [
+        {
+          "address": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
+          "address_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+          "nonce": 1198
+        }
+      ],
       "size": 317,
       "success": true,
       "timestamp": "2023-12-12T09:28:43Z",
@@ -456,6 +568,13 @@
       "round": 8059950,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199105
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:28:31Z",
@@ -483,6 +602,13 @@
       "round": 8059940,
       "sender_0": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
       "sender_0_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+      "signers": [
+        {
+          "address": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
+          "address_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+          "nonce": 1197
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:27:27Z",
@@ -510,6 +636,13 @@
       "round": 8059927,
       "sender_0": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
       "sender_0_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+      "signers": [
+        {
+          "address": "oasis1qry3w8j35ytzk4nqhgjctueen64jfxh7qydz99n3",
+          "address_eth": "0x7F562ca612854Eb91EC9Ba34fFF08048b0E95945",
+          "nonce": 1196
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:26:10Z",
@@ -537,6 +670,13 @@
       "round": 8059925,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199104
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:25:59Z",
@@ -564,6 +704,13 @@
       "round": 8059901,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199103
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:23:37Z",
@@ -591,6 +738,13 @@
       "round": 8059875,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199102
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:21:00Z",
@@ -618,6 +772,13 @@
       "round": 8059850,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199101
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:18:33Z",
@@ -645,6 +806,13 @@
       "round": 8059824,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199100
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:16:00Z",
@@ -672,6 +840,13 @@
       "round": 8059799,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199099
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:13:33Z",
@@ -699,6 +874,13 @@
       "round": 8059774,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199098
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:11:01Z",
@@ -726,6 +908,13 @@
       "round": 8059750,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199097
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T09:08:35Z",
@@ -753,6 +942,13 @@
       "round": 8059724,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199096
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:06:02Z",
@@ -780,6 +976,13 @@
       "round": 8059698,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199095
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:03:29Z",
@@ -807,6 +1010,13 @@
       "round": 8059673,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199094
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T09:01:02Z",
@@ -834,6 +1044,13 @@
       "round": 8059647,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199093
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:58:30Z",
@@ -861,6 +1078,13 @@
       "round": 8059622,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199092
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T08:56:03Z",
@@ -888,6 +1112,13 @@
       "round": 8059596,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199091
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:53:28Z",
@@ -915,6 +1146,13 @@
       "round": 8059571,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199090
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:50:59Z",
@@ -942,6 +1180,13 @@
       "round": 8059546,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199089
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T08:48:32Z",
@@ -969,6 +1214,13 @@
       "round": 8059521,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199088
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:46:04Z",
@@ -996,6 +1248,13 @@
       "round": 8059495,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199087
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T08:43:31Z",
@@ -1023,6 +1282,13 @@
       "round": 8059470,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199086
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:41:04Z",
@@ -1050,6 +1316,13 @@
       "round": 8059444,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199085
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:38:31Z",
@@ -1077,6 +1350,13 @@
       "round": 8059419,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199084
+        }
+      ],
       "size": 314,
       "success": true,
       "timestamp": "2023-12-12T08:36:04Z",
@@ -1104,6 +1384,13 @@
       "round": 8059393,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199083
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T08:33:31Z",
@@ -1131,6 +1418,13 @@
       "round": 8059368,
       "sender_0": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
       "sender_0_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+      "signers": [
+        {
+          "address": "oasis1qqn5lhdlq7t730qyrsxj4ph4a8xnhwjtcs87fmrd",
+          "address_eth": "0xe9dD2cE7F0712F19313704b7e977b9C776802FC8",
+          "nonce": 199082
+        }
+      ],
       "size": 315,
       "success": true,
       "timestamp": "2023-12-12T08:31:03Z",


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/nexus/issues/884

The existing sender_0, sender_0_eth, and nonce_0 are deprecated and will be removed in the future.