### PR TITLE
storage/db: Configuring max connection to the database

### DIFF
--- a/.changelog/929.feature.md
+++ b/.changelog/929.feature.md
@@ -1,0 +1,5 @@
+storage/db/config: Support configuring max connections
+
+By default, `pgxpool` uses a very conservative limit for the maximum number of
+connections (`max(num_cpus, 4)`). This change makes it configurable and
+increases the default to 10.

--- a/cmd/bisect/main.go
+++ b/cmd/bisect/main.go
@@ -144,7 +144,7 @@ func initBackends(ctx context.Context) (*history.HistoryConsensusApiLite, *postg
 		os.Exit(1)
 	}
 
-	db, err := postgres.NewClient(cfg.Analysis.Storage.Endpoint, logger)
+	db, err := postgres.NewClient(cfg.Analysis.Storage.Endpoint, logger, cfg.Analysis.Storage.Postgres)
 	if err != nil {
 		logger.Error("cannot connect to DB", "error", err)
 		os.Exit(1)

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -95,7 +95,7 @@ func NewClient(cfg *config.StorageConfig, logger *log.Logger) (storage.TargetSto
 	var err error
 	switch backend {
 	case config.BackendPostgres:
-		client, err = postgres.NewClient(cfg.Endpoint, logger)
+		client, err = postgres.NewClient(cfg.Endpoint, logger, cfg.Postgres)
 	default:
 		panic(fmt.Sprintf("unsupported storage backend: %v", backend))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type AnalysisConfig struct {
 	// They are instantiated if and only if analyzers are instantiated.
 	Helpers HelperList `koanf:"helpers"`
 
+	// Storage is the storage configuration for the analyzers.
 	Storage *StorageConfig `koanf:"storage"`
 }
 
@@ -593,6 +594,7 @@ type ServerConfig struct {
 	// Endpoint is the service endpoint from which to serve the API.
 	Endpoint string `koanf:"endpoint"`
 
+	// Storage is the storage configuration for the API server.
 	Storage *StorageConfig `koanf:"storage"`
 
 	// Source is the configuration for accessing oasis-node(s) and chain
@@ -705,6 +707,15 @@ type StorageConfig struct {
 	// If true, we'll first delete all tables in the DB to
 	// force a full re-index of the blockchain.
 	WipeStorage bool `koanf:"DANGER__WIPE_STORAGE_ON_STARTUP"`
+
+	// Postgres is the postgres specific configuration to use.
+	Postgres *PostgresConfig `koanf:"postgres"`
+}
+
+// PostgresConfig is the postgres specific configuration to use when using the postgres backend.
+type PostgresConfig struct {
+	// MaxConnections is the maximum number of connections in the database connection pool.
+	MaxConnections *int32 `koanf:"max_connections"`
 }
 
 // Validate validates the storage configuration.

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -12,12 +12,15 @@ import (
 	"github.com/jackc/pgx/v5/tracelog"
 
 	common "github.com/oasisprotocol/nexus/analyzer/uncategorized"
+	"github.com/oasisprotocol/nexus/config"
 	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage"
 )
 
 const (
 	moduleName = "postgres"
+
+	defaultMaxConns = 10
 )
 
 // Client is a client for connecting to PostgreSQL.
@@ -61,7 +64,7 @@ func (l *pgxLogger) Log(ctx context.Context, level tracelog.LogLevel, msg string
 }
 
 // NewClient creates a new PostgreSQL client.
-func NewClient(connString string, l *log.Logger) (*Client, error) {
+func NewClient(connString string, l *log.Logger, cfg *config.PostgresConfig) (*Client, error) {
 	config, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, err
@@ -75,6 +78,10 @@ func NewClient(connString string, l *log.Logger) (*Client, error) {
 		Logger: &pgxLogger{
 			logger: l.WithModule(moduleName).With("db", config.ConnConfig.Database).WithCallerUnwind(10),
 		},
+	}
+	config.MaxConns = defaultMaxConns
+	if cfg != nil && cfg.MaxConnections != nil {
+		config.MaxConns = *cfg.MaxConnections
 	}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), config)

--- a/storage/postgres/client_test.go
+++ b/storage/postgres/client_test.go
@@ -32,7 +32,7 @@ func TestInvalidConnect(t *testing.T) {
 	logger, err := log.NewLogger("postgres-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.NoError(t, err)
 
-	_, err = postgres.NewClient(connString, logger)
+	_, err = postgres.NewClient(connString, logger, nil)
 	require.Error(t, err)
 }
 

--- a/storage/postgres/testutil/testutil.go
+++ b/storage/postgres/testutil/testutil.go
@@ -16,7 +16,7 @@ func NewTestClient(t *testing.T) *postgres.Client {
 	logger, err := log.NewLogger("postgres-test", os.Stdout, log.FmtJSON, log.LevelError)
 	require.NoError(t, err, "log.NewLogger")
 
-	client, err := postgres.NewClient(connString, logger)
+	client, err := postgres.NewClient(connString, logger, nil)
 	require.NoError(t, err, "postgres.NewClient")
 	return client
 }

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -29,7 +29,7 @@ func newTargetClient(t *testing.T) (*postgres.Client, error) {
 	logger, err := log.NewLogger("db-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.NoError(t, err)
 
-	return postgres.NewClient(connString, logger)
+	return postgres.NewClient(connString, logger, nil)
 }
 
 func newSdkConnection(ctx context.Context) (connection.Connection, error) {


### PR DESCRIPTION
By default `pgxpool` uses a very conservative limit for maximum number of connections (`max(num_cpu's, 4)`). We make this configurable, and also bump the default to 10.

In production we probably want to bump this to something like 50 or 100.