### PR TITLE
config: add support for array values via environment variables

### DIFF
--- a/.changelog/933.feature.md
+++ b/.changelog/933.feature.md
@@ -1,0 +1,1 @@
+config: fix consensus_circulating_supply_exclusions via env

--- a/config/config.go
+++ b/config/config.go
@@ -770,9 +770,16 @@ func initConfig(p koanf.Provider) (*Config, error) {
 	}
 
 	// Load environment variables and merge into the loaded config.
-	if err := k.Load(env.Provider("", ".", func(s string) string {
+	if err := k.Load(env.ProviderWithValue("", ".", func(key string, value string) (string, interface{}) {
 		// `__` is used as a hierarchy delimiter.
-		return strings.ReplaceAll(strings.ToLower(s), "__", ".")
+		key = strings.ReplaceAll(strings.ToLower(key), "__", ".")
+
+		// Support comma separated list for specific keys.
+		if key == "server.consensus_circulating_supply_exclusions" {
+			return key, strings.Split(value, ",")
+		}
+
+		return key, value
 	}), nil); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/932

This should be good enough since we only use env variables for a couple of config settings (none of those should have commas unless providing a list of values).