### PR TITLE
analyer/block: Simplify and improve batch processing

### DIFF
--- a/.changelog/1068.feature.md
+++ b/.changelog/1068.feature.md
@@ -1,0 +1,1 @@
+analyer/block: Simplify and improve batch processing

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -239,7 +239,7 @@ func (m *processor) ProcessBlock(ctx context.Context, round uint64) error {
 	blockHeader, err := m.source.GetBlockHeader(ctx, round)
 	if err != nil {
 		if strings.Contains(err.Error(), "roothash: block not found") {
-			return analyzer.ErrOutOfRange
+			return fmt.Errorf("%w: %v", analyzer.ErrOutOfRange, err)
 		}
 		return err
 	}


### PR DESCRIPTION
In the old code, when the block analyzer was near the head of the chain, the backoff was almost always at 6 seconds. 

See retry interval quickly increasing to 6 seconds on a recently started node that is at the head of the chain:

```json
{"analyzer":"sapphire","caller":"block.go:420","height":12287791,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":100,"ts":"2025-06-25T08:36:03.901279912Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287791,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":200,"ts":"2025-06-25T08:36:04.13376454Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287791,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":400,"ts":"2025-06-25T08:36:04.570368877Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287791,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":800,"ts":"2025-06-25T08:36:05.403994745Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287792,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":1440,"ts":"2025-06-25T08:36:07.952763714Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287792,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":2880,"ts":"2025-06-25T08:36:10.862558227Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287794,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":4665,"ts":"2025-06-25T08:36:21.879480568Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287798,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":6000,"ts":"2025-06-25T08:36:46.568709867Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287803,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":6000,"ts":"2025-06-25T08:37:21.578675488Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287810,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":5739,"ts":"2025-06-25T08:38:03.155313823Z"}
{"analyzer":"sapphire","caller":"block.go:420","height":12287817,"level":"info","mode":"slow-sync","module":"analysis_service","msg":"no data available; will retry","retry_interval_ms":5490,"ts":"2025-06-25T08:38:43.316051961Z"}
```

This often caused the analyzers to lag behind the head by 1–2 blocks. There were a couple of reasons for this, so we’ve restructured the code, simplified the logic, and adjusted the backoff behavior for block analyzers.

Summary of changes:
- Added detection for when we are at the head of the chain (`isRecentOutOfRangeError`). In such cases, we now poll every 1 second.
- Increased the maximum backoff to 30 seconds (can be raised in the future) for errors not related to being at the head of the chain.


In practice, a failing analyzer should now send queries less frequently (previously every 6 seconds, now up to a 30-second maximum timeout). However, after recovering, or when at the head of the chain, it should resume polling more quickly (every 1 second).