### PR TITLE
rofl_instances: Support rofl instance metadata

### DIFF
--- a/.changelog/1071.feature.md
+++ b/.changelog/1071.feature.md
@@ -1,0 +1,1 @@
+rofl_instances: Support rofl instance metadata

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -1360,9 +1360,9 @@ var (
         WHERE runtime = $1::runtime AND id = $2
       )
 
-    INSERT INTO chain.rofl_instances (runtime, app_id, rak, endorsing_node_id, endorsing_entity_id, rek, expiration_epoch, extra_keys, registration_round, last_processed_round)
+    INSERT INTO chain.rofl_instances (runtime, app_id, rak, endorsing_node_id, endorsing_entity_id, rek, expiration_epoch, metadata, extra_keys, registration_round, last_processed_round)
     SELECT
-      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
     FROM
       check_app
     ON CONFLICT (runtime, app_id, rak) DO UPDATE
@@ -1371,6 +1371,7 @@ var (
       endorsing_entity_id = excluded.endorsing_entity_id,
       rek = excluded.rek,
       expiration_epoch = excluded.expiration_epoch,
+      metadata = excluded.metadata,
       extra_keys = excluded.extra_keys,
       registration_round = LEAST(excluded.registration_round, chain.rofl_instances.registration_round),
       last_processed_round = COALESCE(chain.rofl_instances.last_processed_round, excluded.last_processed_round)`

--- a/analyzer/rofl/rofl.go
+++ b/analyzer/rofl/rofl.go
@@ -172,6 +172,7 @@ func (p *processor) queueRoflAppInstancesRefresh(ctx context.Context, batch *sto
 			entityID,
 			rek,
 			instance.Expiration,
+			instance.Metadata,
 			extraKeys,
 			// In case the ROFL analyzer would be lagging behind, this round is not necessary the registration round,
 			// since there could have been more events in the meantime. This means we might miss some early instance

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -4005,6 +4005,9 @@ components:
           type: integer
           format: uint64
           description: The epoch at which the instance expires.
+        metadata:
+          type: object
+          description: Arbitrary metadata key-value pairs, assigned by the application.
         extra_keys:
           type: array
           items:

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -2658,6 +2658,7 @@ func (c *StorageClient) RuntimeRoflAppInstances(ctx context.Context, runtime com
 			&instance.EndorsingEntityId,
 			&instance.Rek,
 			&instance.ExpirationEpoch,
+			&instance.Metadata,
 			&instance.ExtraKeys,
 		); err != nil {
 			return nil, wrapError(err)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -987,6 +987,7 @@ const (
 			endorsing_entity_id,
 			rek,
 			expiration_epoch,
+			metadata,
 			extra_keys
 		FROM chain.rofl_instances
 		WHERE

--- a/storage/migrations/19_runtime_rofl.up.sql
+++ b/storage/migrations/19_runtime_rofl.up.sql
@@ -46,6 +46,8 @@ CREATE TABLE chain.rofl_instances
   expiration_epoch UINT63 NOT NULL,
   extra_keys TEXT[],
 
+  -- metadata JSONB, -- Added in 42_runtime_rofl_instances_metadata.up.sql.
+
   -- Fields for rofl instance transactions analyzer progress tracking.
   registration_round UINT63 NOT NULL,
   last_processed_round UINT63 NOT NULL

--- a/storage/migrations/42_runtime_rofl_instances_metadata.up.sql
+++ b/storage/migrations/42_runtime_rofl_instances_metadata.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE chain.rofl_instances ADD COLUMN metadata JSONB;
+
+-- Schedule for refresh all active rofl apps.
+UPDATE chain.rofl_apps
+	SET last_processed_round = NULL
+	WHERE removed = FALSE;
+
+COMMIT;


### PR DESCRIPTION
Initially, rofl apps did not have metadata. Update rofl instances to support metadata and queue refresh of all active rofl apps, so that the instance metadata is fetched.