### PR TITLE
openapi: Document missing `success` field in two-step transactions

### DIFF
--- a/.changelog/923.trivial.md
+++ b/.changelog/923.trivial.md
@@ -1,0 +1,1 @@
+openapi: Document missing `success` field in two-step transactions

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -3088,6 +3088,8 @@ components:
           type: boolean
           description: |
             Whether this transaction successfully executed.
+            Is absent in multi-step runtime transactions (`consensus.Deposit`, `consensus.Withdraw`,
+            `consensus.Delegate`, and `consensus.Undelegate`) until the second step is completed.
             Can be absent (meaning "unknown") for confidential runtimes.
         evm_fn_name:
           type: string


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/nexus/pull/820