### PR TITLE
analyzer/runtime: Fix 'success' compute for undelegate tx

### DIFF
--- a/.changelog/963.bugfix.1.md
+++ b/.changelog/963.bugfix.1.md
@@ -1,0 +1,1 @@
+runtime: Fix 'success' field for failed multi-step transactions

--- a/.changelog/963.bugfix.2.md
+++ b/.changelog/963.bugfix.2.md
@@ -1,0 +1,1 @@
+analyzer/runtime: Fix 'success' field for undelegate transactions

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -164,7 +164,8 @@ func (m *processor) queueConsensusAccountsEvents(batch *storage.QueryBatch, bloc
 			m.queueTransactionStatusUpdate(batch, blockData.Header.Round, "consensus.Delegate", e.From, e.Nonce, e.Error)
 		}
 		if e := event.WithScope.ConsensusAccounts.UndelegateStart; e != nil {
-			m.queueTransactionStatusUpdate(batch, blockData.Header.Round, "consensus.Undelegate", e.From, e.Nonce, e.Error)
+			// To contains the signer address.
+			m.queueTransactionStatusUpdate(batch, blockData.Header.Round, "consensus.Undelegate", e.To, e.Nonce, e.Error)
 		}
 		// Nothing to do for 'UndelegateEnd'.
 	}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -365,8 +365,11 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 						// Ref: https://github.com/oasisprotocol/oasis-sdk/blob/runtime-sdk/v0.8.4/runtime-sdk/src/modules/consensus_accounts/mod.rs#L418
 						to = blockTransactionData.SignerData[0].Address
 					}
-					// Set the 'Success' field to 'Pending' for deposits. This is because the outcome of the Deposit tx is only known in the next block.
-					blockTransactionData.Success = nil
+					// If transaction has not failed, set the 'Success' field to 'Pending' for deposits.
+					// This is because the outcome of the Deposit tx is only known in the next block.
+					if blockTransactionData.Success != nil && *blockTransactionData.Success {
+						blockTransactionData.Success = nil
+					}
 					blockTransactionData.RelatedAccountAddresses[to] = struct{}{}
 					return nil
 				},
@@ -385,8 +388,11 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 						to = blockTransactionData.SignerData[0].Address
 					}
 					blockTransactionData.RelatedAccountAddresses[to] = struct{}{}
-					// Set the 'Success' field to 'Pending' for withdrawals. This is because the outcome of the Withdraw tx is only known in the next block.
-					blockTransactionData.Success = nil
+					// If transaction has not failed, set the 'Success' field to 'Pending' for withdrawals.
+					// This is because the outcome of the Withdraw tx is only known in the next block.
+					if blockTransactionData.Success != nil && *blockTransactionData.Success {
+						blockTransactionData.Success = nil
+					}
 
 					return nil
 				},
@@ -421,8 +427,11 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 						return fmt.Errorf("to: %w", err)
 					}
 					blockTransactionData.RelatedAccountAddresses[to] = struct{}{}
-					// Set the 'Success' field to 'Pending' for delegations. This is because the outcome of the Delegate tx is only known in the next block.
-					blockTransactionData.Success = nil
+					// If transaction has not failed, set the 'Success' field to 'Pending' for delegations.
+					// This is because the outcome of the Delegate tx is only known in the next block.
+					if blockTransactionData.Success != nil && *blockTransactionData.Success {
+						blockTransactionData.Success = nil
+					}
 					return nil
 				},
 				ConsensusAccountsUndelegate: func(body *consensusaccounts.Undelegate) error {
@@ -441,8 +450,11 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					// the validator's token pool might change, e.g. because of slashing.
 					// Do not store `body.Shares` in DB's `amount` to avoid confusion. Clients can still look up the shares in the tx body if they really need it.
 
-					// Set the 'Success' field to 'Pending' for undelegations. This is because the outcome of the Undelegate tx is only known in the next block.
-					blockTransactionData.Success = nil
+					// If transaction has not failed, set the 'Success' field to 'Pending' for undelegations.
+					// This is because the outcome of the Undelegate tx is only known in the next block.
+					if blockTransactionData.Success != nil && *blockTransactionData.Success {
+						blockTransactionData.Success = nil
+					}
 					return nil
 				},
 				EVMCreate: func(body *sdkEVM.Create, ok *[]byte) error {

--- a/storage/migrations/22_runtime_transactions_status_fix.up.sql
+++ b/storage/migrations/22_runtime_transactions_status_fix.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+-- Fix status field for transactions that had failed, but were mistakenly
+-- overriden as pending.
+UPDATE chain.runtime_transactions
+	SET success = false
+	WHERE success IS NULL
+	AND method IN (
+		'consensus.Deposit',
+		'consensus.Delegate',
+		'consensus.Withdraw',
+		'consensus.Undelegate'
+	)
+	AND error_message_raw IS NOT NULL;
+
+-- Fix status field for successful 'consensus.Undelegate' transactions, which
+-- were not correctly handled before.
+UPDATE chain.runtime_transactions tx
+	SET success = true
+	WHERE
+		tx.method = 'consensus.Undelegate'AND
+		tx.success IS NULL AND
+		EXISTS (
+			SELECT 1
+			FROM chain.runtime_transaction_signers rts
+			JOIN chain.runtime_events ev ON
+				ev.runtime = tx.runtime AND
+				ev.round = tx.round + 1 AND
+				ev.type = 'consensus_accounts.undelegate_start' AND
+				ev.body->>'to' = rts.signer_address
+			WHERE
+				rts.runtime = tx.runtime AND
+				rts.round = tx.round AND
+				rts.tx_index = tx.tx_index
+		);
+
+COMMIT;


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/963

Also do not override the success field for failed transactions.

TODO: 
- [x] check if there's a somewhat straightforward DB migration we can do to fix it for already processed txs.
- [x] in some rare cases, some other methods also have a missing status, look into it