### PR TITLE
internal: bump CI to ubuntu-22.04

### DIFF
--- a/.changelog/945.internal.md
+++ b/.changelog/945.internal.md
@@ -1,0 +1,1 @@
+internal: bump CI to ubuntu-22.04

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   lint-go:
     name: lint-go
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build-go:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       # Generic postgres server; used only for testing our DB client lib. Not used by nexus.
       postgres:
@@ -69,7 +69,7 @@ jobs:
           file: ./coverage.txt
 
   validate-openapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
           ./vacuum lint --ruleset .vacuum.yaml --details --snippets --errors api/spec/v1-normalized.yaml
 
   validate-migrations:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
         run: scripts/validate_migrations.py --migrations storage/migrations
 
   test-e2e-localnet:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
           - eden
           - edenfast
           - eden_testnet_2025
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -32,23 +32,23 @@ on:
 jobs:
   build-go:
     name: build-go
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]
   lint-go:
     name: lint-go
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]
   validate-openapi:
     name: validate-openapi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]
   validate-migrations:
     name: validate-migrations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]
   test-e2e-localnet:
     name: test-e2e-localnet
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]
   test-e2e-regression:
     strategy:
@@ -59,5 +59,5 @@ jobs:
           - edenfast
           - eden_testnet_2025
     name: test-e2e-regression
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: [{name: "fake success", run: "exit 0"}]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu 20-04 images are getting deprecated: https://github.com/actions/runner-images/issues/11101