### PR TITLE
api/transactions: Optimize related accounts filtering

### DIFF
--- a/.changelog/967.feature.md
+++ b/.changelog/967.feature.md
@@ -1,0 +1,1 @@
+Optimize Transactions query based on related address filter

--- a/tests/e2e_regression/common_test_cases.sh
+++ b/tests/e2e_regression/common_test_cases.sh
@@ -68,6 +68,9 @@ commonMainnetTestCases=(
   'delegations_to                     /v1/consensus/accounts/oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6/delegations_to'
   'debonding_delegations              /v1/consensus/accounts/oasis1qpk366qvtjrfrthjp3xuej5mhvvtnkr8fy02hm2s/debonding_delegations'
   'debonding_delegations_to           /v1/consensus/accounts/oasis1qp0j5v5mkxk3eg4kxfdsk8tj6p22g4685qk76fw6/debonding_delegations_to'
+  'txs_by_related_account             /v1/consensus/transactions?rel=oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3'
+  'txs_by_related_account_and_method  /v1/consensus/transactions?rel=oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5&method=staking.Transfer'
+  'txs_by_sender_and_method           /v1/consensus/transactions?sender=oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv&method=staking.Transfer'
 )
 
 commonEmeraldTestCases=(

--- a/tests/e2e_regression/damask/expected/txs_by_related_account.body
+++ b/tests/e2e_regression/damask/expected/txs_by_related_account.body
@@ -1,0 +1,80 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 2,
+  "transactions": [
+    {
+      "block": 8049565,
+      "body": {
+        "signatures": [
+          {
+            "public_key": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
+            "signature": "UgUQecbP3LDpFQvWh3XQJxS3b1uRpDDGZMxQ8yG4F63f3pQv3xTziHqOVACGr5VfYbXuB4D3QvMr9jHsvt0EDg=="
+          },
+          {
+            "public_key": "fr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yg=",
+            "signature": "PmyZlpvE0IMBNvg0kAig/BNxPTZJvtWzY3ciPwULeqVKs5fnOLY5ZMjiu+FQznqgWdpCL1+r2ag9QoSbEI+dCw=="
+          },
+          {
+            "public_key": "ZO3H0ByMWsodFIZHC75ETDWkIYB00ZAiaonDONdN358=",
+            "signature": "HGBr06yyaQLhnObeRpjauDr9vUCkDGVKknNBPVtj/viZh5ixO+DgV0JtvjaoxyZq8tM8LWdNgg68VZW5EuL3Dg=="
+          },
+          {
+            "public_key": "98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIY=",
+            "signature": "SZjDZAF2FGN7N9tbFqtaghqWmqoAJgDLEKuomSMV70ezn/e1+9CMa8P/QMfx36T+4e7pGol+lpxzW8Lf7aj1Cg=="
+          },
+          {
+            "public_key": "Vn5bvXh0D0UQPp76znn09yr7htOLsxlkSt6MXBjVLMg=",
+            "signature": "TwxaBxzr+sJ5iqDoahQq939zv8Gpf3HRWJgiAOMz+n26zYaatccKC0dqvxS3Q13kJBfjf+84ruxv8MaenFFzDg=="
+          }
+        ],
+        "untrusted_raw_value": "q2F2AmJpZFggSCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWpjcDJwomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhpYWRkcmVzc2Vz9mN0bHOjZ3B1Yl9rZXlYIFZ+W714dA9FED6e+s559Pcq+4bTi7MZZErejFwY1SzIaWFkZHJlc3Nlc/ZsbmV4dF9wdWJfa2V5WCDfGiyyEOtagz53OWe+Xm/rQfynp1ZYkv1L1HE3wGfEamN2cmahYmlkWCD3x7nJybp7q3PnFcNmBZH0nnzN6y9aK7JZOftP8lkEhmVyb2xlcwhocnVudGltZXP2aWNvbnNlbnN1c6JiaWRYIGTtx9AcjFrKHRSGRwu+REw1pCGAdNGQImqJwzjXTd+faWFkZHJlc3Nlc4GiYmlkWCB+v6eHKRCMiz/KUH21cb1M8Sef0taJIktKA4WEQRjnKGdhZGRyZXNzo2JJUFAAAAAAAAAAAAAA//+HtbByZFBvcnQZaCBkWm9uZWBpZW50aXR5X2lkWCD0P6TOJPEWGDvv5zK34XB3p5dESRnXAfDtZftUbnsx4GpleHBpcmF0aW9uGTRdcHNvZnR3YXJlX3ZlcnNpb25mMjIuMS4z"
+      },
+      "fee": "0",
+      "gas_limit": "1360",
+      "hash": "8e00f5beb25455a425d7d46f37d3f142d2a6bcc5eda9bf3a93f0e61b70a1258b",
+      "index": 1,
+      "method": "registry.RegisterNode",
+      "nonce": 13402,
+      "sender": "oasis1qrs74qakgmxcrj4vcvl6javrps65awk6x5656msr",
+      "success": true,
+      "timestamp": "2022-04-11T12:07:21Z"
+    },
+    {
+      "block": 8048958,
+      "body": {
+        "signatures": [
+          {
+            "public_key": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
+            "signature": "bXmLXHJQMXzpk1TYZH2qYYknGzfZZYh5ch/oZhq0phyqkUy1D0S2DwEledbEY/rxnvknzHUiSWzMW0tQ8cfoBA=="
+          },
+          {
+            "public_key": "fr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yg=",
+            "signature": "xNNeuBNVIeM1a1xcSzZwpv4uwe9ZBU8+XumlTGJAQny6+UVbcCLEj4eZLNYmwK7HDlpW8tgqLG7n6BsWzn6VDw=="
+          },
+          {
+            "public_key": "ZO3H0ByMWsodFIZHC75ETDWkIYB00ZAiaonDONdN358=",
+            "signature": "loKx83IJi/cs7j2pB6sval0G7EKjS52EaE9PDUEN5VYLHrZasFikWEDxiLQBJWy20QRfYOghwL5imh3mxbXpCw=="
+          },
+          {
+            "public_key": "98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIY=",
+            "signature": "j/qiU84B/+S3VMzDH+4GSv3ndPS+TH1EbK528Ikc3Huiez2F7RmF8C5g8m5yNKggjeZDxwOwrFgIVxa7yx5kCw=="
+          },
+          {
+            "public_key": "Vn5bvXh0D0UQPp76znn09yr7htOLsxlkSt6MXBjVLMg=",
+            "signature": "dbW8yFOzDQ9s6BsDVlrna9OTCd42rqrqZPzdNFGFl0racUFm2IUqGwr5h73Z10nNtw0HpLyhh/wU7AJu6NVmDg=="
+          }
+        ],
+        "untrusted_raw_value": "q2F2AmJpZFggSCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWpjcDJwomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhpYWRkcmVzc2Vz9mN0bHOjZ3B1Yl9rZXlYIFZ+W714dA9FED6e+s559Pcq+4bTi7MZZErejFwY1SzIaWFkZHJlc3Nlc/ZsbmV4dF9wdWJfa2V5WCDfGiyyEOtagz53OWe+Xm/rQfynp1ZYkv1L1HE3wGfEamN2cmahYmlkWCD3x7nJybp7q3PnFcNmBZH0nnzN6y9aK7JZOftP8lkEhmVyb2xlcwhocnVudGltZXP2aWNvbnNlbnN1c6JiaWRYIGTtx9AcjFrKHRSGRwu+REw1pCGAdNGQImqJwzjXTd+faWFkZHJlc3Nlc4GiYmlkWCB+v6eHKRCMiz/KUH21cb1M8Sef0taJIktKA4WEQRjnKGdhZGRyZXNzo2JJUFAAAAAAAAAAAAAA//+HtbByZFBvcnQZaCBkWm9uZWBpZW50aXR5X2lkWCD0P6TOJPEWGDvv5zK34XB3p5dESRnXAfDtZftUbnsx4GpleHBpcmF0aW9uGTRccHNvZnR3YXJlX3ZlcnNpb25mMjIuMS4z"
+      },
+      "fee": "0",
+      "gas_limit": "1360",
+      "hash": "015d61feba5e6647aa52cd9302c567eb7f3c4e9262869793547464ba74a627b5",
+      "index": 73,
+      "method": "registry.RegisterNode",
+      "nonce": 13400,
+      "sender": "oasis1qrs74qakgmxcrj4vcvl6javrps65awk6x5656msr",
+      "success": true,
+      "timestamp": "2022-04-11T11:00:27Z"
+    }
+  ]
+}

--- a/tests/e2e_regression/damask/expected/txs_by_related_account.headers
+++ b/tests/e2e_regression/damask/expected/txs_by_related_account.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Transfer-Encoding: chunked
+

--- a/tests/e2e_regression/damask/expected/txs_by_related_account_and_method.body
+++ b/tests/e2e_regression/damask/expected/txs_by_related_account_and_method.body
@@ -1,0 +1,5 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 0,
+  "transactions": []
+}

--- a/tests/e2e_regression/damask/expected/txs_by_related_account_and_method.headers
+++ b/tests/e2e_regression/damask/expected/txs_by_related_account_and_method.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/damask/expected/txs_by_sender_and_method.body
+++ b/tests/e2e_regression/damask/expected/txs_by_sender_and_method.body
@@ -1,0 +1,5 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 0,
+  "transactions": []
+}

--- a/tests/e2e_regression/damask/expected/txs_by_sender_and_method.headers
+++ b/tests/e2e_regression/damask/expected/txs_by_sender_and_method.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden/expected/txs_by_related_account.body
+++ b/tests/e2e_regression/eden/expected/txs_by_related_account.body
@@ -1,0 +1,117 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 3,
+  "transactions": [
+    {
+      "block": 16818567,
+      "body": {
+        "signatures": [
+          {
+            "public_key": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
+            "signature": "h8T1ibI9k7X73Qpio21/+4wWKlvFJB53fCkpabv8ogOMyZIHJHPEISlwYh0rLndno3Srzvinsu/kXkfbYuPDCA=="
+          },
+          {
+            "public_key": "fr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yg=",
+            "signature": "x0ugLKDEZ3IHuTgM2AYl2Umdo3gCdyuigQ+1RqSg8at4JXN5RBy/TwVsAmoKmQxxl5k89BE5QRZPrUTRTstODw=="
+          },
+          {
+            "public_key": "ZO3H0ByMWsodFIZHC75ETDWkIYB00ZAiaonDONdN358=",
+            "signature": "N8/FjtbP61zrLKr+SJKIOYYAHbm2moZ7beSYdTEtW/B4X4GLRxBC+LAJQmgwyJRhYX/1Qoh4xxM+nkcTlXKGCg=="
+          },
+          {
+            "public_key": "98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIY=",
+            "signature": "Mdub7Aq3ZAsZzKtrIo0KpvcmqKfcH2lczYNH8zd5y1rugArNoyrOfmTbbM4nTeikLKfbvJgGRC29lWmLW1PbDQ=="
+          },
+          {
+            "public_key": "P1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0M=",
+            "signature": "w7eCBZAg8BvTdZ8WI/aafWy4H0b9r6KD2DCMwRNm9lGO5IvdzEw+dkD+6GiuHiKJ++jFi31D8Rw+FHQe306EDA=="
+          }
+        ],
+        "untrusted_raw_value": "q2F2A2JpZFggSCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWpjcDJwomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhpYWRkcmVzc2VzgaNiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GSPwZFpvbmVgY3Rsc6FncHViX2tleVggP1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0NjdnJmoWJpZFgg98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIZlcm9sZXMIaHJ1bnRpbWVz9mljb25zZW5zdXOiYmlkWCBk7cfQHIxayh0UhkcLvkRMNaQhgHTRkCJqicM4103fn2lhZGRyZXNzZXOBomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhnYWRkcmVzc6NiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GaagZFpvbmVgaWVudGl0eV9pZFgg9D+kziTxFhg77+cyt+Fwd6eXREkZ1wHw7WX7VG57MeBqZXhwaXJhdGlvbhltdHBzb2Z0d2FyZV92ZXJzaW9uaTAuMC11bnNldA=="
+      },
+      "fee": "0",
+      "gas_limit": "1340",
+      "hash": "b6c552cd72e5f9b1ee1c994565e4250d06cf180f0a2fdd90ed5a5cf4879ff060",
+      "index": 0,
+      "method": "registry.RegisterNode",
+      "nonce": 42647,
+      "sender": "oasis1qrs74qakgmxcrj4vcvl6javrps65awk6x5656msr",
+      "success": true,
+      "timestamp": "2023-11-29T17:33:07Z"
+    },
+    {
+      "block": 16818187,
+      "body": {
+        "signatures": [
+          {
+            "public_key": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
+            "signature": "d5lluIwxjEFs/tK0uBcoe5gnUoinv8FGcDly8c9deykqeyC1AgNnQsvm9wc+7Haqg4AKPvn4FSEaP8YehiLACQ=="
+          },
+          {
+            "public_key": "fr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yg=",
+            "signature": "UGvSY7IQb5UZyuD9moJVeeKgH57ZsF2fpBhY64EKj77WGFu3XuUPeSqxRDecUCkz3nJyfxt6jm1GmxLTa8xcCQ=="
+          },
+          {
+            "public_key": "ZO3H0ByMWsodFIZHC75ETDWkIYB00ZAiaonDONdN358=",
+            "signature": "bC+T/b060DiB6BD4LQVd0UqGGnakqusVm+YTC+wUEd1Y8/ioeKVzPpDMrnXYxO8ne/8sap45PBQUiuWTqfMGAA=="
+          },
+          {
+            "public_key": "98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIY=",
+            "signature": "e6CcM8vhulX3raOLPDO7xSU4wtA5GH96ttX0m2s/CrizWWOXkaOpzalFB55BovLeI7sBZLsgfRBt0bkTD1qXCg=="
+          },
+          {
+            "public_key": "P1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0M=",
+            "signature": "pzrIcZKk0ZpOjptkzCipOZ3kIH4ofix+6CPM7mbBC6vEen8pZI2Tno95I2dJA3I1OmshNRsjycycA3Zx8q89Cw=="
+          }
+        ],
+        "untrusted_raw_value": "q2F2A2JpZFggSCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWpjcDJwomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhpYWRkcmVzc2VzgaNiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GSPwZFpvbmVgY3Rsc6FncHViX2tleVggP1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0NjdnJmoWJpZFgg98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIZlcm9sZXMIaHJ1bnRpbWVz9mljb25zZW5zdXOiYmlkWCBk7cfQHIxayh0UhkcLvkRMNaQhgHTRkCJqicM4103fn2lhZGRyZXNzZXOBomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhnYWRkcmVzc6NiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GaagZFpvbmVgaWVudGl0eV9pZFgg9D+kziTxFhg77+cyt+Fwd6eXREkZ1wHw7WX7VG57MeBqZXhwaXJhdGlvbhltc3Bzb2Z0d2FyZV92ZXJzaW9uaTAuMC11bnNldA=="
+      },
+      "fee": "0",
+      "gas_limit": "1340",
+      "hash": "2b30c130d17b5dd6bf42ccc3c2aa132778bae259aee6eb6ecbffe9c7da39cee5",
+      "index": 17,
+      "method": "registry.RegisterNode",
+      "nonce": 42645,
+      "sender": "oasis1qrs74qakgmxcrj4vcvl6javrps65awk6x5656msr",
+      "success": true,
+      "timestamp": "2023-11-29T16:51:31Z"
+    },
+    {
+      "block": 16817958,
+      "body": {
+        "signatures": [
+          {
+            "public_key": "SCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWo=",
+            "signature": "d5lluIwxjEFs/tK0uBcoe5gnUoinv8FGcDly8c9deykqeyC1AgNnQsvm9wc+7Haqg4AKPvn4FSEaP8YehiLACQ=="
+          },
+          {
+            "public_key": "fr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yg=",
+            "signature": "UGvSY7IQb5UZyuD9moJVeeKgH57ZsF2fpBhY64EKj77WGFu3XuUPeSqxRDecUCkz3nJyfxt6jm1GmxLTa8xcCQ=="
+          },
+          {
+            "public_key": "ZO3H0ByMWsodFIZHC75ETDWkIYB00ZAiaonDONdN358=",
+            "signature": "bC+T/b060DiB6BD4LQVd0UqGGnakqusVm+YTC+wUEd1Y8/ioeKVzPpDMrnXYxO8ne/8sap45PBQUiuWTqfMGAA=="
+          },
+          {
+            "public_key": "98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIY=",
+            "signature": "e6CcM8vhulX3raOLPDO7xSU4wtA5GH96ttX0m2s/CrizWWOXkaOpzalFB55BovLeI7sBZLsgfRBt0bkTD1qXCg=="
+          },
+          {
+            "public_key": "P1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0M=",
+            "signature": "pzrIcZKk0ZpOjptkzCipOZ3kIH4ofix+6CPM7mbBC6vEen8pZI2Tno95I2dJA3I1OmshNRsjycycA3Zx8q89Cw=="
+          }
+        ],
+        "untrusted_raw_value": "q2F2A2JpZFggSCA1zoR15jpC2eugP1P/CZBQhMjHEtmJ7+hWemgTdWpjcDJwomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhpYWRkcmVzc2VzgaNiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GSPwZFpvbmVgY3Rsc6FncHViX2tleVggP1Hxpy91X4wsE1o3aHO2+JFdtlQ9uAV0IyHK1enIY0NjdnJmoWJpZFgg98e5ycm6e6tz5xXDZgWR9J58zesvWiuyWTn7T/JZBIZlcm9sZXMIaHJ1bnRpbWVz9mljb25zZW5zdXOiYmlkWCBk7cfQHIxayh0UhkcLvkRMNaQhgHTRkCJqicM4103fn2lhZGRyZXNzZXOBomJpZFggfr+nhykQjIs/ylB9tXG9TPEnn9LWiSJLSgOFhEEY5yhnYWRkcmVzc6NiSVBQAAAAAAAAAAAAAP//w71hD2RQb3J0GaagZFpvbmVgaWVudGl0eV9pZFgg9D+kziTxFhg77+cyt+Fwd6eXREkZ1wHw7WX7VG57MeBqZXhwaXJhdGlvbhltc3Bzb2Z0d2FyZV92ZXJzaW9uaTAuMC11bnNldA=="
+      },
+      "fee": "0",
+      "gas_limit": "1340",
+      "hash": "8f78e841245008b29611b8a64a7b31e2c416729e22712a70e7086c0ed9f10f4e",
+      "index": 3,
+      "method": "registry.RegisterNode",
+      "nonce": 42644,
+      "sender": "oasis1qrs74qakgmxcrj4vcvl6javrps65awk6x5656msr",
+      "success": true,
+      "timestamp": "2023-11-29T11:25:24Z"
+    }
+  ]
+}

--- a/tests/e2e_regression/eden/expected/txs_by_related_account.headers
+++ b/tests/e2e_regression/eden/expected/txs_by_related_account.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Transfer-Encoding: chunked
+

--- a/tests/e2e_regression/eden/expected/txs_by_related_account_and_method.body
+++ b/tests/e2e_regression/eden/expected/txs_by_related_account_and_method.body
@@ -1,0 +1,54 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 3,
+  "transactions": [
+    {
+      "block": 16818803,
+      "body": {
+        "amount": "2490000000",
+        "to": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv"
+      },
+      "fee": "0",
+      "gas_limit": "1300",
+      "hash": "f5ebd2503d74e5f1b885805b115f97692002d71abc2abd5781cbf43fabf06039",
+      "index": 1,
+      "method": "staking.Transfer",
+      "nonce": 0,
+      "sender": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5",
+      "success": true,
+      "timestamp": "2023-11-29T17:55:30Z"
+    },
+    {
+      "block": 16818568,
+      "body": {
+        "amount": "1200000000",
+        "to": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5"
+      },
+      "fee": "0",
+      "gas_limit": "1300",
+      "hash": "28439354075cac2020962fde405af1b849ac649ea06ae20d6f92afe3f4dce55d",
+      "index": 3,
+      "method": "staking.Transfer",
+      "nonce": 3,
+      "sender": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv",
+      "success": true,
+      "timestamp": "2023-11-29T17:33:12Z"
+    },
+    {
+      "block": 16818184,
+      "body": {
+        "amount": "1300000000",
+        "to": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5"
+      },
+      "fee": "0",
+      "gas_limit": "1300",
+      "hash": "f8392d609c4c304f37b7ca75ae03bd98e431fc4fe42b18704788b0fa150c9d7a",
+      "index": 2,
+      "method": "staking.Transfer",
+      "nonce": 2,
+      "sender": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv",
+      "success": true,
+      "timestamp": "2023-11-29T11:54:43Z"
+    }
+  ]
+}

--- a/tests/e2e_regression/eden/expected/txs_by_related_account_and_method.headers
+++ b/tests/e2e_regression/eden/expected/txs_by_related_account_and_method.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden/expected/txs_by_sender_and_method.body
+++ b/tests/e2e_regression/eden/expected/txs_by_sender_and_method.body
@@ -1,0 +1,38 @@
+{
+  "is_total_count_clipped": false,
+  "total_count": 2,
+  "transactions": [
+    {
+      "block": 16818568,
+      "body": {
+        "amount": "1200000000",
+        "to": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5"
+      },
+      "fee": "0",
+      "gas_limit": "1300",
+      "hash": "28439354075cac2020962fde405af1b849ac649ea06ae20d6f92afe3f4dce55d",
+      "index": 3,
+      "method": "staking.Transfer",
+      "nonce": 3,
+      "sender": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv",
+      "success": true,
+      "timestamp": "2023-11-29T17:33:12Z"
+    },
+    {
+      "block": 16818184,
+      "body": {
+        "amount": "1300000000",
+        "to": "oasis1qqwllxt8tvqxt8sryeg3r8ts0yulyu8frqr2kzg5"
+      },
+      "fee": "0",
+      "gas_limit": "1300",
+      "hash": "f8392d609c4c304f37b7ca75ae03bd98e431fc4fe42b18704788b0fa150c9d7a",
+      "index": 2,
+      "method": "staking.Transfer",
+      "nonce": 2,
+      "sender": "oasis1qr85nf4hnsw6crrf9l9ppzq5ucyynnzqqy300cyv",
+      "success": true,
+      "timestamp": "2023-11-29T11:54:43Z"
+    }
+  ]
+}

--- a/tests/e2e_regression/eden/expected/txs_by_sender_and_method.headers
+++ b/tests/e2e_regression/eden/expected/txs_by_sender_and_method.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+


### PR DESCRIPTION
Fixes #966

Split Transactions query based on the presence of related address filter.




