### PR TITLE
openapi: remove experimental/deprecated markers from consensus endpoints

### DIFF
--- a/.changelog/898.doc.md
+++ b/.changelog/898.doc.md
@@ -1,0 +1,1 @@
+openapi: remove experimental/deprecated markers from consensus endpoints

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -151,8 +151,6 @@ paths:
 
   /consensus/blocks:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of consensus blocks, sorted from most to least recent.
       parameters:
         - *limit
@@ -207,8 +205,6 @@ paths:
 
   /consensus/blocks/{height}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a consensus block.
       parameters:
         - in: path
@@ -230,8 +226,6 @@ paths:
 
   /consensus/transactions:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of consensus transactions.
       parameters:
         - *limit
@@ -285,8 +279,6 @@ paths:
 
   /consensus/transactions/{tx_hash}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns consensus transactions with the given transaction hash.
       parameters:
         - in: path
@@ -312,8 +304,6 @@ paths:
 
   /consensus/events:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of consensus events.
       parameters:
         - *limit
@@ -372,8 +362,6 @@ paths:
 
   /consensus/roothash_messages:
     get:
-      tags: [Experimental]
-      deprecated: true
       parameters:
         - *limit
         - *offset
@@ -410,8 +398,6 @@ paths:
 
   /consensus/entities:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of entities registered at the consensus layer.
       parameters:
         - *limit
@@ -429,8 +415,6 @@ paths:
 
   /consensus/entities/{address}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns an entity registered at the consensus layer.
       parameters:
         - in: path
@@ -452,8 +436,6 @@ paths:
 
   /consensus/entities/{address}/nodes:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of nodes registered at the consensus layer.
       parameters:
         - *limit
@@ -477,8 +459,6 @@ paths:
 
   /consensus/entities/{address}/nodes/{node_id}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a node registered at the consensus layer.
       parameters:
         - in: path
@@ -507,8 +487,6 @@ paths:
 
   /consensus/validators:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of validators registered at the consensus layer (the list includes all registered entities, even those without a currently active validator node).
       parameters:
         - *limit
@@ -534,8 +512,6 @@ paths:
 
   /consensus/validators/{address}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a validator registered at the consensus layer.
       parameters:
         - in: path
@@ -557,8 +533,6 @@ paths:
 
   /consensus/validators/{address}/history:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns historical information for a single validator.
       parameters:
         - *limit
@@ -596,8 +570,6 @@ paths:
 
   /consensus/accounts:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: |
         Returns a list of consensus layer accounts.
         Note that for performance reasons, the info returned by this endpoint
@@ -618,8 +590,6 @@ paths:
 
   /consensus/accounts/{address}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a consensus layer account.
       parameters:
         - in: path
@@ -639,8 +609,6 @@ paths:
 
   /consensus/accounts/{address}/delegations:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns an account's delegations.
       parameters:
         - *limit
@@ -662,8 +630,6 @@ paths:
 
   /consensus/accounts/{address}/delegations_to:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of delegations to an account.
       parameters:
         - *limit
@@ -685,8 +651,6 @@ paths:
 
   /consensus/accounts/{address}/debonding_delegations:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns an account's debonding delegations.
       parameters:
         - *limit
@@ -708,8 +672,6 @@ paths:
 
   /consensus/accounts/{address}/debonding_delegations_to:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of debonding delegations to an account.
       parameters:
         - *limit
@@ -731,8 +693,6 @@ paths:
 
   /consensus/epochs:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of consensus epochs.
       parameters:
         - *limit
@@ -748,8 +708,6 @@ paths:
 
   /consensus/epochs/{epoch}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a consensus epoch.
       parameters:
         - in: path
@@ -771,8 +729,6 @@ paths:
 
   /consensus/proposals:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of governance proposals.
       parameters:
         - *limit
@@ -799,8 +755,6 @@ paths:
 
   /consensus/proposals/{proposal_id}:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a governance proposal.
       parameters:
         - in: path
@@ -822,8 +776,6 @@ paths:
 
   /consensus/proposals/{proposal_id}/votes:
     get:
-      tags: [Experimental]
-      deprecated: true
       summary: Returns a list of votes for a governance proposal.
       parameters:
         - *limit


### PR DESCRIPTION
Now that we have released consensus support, we no longer have to mark these endpoints as Experimental / deprecated