### PR TITLE
Add named addresses for pontusxdev and pontusxtest runtimes

### DIFF
--- a/.changelog/925.trivial.md
+++ b/.changelog/925.trivial.md
@@ -1,0 +1,1 @@
+Add named addresses for pontusxdev and pontusxtest runtimes

--- a/named-addresses/testnet_pontusxdev.json
+++ b/named-addresses/testnet_pontusxdev.json
@@ -1,0 +1,42 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    },
+    {
+        "Name": "Faucet Address",
+        "Address": "oasis1qzna6nq9kuktjmxx2s84z38eysqyts84jc9lgdg2",
+        "Description": "This account contains TEST tokens distributed by the faucet."
+    }
+]

--- a/named-addresses/testnet_pontusxtest.json
+++ b/named-addresses/testnet_pontusxtest.json
@@ -1,0 +1,42 @@
+[
+    {
+        "Name": "Common Pool",
+        "Address": "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30",
+        "Description": "ParaTime account for rewarding token stakers."
+    },
+    {
+        "Name": "Fee Accumulator",
+        "Address": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+        "Description": "This account collects transaction fees of each ParaTime block that are distributed among the validators."
+    },
+    {
+        "Name": "Rewards Account",
+        "Address": "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav",
+        "Description": "ParaTime account for rewarding the compute nodes."
+    },
+    {
+        "Name": "Pending Withdrawal Account",
+        "Address": "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln",
+        "Description": "Withdrawal from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Pending Delegation Account",
+        "Address": "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r",
+        "Description": "Delegation from the ParaTime is performed in two steps. This account holds the tokens that are still waiting for the consensus transaction to be confirmed."
+    },
+    {
+        "Name": "Zero Address",
+        "Address": "oasis1qq2v39p9fqk997vk6742axrzqyu9v2ncyuqt8uek",
+        "Description": "This address is the oasis-standard derivation/counterpart of the Ethereum address 0x0. Sometimes used in internal data representations to indicate the absence of an account. For example, token mints are encoded as transfers from this address, and token burns as transfers to this address."
+    },
+    {
+        "Name": "Subcall Precompile",
+        "Address": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
+        "Description": "Interacts with Oasis Runtime SDK modules. Some transactions are performed in two steps and emit event in the next block."
+    },
+    {
+        "Name": "Faucet Address",
+        "Address": "oasis1qzna6nq9kuktjmxx2s84z38eysqyts84jc9lgdg2",
+        "Description": "This account contains TEST tokens distributed by the faucet."
+    }
+]


### PR DESCRIPTION
testnet pontusxdev and pontusxtest are both similar to sapphire. For now, the same names addresses are also valid there.

This commit adds the corresponding JSON lists.
(Which are simply copies for the one for Sapphire.)