### PR TITLE
api/rofl: Add endpoint for fetching a specific rofl app instance

### DIFF
--- a/.changelog/982.feature.md
+++ b/.changelog/982.feature.md
@@ -1,0 +1,4 @@
+api/rofl: Add endpoint for fetching a specific rofl app instance
+
+- `/{runtime}/rofl_apps/{id}/instances/{rak}` - returns a specific
+ROFL app instance

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1352,6 +1352,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/RoflAppInstanceList'
 
+  /{runtime}/rofl_apps/{id}/instances/{rak}:
+    get:
+      summary: Returns a specific ROFL instance.
+      parameters:
+        - *runtime
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The ID of the ROFL app to return an instance for.
+        - in: path
+          name: rak
+          required: true
+          schema:
+            type: string
+          description: The RAK of the ROFL instance to return.
+      responses:
+        '200':
+          description: A JSON object containing a ROFL instance.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoflInstance'
+        <<: *common_error_responses
+
   /{runtime}/rofl_apps/{id}/instances/{rak}/transactions:
     get:
       summary: Returns a list of transactions submitted by the given ROFL instance.

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -480,11 +480,22 @@ func (srv *StrictServerImpl) GetRuntimeRoflAppsIdInstanceTransactions(ctx contex
 }
 
 func (srv *StrictServerImpl) GetRuntimeRoflAppsIdInstances(ctx context.Context, request apiTypes.GetRuntimeRoflAppsIdInstancesRequestObject) (apiTypes.GetRuntimeRoflAppsIdInstancesResponseObject, error) {
-	instances, err := srv.dbClient.RuntimeRoflAppInstances(ctx, request.Params, request.Id)
+	instances, err := srv.dbClient.RuntimeRoflAppInstances(ctx, request.Params, request.Id, nil)
 	if err != nil {
 		return nil, err
 	}
 	return apiTypes.GetRuntimeRoflAppsIdInstances200JSONResponse(*instances), nil
+}
+
+func (srv *StrictServerImpl) GetRuntimeRoflAppsIdInstancesRak(ctx context.Context, request apiTypes.GetRuntimeRoflAppsIdInstancesRakRequestObject) (apiTypes.GetRuntimeRoflAppsIdInstancesRakResponseObject, error) {
+	instances, err := srv.dbClient.RuntimeRoflAppInstances(ctx, apiTypes.GetRuntimeRoflAppsIdInstancesParams{Limit: common.Ptr(uint64(1)), Offset: common.Ptr(uint64(0))}, request.Id, &request.Rak)
+	if err != nil {
+		return nil, err
+	}
+	if len(instances.Instances) != 1 {
+		return apiTypes.GetRuntimeRoflAppsIdInstancesRak404JSONResponse{}, nil
+	}
+	return apiTypes.GetRuntimeRoflAppsIdInstancesRak200JSONResponse(instances.Instances[0]), nil
 }
 
 func (srv *StrictServerImpl) GetRuntimeRoflAppsIdInstancesRakTransactions(ctx context.Context, request apiTypes.GetRuntimeRoflAppsIdInstancesRakTransactionsRequestObject) (apiTypes.GetRuntimeRoflAppsIdInstancesRakTransactionsResponseObject, error) {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -2540,12 +2540,13 @@ func (c *StorageClient) RuntimeRoflApps(ctx context.Context, params apiTypes.Get
 }
 
 // RuntimeRoflAppInstances returns a list of ROFL app instances.
-func (c *StorageClient) RuntimeRoflAppInstances(ctx context.Context, params apiTypes.GetRuntimeRoflAppsIdInstancesParams, id string) (*RoflAppInstanceList, error) {
+func (c *StorageClient) RuntimeRoflAppInstances(ctx context.Context, params apiTypes.GetRuntimeRoflAppsIdInstancesParams, id string, rak *string) (*RoflAppInstanceList, error) {
 	res, err := c.withTotalCount(
 		ctx,
 		queries.RuntimeRoflAppInstances,
 		runtimeFromCtx(ctx),
 		id,
+		rak,
 		params.Limit,
 		params.Offset,
 	)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -1141,11 +1141,13 @@ const (
 			expiration_epoch,
 			extra_keys
 		FROM chain.rofl_instances
-		WHERE runtime = $1::runtime AND
-			app_id = $2::text
+		WHERE
+			runtime = $1::runtime AND
+			app_id = $2::text AND
+			($3::text IS NULL OR rak = $3::text)
 		ORDER BY expiration_epoch DESC
-		LIMIT $3::bigint
-		OFFSET $4::bigint`
+		LIMIT $4::bigint
+		OFFSET $5::bigint`
 
 	RuntimeRoflAppInstanceTransactions = `
 		WITH filtered AS (

--- a/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_instance.body
+++ b/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_instance.body
@@ -1,0 +1,9 @@
+{
+  "endorsing_node_id": "7zI/cYuiUTPz61PL9M7f1Q/7b43nG0xk1w6yGde+msQ=",
+  "expiration_epoch": 42724,
+  "extra_keys": [
+    "{\"secp256k1\":\"A/F6qq+T7UR+BM8s+KdHJ0TiufRTcE7odkURAWXSqafC\"}"
+  ],
+  "rak": "8EUGnz+hAqblEMWh+ZHKyZU7CSItm1wrJqK15dAjlfI=",
+  "rek": "QqMeqt6vnRTRiSJOY/3DeSqaC0GupgkZcBjRtOsIQ0c="
+}

--- a/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_instance.headers
+++ b/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_instance.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden_testnet_2025/test_cases.sh
+++ b/tests/e2e_regression/eden_testnet_2025/test_cases.sh
@@ -33,6 +33,7 @@ testCases=(
   'sapphire_account_with_evm_token                     /v1/sapphire/accounts/0xeDA395666E56dd9E2Ef3Bdc76eee373b738640DD'
   'sapphire_rofl_app                                   /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw'
   'sapphire_rofl_app_instances                         /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instances'
+  'sapphire_rofl_app_instance                          /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instances/8EUGnz+hAqblEMWh+ZHKyZU7CSItm1wrJqK15dAjlfI='
   'sapphire_rofl_app_transactions                      /v1/sapphire/rofl_apps/rofl1qr5s5r9pkdkhmj7l5z4nuncjkc05p62m9uqa2svc/transactions'
   'sapphire_rofl_app_instance_transactions             /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instance_transactions'
   'sapphire_rofl_app_instance_transactions_method      /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instance_transactions?method=rofl.Register'


### PR DESCRIPTION
This endpoint was missed in the initial rofl API implementation.