### PR TITLE
api/rofl_apps: Optimize rofl apps query

### DIFF
--- a/.changelog/998.bugfix.md
+++ b/.changelog/998.bugfix.md
@@ -1,0 +1,4 @@
+api/rofl_apps: Optimize rofl apps query
+
+Additionally, the api/rofl_apps is now limited to returning at most 100
+responses, down from 1000.

--- a/analyzer/rofl/instance_transactions/instance_transactions.go
+++ b/analyzer/rofl/instance_transactions/instance_transactions.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/oasisprotocol/nexus/analyzer"
 	"github.com/oasisprotocol/nexus/analyzer/item"
+	"github.com/oasisprotocol/nexus/analyzer/queries"
 	"github.com/oasisprotocol/nexus/common"
 	"github.com/oasisprotocol/nexus/config"
 	"github.com/oasisprotocol/nexus/log"
@@ -172,6 +173,11 @@ func (p *processor) ProcessItem(ctx context.Context, batch *storage.QueryBatch, 
 			txIndex,
 			method,
 			isNativeTransfer,
+		)
+		batch.Queue(
+			queries.RuntimeRoflNumTransactionsIncrement,
+			p.runtime,
+			item.AppID,
 		)
 	}
 

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -424,6 +424,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		m.queueTransactionInsert(batch, data.Header.Round, data.Header.Timestamp, transactionData)
 		for appID := range transactionData.RelatedRoflAddresses {
 			batch.Queue(queries.RuntimeRoflRelatedTransactionInsert, m.runtime, appID, data.Header.Round, transactionData.Index, transactionData.Method, transactionData.IsLikelyTokenTransfer)
+			batch.Queue(queries.RuntimeRoflNumTransactionsIncrement, m.runtime, appID)
 		}
 
 		if transactionData.ContractCandidate != nil {

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -37,6 +37,17 @@ x-query-params:
       maximum: 1000
     description: |
       The maximum numbers of items to return.
+  - &limit100
+    in: query
+    name: limit
+    schema:
+      type: integer
+      format: uint64
+      default: 100
+      minimum: 1
+      maximum: 100
+    description: |
+      The maximum numbers of items to return.
   - &height
     in: query
     name: height
@@ -1250,7 +1261,7 @@ paths:
     get:
       summary: Returns a list of ROFL apps on the runtime.
       parameters:
-        - *limit
+        - *limit100
         - *offset
         - *runtime
         - in: query

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -478,6 +478,8 @@ CREATE TABLE chain.runtime_sdk_balances (
 --   metadata JSONB, -- arbitrary key/value pairs.
 --   secrets JSONB, -- arbitrary key/value pairs.
 
+--   num_transactions UINT63 NOT NULL, -- Added in 27_runtime_rofl_num_transactions.up.sql.
+
 --   removed BOOLEAN NOT NULL DEFAULT FALSE,
 
 --   -- Fields for analyzer tracking.

--- a/storage/migrations/19_runtime_rofl.up.sql
+++ b/storage/migrations/19_runtime_rofl.up.sql
@@ -17,6 +17,8 @@ CREATE TABLE chain.rofl_apps
   -- metadata_name TEXT, -- Name, extracted from metadata key `net.oasis.rofl.name`. -- Added in 26_runtime_rofl_metadata_name.up.sql.
   secrets JSONB, -- arbitrary key/value pairs.
 
+  -- num_transactions UINT63 NOT NULL, -- Added in 27_runtime_rofl_num_transactions.up.sql.
+
   removed BOOLEAN NOT NULL DEFAULT FALSE,
 
   -- Fields for analyzer tracking.

--- a/storage/migrations/26_runtime_rofl_metadata_name.up.sql
+++ b/storage/migrations/26_runtime_rofl_metadata_name.up.sql
@@ -4,8 +4,8 @@ ALTER TABLE chain.rofl_apps ADD COLUMN metadata_name TEXT;
 
 -- Populate name from metadata JSON (it's optionally present in the metadata key-value pairs).
 UPDATE chain.rofl_apps
-	SET metadata_name = metadata->>'net.oasis.rofl.name'
-	WHERE metadata ? 'net.oasis.rofl.name';
+  SET metadata_name = metadata->>'net.oasis.rofl.name'
+  WHERE metadata ? 'net.oasis.rofl.name';
 
 -- Create index on the name.
 CREATE INDEX ix_rofl_apps_metadata_name ON chain.rofl_apps (runtime, metadata_name);

--- a/storage/migrations/27_runtime_rofl_num_transactions.up.sql
+++ b/storage/migrations/27_runtime_rofl_num_transactions.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+ALTER TABLE chain.rofl_apps
+  ADD COLUMN num_transactions UINT63 NOT NULL DEFAULT 0;
+
+-- Populate num_transactions from rofl related and instance transactions.
+UPDATE chain.rofl_apps apps
+  SET num_transactions = tx_counts.total
+  FROM (
+    SELECT runtime, app_id, COUNT(*) AS total
+    FROM (
+      SELECT runtime, app_id
+      FROM chain.rofl_related_transactions
+
+      UNION ALL
+
+      SELECT runtime, app_id
+      FROM chain.rofl_instance_transactions
+    ) all_tx
+    GROUP BY runtime, app_id
+  ) tx_counts
+  WHERE
+    apps.runtime = tx_counts.runtime AND apps.id = tx_counts.app_id;
+
+COMMIT;


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/989

Some fixes/optimisation for the rofl apps query:
- num_transactions is kept in DB, avoiding the need to compute the number of all rofl related transactions on the fly (this was getting huge, since we had to count all transactions ever submitted by all rofl instances for each rofl app)
- separate query to fetch first/last activity txs for ROFL apps, that way we only fetch these for the selected matched ROFL apps (e.g. 10 or 100) and not all ROFL apps


TODO:
- [x] test on live db