### PR TITLE
rofl: Fix support for Instance Registered event

### DIFF
--- a/.changelog/922.bugfix.md
+++ b/.changelog/922.bugfix.md
@@ -1,0 +1,1 @@
+rofl: Fix support for Instance Registered event

--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -176,6 +176,14 @@ func DecodeRoflEvent(event *nodeapi.RuntimeEvent) ([]rofl.Event, error) {
 		for _, ev := range evs {
 			events = append(events, rofl.Event{AppRemoved: ev})
 		}
+	case rofl.InstanceRegisteredEventCode:
+		var evs []*rofl.InstanceRegisteredEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode rofl instance registered event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, rofl.Event{InstanceRegistered: ev})
+		}
 	default:
 		return nil, fmt.Errorf("invalid rofl event code: %v", event.Code)
 	}


### PR DESCRIPTION
The Nexus Sapphire Testnet analyzer got stuck at processing block `10653792` that includes the new recently added `InstanceRegisteredEvent` (https://github.com/oasisprotocol/oasis-sdk/pull/2159). This PR adds support for decoding such events that was missing in https://github.com/oasisprotocol/nexus/pull/917. 

```
{"analyzer":"sapphire","caller":"block.go:412","height":10653792,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"processing block","ts":"2025-03-05T18:00:43.160965827Z"}
{"analyzer":"sapphire","caller":"block.go:425","err":"extract non-tx events: event 6: decode rofl: invalid rofl event code: 4; raw event: {Module:rofl Code:4 Value:[129 162 99 114 97 107 161 103 101 100 50 53 53 49 57 88 32 22 23 122 67 18 40 176 86 9 150 65 237 63 79 58 186 10 247 12 51 163 118 159 50 118 57 28 89 227 17 215 75 102 97 112 112 95 105 100 85 0 215 149 192 51 251 75 148 135 61 129 182 50 127 83 113 118 143 252 111 207] TxHash:41ba7d12683a75b590f72e33b16c9979d92ce9a3d5caf4c177e36e885b432dcb}","height":10653792,"level":"error","mode":"slow-sync","module":"analysis_service","msg":"error processing block","ts":"2025-03-05T18:00:43.161497176Z"}
```

After applying this hotfix the Nexus Sapphire Testnet analyzer works again.