### PR TITLE
analyzer/consensus: Record timing only for successful requests

### DIFF
--- a/.changelog/1073.bugfix.md
+++ b/.changelog/1073.bugfix.md
@@ -1,0 +1,1 @@
+analyzer/consensus: Record timing only for successful requests

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -348,10 +348,11 @@ func (m *processor) ProcessBlock(ctx context.Context, uheight uint64) error {
 		// Fetch all data.
 		fetchTimer := m.metrics.BlockFetchLatencies()
 		data, err := fetchAllData(ctx, m.source, m.network, height, m.mode == analyzer.FastSyncMode)
-		fetchTimer.ObserveDuration()
 		if err != nil {
 			return err
 		}
+		// We make no observation in case of a data fetch error; those timings are misleading.
+		fetchTimer.ObserveDuration()
 
 		// Process data, prepare updates.
 		analysisTimer := m.metrics.BlockAnalysisLatencies()

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -256,8 +256,8 @@ func (m *processor) ProcessBlock(ctx context.Context, round uint64) error {
 	if err != nil {
 		return err
 	}
-
-	fetchTimer.ObserveDuration() // We make no observation in case of a data fetch error; those timings are misleading.
+	// We make no observation in case of a data fetch error; those timings are misleading.
+	fetchTimer.ObserveDuration()
 
 	// Preprocess data.
 	analysisTimer := m.metrics.BlockAnalysisLatencies()


### PR DESCRIPTION
This makes it consistent with other (runtime) block analyzers.