### PR TITLE
evmabi-backfill: Optimize db queries

### DIFF
--- a/.changelog/935.bugfix.md
+++ b/.changelog/935.bugfix.md
@@ -1,0 +1,1 @@
+evmabi-backfill: Optimize db queries

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -98,7 +98,7 @@ CREATE TABLE chain.runtime_transactions
   error_params JSONB,
   -- Internal tracking for parsing evm.Call transactions using the contract
   -- abi when available.
-  abi_parsed_at TIMESTAMP WITH TIME ZONE
+  abi_parsed_at TIMESTAMP WITH TIME ZONE -- Updated in 34_runtime_abi_parsed_at.up.sql: NOT NULL DEFAULT '0001-01-01'
 
   -- likely_native_transfer BOOLEAN NOT NULL DEFAULT FALSE -- Added in 18_related_runtime_transactions_method_denorm.up.sql.
 );
@@ -106,7 +106,10 @@ CREATE INDEX ix_runtime_transactions_tx_hash ON chain.runtime_transactions USING
 CREATE INDEX ix_runtime_transactions_tx_eth_hash ON chain.runtime_transactions USING hash (tx_eth_hash);
 CREATE INDEX ix_runtime_transactions_timestamp ON chain.runtime_transactions (runtime, timestamp);
 CREATE INDEX ix_runtime_transactions_to ON chain.runtime_transactions(runtime, "to");
-CREATE INDEX ix_runtime_transactions_to_abi_parsed_at ON chain.runtime_transactions (runtime, "to", abi_parsed_at);
+CREATE INDEX ix_runtime_transactions_to_abi_parsed_at ON chain.runtime_transactions (runtime, "to", abi_parsed_at); -- Removed in 34_runtime_abi_parsed_at.up.sql.
+-- Added in 34_runtime_abi_parsed_at.up.sql.
+-- CREATE INDEX ix_runtime_transactions_to_round_abi_parsed_at ON chain.runtime_transactions (runtime, "to", round DESC, abi_parsed_at) WHERE method = 'evm.Call' AND body IS NOT NULL;
+
 -- CREATE INDEX ix_runtime_transactions_method_round ON chain.runtime_transactions (runtime, method, round, tx_index); -- Added in 08_runtime_transactions_method_idx.up.sql
 
 -- Added in 18_related_runtime_transactions_method_denorm.up.sql.
@@ -183,7 +186,7 @@ CREATE TABLE chain.runtime_events
 
   -- Internal tracking for parsing evm.Call events using the contract
   -- abi when available.
-  abi_parsed_at TIMESTAMP WITH TIME ZONE
+  abi_parsed_at TIMESTAMP WITH TIME ZONE -- Added in 34_runtime_abi_parsed_at.up.sql. NOT NULL DEFAULT '0001-01-01'.
 );
 CREATE INDEX ix_runtime_events_round ON chain.runtime_events(runtime, round);  -- Removed in 14_runtime_events_related_accounts.up.sql. (Replaced by the primary key.)
 CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events USING hash (tx_hash);
@@ -199,6 +202,8 @@ CREATE INDEX ix_runtime_events_nft_transfers ON chain.runtime_events (runtime, (
         type = 'evm.log' AND
         evm_log_signature = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' AND
         jsonb_array_length(body -> 'topics') = 4;
+-- Added in 34_runtime_abi_parsed_at.up.sql.
+-- CREATE INDEX ix_runtime_events_abi_parsed_at ON chain.runtime_events (runtime, (body ->> 'address'), round DESC, abi_parsed_at) WHERE type = 'evm.log';
 
 -- Added in 07_runtime_events_evm_contracts_events.up.sql
 -- Index used for fetching events emitted by a specific contract.

--- a/storage/migrations/34_runtime_abi_parsed_at.up.sql
+++ b/storage/migrations/34_runtime_abi_parsed_at.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+UPDATE chain.runtime_transactions
+	SET abi_parsed_at = '0001-01-01'
+	WHERE abi_parsed_at IS NULL;
+
+ALTER TABLE chain.runtime_transactions
+	ALTER COLUMN abi_parsed_at SET DEFAULT '0001-01-01',
+	ALTER COLUMN abi_parsed_at SET NOT NULL;
+DROP INDEX IF EXISTS chain.ix_runtime_transactions_to_abi_parsed_at;
+CREATE INDEX IF NOT EXISTS ix_runtime_transactions_to_round_abi_parsed_at ON chain.runtime_transactions (runtime, "to", round DESC, abi_parsed_at) WHERE method = 'evm.Call' AND body IS NOT NULL;
+
+UPDATE chain.runtime_events
+	SET abi_parsed_at = '0001-01-01'
+	WHERE abi_parsed_at IS NULL;
+ALTER TABLE chain.runtime_events
+	ALTER COLUMN abi_parsed_at SET DEFAULT '0001-01-01',
+	ALTER COLUMN abi_parsed_at SET NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_runtime_events_abi_parsed_at ON chain.runtime_events (runtime, (body ->> 'address'), round DESC, abi_parsed_at) WHERE type = 'evm.log';
+
+COMMIT;


### PR DESCRIPTION
Fixes #910 

- add indexes for efficient evmabi-backfill analyzer queries, and update the queries for efficient index usage
- make `abi_parsed_at` field in runtime_transactions and events non-nill, to simplify queries and improve index usage


TODO:
- [x] test migration on mainnet db: ~40 hours
- [x] test new queries performance on mainnet or testnet db
  - almost instant, and using the indexes as expected 
 ```
RuntimeEvmVerifiedContractTxs
                                                                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=698040.63..698043.13 rows=1000 width=880) (actual time=134.601..134.607 rows=7 loops=1)
   ->  Sort  (cost=698040.63..698465.63 rows=170000 width=880) (actual time=134.600..134.604 rows=7 loops=1)
         Sort Key: tx.round DESC
         Sort Method: quicksort  Memory: 73kB
         ->  Nested Loop  (cost=0.69..688719.71 rows=170000 width=880) (actual time=95.900..134.496 rows=7 loops=1)
               ->  Seq Scan on evm_contracts  (cost=0.00..854.34 rows=170 width=765) (actual time=0.119..2.820 rows=373 loops=1)
                     Filter: ((abi IS NOT NULL) AND (runtime = 'sapphire'::runtime))
                     Rows Removed by Filter: 10437
               ->  Limit  (cost=0.69..4021.27 rows=1000 width=724) (actual time=0.271..0.352 rows=0 loops=373)
                     ->  Index Scan using ix_runtime_transactions_to_round_abi_parsed_at on runtime_transactions tx  (cost=0.69..85976.66 rows=21384 width=724) (actual time=0.271..0.352 rows=0 loops=373)
                           Index Cond: ((runtime = evm_contracts.runtime) AND (("to")::text = (evm_contracts.contract_address)::text) AND (abi_parsed_at < evm_contracts.verification_info_downloaded_at))
 Planning Time: 0.424 ms
 Execution Time: 134.690 ms
(13 rows)

RuntimeEvmVerifiedContractEvents
                                                                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=361266.87..361269.37 rows=1000 width=982) (actual time=96.899..97.013 rows=1000 loops=1)
   ->  Sort  (cost=361266.87..361691.87 rows=170000 width=982) (actual time=96.897..96.946 rows=1000 loops=1)
         Sort Key: e.round DESC
         Sort Method: top-N heapsort  Memory: 2049kB
         ->  Nested Loop  (cost=1.25..351945.95 rows=170000 width=982) (actual time=29.907..78.912 rows=27234 loops=1)
               ->  Nested Loop  (cost=0.56..2311.66 rows=170 width=786) (actual time=0.105..8.796 rows=360 loops=1)
                     ->  Seq Scan on evm_contracts  (cost=0.00..854.34 rows=170 width=765) (actual time=0.074..2.877 rows=373 loops=1)
                           Filter: ((abi IS NOT NULL) AND (runtime = 'sapphire'::runtime))
                           Rows Removed by Filter: 10437
                     ->  Index Scan using address_preimages_pkey on address_preimages p  (cost=0.56..8.57 rows=1 width=68) (actual time=0.015..0.015 rows=1 loops=373)
                           Index Cond: ((address)::text = (evm_contracts.contract_address)::text)
               ->  Limit  (cost=0.70..2046.67 rows=1000 width=229) (actual time=0.108..0.187 rows=76 loops=360)
                     ->  Index Scan using ix_runtime_events_abi_parsed_at on runtime_events e  (cost=0.70..250573.28 rows=122471 width=229) (actual time=0.107..0.182 rows=76 loops=360)
                           Index Cond: ((runtime = evm_contracts.runtime) AND ((body ->> 'address'::text) = encode(p.address_data, 'base64'::text)) AND (abi_parsed_at < evm_contracts.verification_info_downloaded_at))
 Planning Time: 1.598 ms
 Execution Time: 97.192 ms
(16 rows)
```