### PR TITLE
storage/db: Remove max connection configuration option

### DIFF
--- a/.changelog/912.bugfix.md
+++ b/.changelog/912.bugfix.md
@@ -1,0 +1,1 @@
+storage/db: Remove max connection configuration option

--- a/cmd/bisect/main.go
+++ b/cmd/bisect/main.go
@@ -144,7 +144,7 @@ func initBackends(ctx context.Context) (*history.HistoryConsensusApiLite, *postg
 		os.Exit(1)
 	}
 
-	db, err := postgres.NewClient(cfg.Analysis.Storage.Endpoint, logger, cfg.Analysis.Storage.Postgres)
+	db, err := postgres.NewClient(cfg.Analysis.Storage.Endpoint, logger)
 	if err != nil {
 		logger.Error("cannot connect to DB", "error", err)
 		os.Exit(1)

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -95,7 +95,7 @@ func NewClient(cfg *config.StorageConfig, logger *log.Logger) (storage.TargetSto
 	var err error
 	switch backend {
 	case config.BackendPostgres:
-		client, err = postgres.NewClient(cfg.Endpoint, logger, cfg.Postgres)
+		client, err = postgres.NewClient(cfg.Endpoint, logger)
 	default:
 		panic(fmt.Sprintf("unsupported storage backend: %v", backend))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -707,15 +707,6 @@ type StorageConfig struct {
 	// If true, we'll first delete all tables in the DB to
 	// force a full re-index of the blockchain.
 	WipeStorage bool `koanf:"DANGER__WIPE_STORAGE_ON_STARTUP"`
-
-	// Postgres is the postgres specific configuration to use.
-	Postgres *PostgresConfig `koanf:"postgres"`
-}
-
-// PostgresConfig is the postgres specific configuration to use when using the postgres backend.
-type PostgresConfig struct {
-	// MaxConnections is the maximum number of connections in the database connection pool.
-	MaxConnections *int32 `koanf:"max_connections"`
 }
 
 // Validate validates the storage configuration.

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -12,15 +12,12 @@ import (
 	"github.com/jackc/pgx/v5/tracelog"
 
 	common "github.com/oasisprotocol/nexus/analyzer/uncategorized"
-	"github.com/oasisprotocol/nexus/config"
 	"github.com/oasisprotocol/nexus/log"
 	"github.com/oasisprotocol/nexus/storage"
 )
 
 const (
 	moduleName = "postgres"
-
-	defaultMaxConns = 10
 )
 
 // Client is a client for connecting to PostgreSQL.
@@ -64,7 +61,7 @@ func (l *pgxLogger) Log(ctx context.Context, level tracelog.LogLevel, msg string
 }
 
 // NewClient creates a new PostgreSQL client.
-func NewClient(connString string, l *log.Logger, cfg *config.PostgresConfig) (*Client, error) {
+func NewClient(connString string, l *log.Logger) (*Client, error) {
 	config, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, err
@@ -78,10 +75,6 @@ func NewClient(connString string, l *log.Logger, cfg *config.PostgresConfig) (*C
 		Logger: &pgxLogger{
 			logger: l.WithModule(moduleName).With("db", config.ConnConfig.Database).WithCallerUnwind(10),
 		},
-	}
-	config.MaxConns = defaultMaxConns
-	if cfg != nil && cfg.MaxConnections != nil {
-		config.MaxConns = *cfg.MaxConnections
 	}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), config)

--- a/storage/postgres/client_test.go
+++ b/storage/postgres/client_test.go
@@ -32,7 +32,7 @@ func TestInvalidConnect(t *testing.T) {
 	logger, err := log.NewLogger("postgres-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.NoError(t, err)
 
-	_, err = postgres.NewClient(connString, logger, nil)
+	_, err = postgres.NewClient(connString, logger)
 	require.Error(t, err)
 }
 

--- a/storage/postgres/testutil/testutil.go
+++ b/storage/postgres/testutil/testutil.go
@@ -16,7 +16,7 @@ func NewTestClient(t *testing.T) *postgres.Client {
 	logger, err := log.NewLogger("postgres-test", os.Stdout, log.FmtJSON, log.LevelError)
 	require.NoError(t, err, "log.NewLogger")
 
-	client, err := postgres.NewClient(connString, logger, nil)
+	client, err := postgres.NewClient(connString, logger)
 	require.NoError(t, err, "postgres.NewClient")
 	return client
 }

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -29,7 +29,7 @@ func newTargetClient(t *testing.T) (*postgres.Client, error) {
 	logger, err := log.NewLogger("db-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.NoError(t, err)
 
-	return postgres.NewClient(connString, logger, nil)
+	return postgres.NewClient(connString, logger)
 }
 
 func newSdkConnection(ctx context.Context) (connection.Connection, error) {


### PR DESCRIPTION
As mentioned in https://github.com/oasisprotocol/nexus/pull/929/files#r2009079229

No need to provide a config option for this, as it can be specified in the db connection string.