### PR TITLE
Add epoch index for history.validators

### DIFF
--- a/.changelog/1032.feature.md
+++ b/.changelog/1032.feature.md
@@ -1,0 +1,1 @@
+Add epoch index for history.validators

--- a/storage/migrations/00_consensus.up.sql
+++ b/storage/migrations/00_consensus.up.sql
@@ -399,6 +399,8 @@ CREATE TABLE history.validators
     num_delegators UINT63,
     staking_rewards UINT_NUMERIC -- Note: staking rewards are granted in the first block of the subsequent epoch
 );
+-- Index for efficient query of validators by epoch.
+-- CREATE INDEX ix_validators_epoch ON history.validators (epoch); -- Added in 35_history_validators_epoch_idx.up.sql.
 
 CREATE TABLE history.escrow_events
 (

--- a/storage/migrations/35_history_validators_epoch_idx.up.sql
+++ b/storage/migrations/35_history_validators_epoch_idx.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS ix_validators_epoch ON history.validators (epoch);
+
+COMMIT;


### PR DESCRIPTION
This makes the query `ValidatorStakingHistoryUnprocessedEpochs`  used by validator_history analyzer efficient.

The table and the index are small compared to other tables, so overhead by adding this index is small.