### PR TITLE
Update oasis-sdk to include rofl tx fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/oasisprotocol/metadata-registry-tools v0.0.0-20240304080528-3218befba9ca
 	github.com/oasisprotocol/oasis-core/go v0.2503.0
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.0
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.1-0.20250604102908-26d1cef956b7
 	github.com/rs/cors v1.11.1
 	go.dedis.ch/kyber/v3 v3.1.0
 	golang.org/x/crypto v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/oasisprotocol/oasis-core/go v0.2503.0 h1:3Vs45JnvZCYbr5a7xSB9mBV7kna0
 github.com/oasisprotocol/oasis-core/go v0.2503.0/go.mod h1:0wO1wYzDCNToNemyt/wF+1BjcrSBRyw6MJrWr7LvrJs=
 github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.0 h1:c+m1aKhT0/hyt3uwh6jl15Rc0TAWRmW0z+BJb0kqQK8=
 github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.0/go.mod h1:cLtdOgAtSsVGQAZ1KWCXCgnj9CzNeOOEWUMZB0PIBeA=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.1-0.20250604102908-26d1cef956b7 h1:8hXUr4NJfeZMg/JPJc6tviDEbU8MG6BRxELJI8j40UQ=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.15.1-0.20250604102908-26d1cef956b7/go.mod h1:cLtdOgAtSsVGQAZ1KWCXCgnj9CzNeOOEWUMZB0PIBeA=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=


### PR DESCRIPTION
Includes: https://github.com/oasisprotocol/oasis-sdk/pull/2230

After the fix is confirmed, tag a new oasis-sdk version and update to that.