### PR TITLE
runtime/evm_tokens: Fetch Neby price for tokens

### DIFF
--- a/.changelog/1102.feature.md
+++ b/.changelog/1102.feature.md
@@ -1,0 +1,1 @@
+runtime/evm_tokens: Fetch Neby price for tokens

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -135,7 +135,7 @@ jobs:
 
   test-e2e-regression:
     env:
-      E2E_REGRESSION_ARTIFACTS_VERSION: 2025-05-30
+      E2E_REGRESSION_ARTIFACTS_VERSION: 2025-07-21-2
     strategy:
       matrix:
         suite:
@@ -174,12 +174,13 @@ jobs:
         run: |
           make postgres
 
-      - name: Block access to Sourcify
-        # Sourcify should not need to be available in CI; we run everything from caches.
+      - name: Block access to Sourcify and Neby Graph API
+        # These services should not be available in CI; we run everything from caches.
         # Enforce unavailability to keep tests confidently reproducible, and to catch
-        # any bugs that might cause CI to accidentally use Sourcify.
+        # any bugs that might cause CI to accidentally use live external services.
         run: |
           sudo bash -c 'echo 0.0.0.0 sourcify.dev | tee -a /etc/hosts'
+          sudo bash -c 'echo 0.0.0.0 graph.api.neby.exchange | tee -a /etc/hosts'
 
       - name: Run e2e regression tests
         run : |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
             - github.com/oasisprotocol/oasis-sdk
             - github.com/oasisprotocol/metadata-registry-tools
             - github.com/akrylysov/pogreb
+            - github.com/cockroachdb/apd
             - github.com/dgraph-io/ristretto
             - github.com/ethereum/go-ethereum
             - github.com/go-chi/chi/v5

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ E2E_REGRESSION_SUITES_NO_LINKS := eden_testnet_2025 eden_2025 eden damask
 # make E2E_REGRESSION_SUITES='suite1 suite2' test-e2e-regression
 E2E_REGRESSION_SUITES := $(E2E_REGRESSION_SUITES_NO_LINKS) edenfast
 
-E2E_REGRESSION_ARTIFACTS_VERSION = 2025-05-30
+E2E_REGRESSION_ARTIFACTS_VERSION = 2025-07-21-2
 
 upload-e2e-regression-caches:
 	for suite in $(E2E_REGRESSION_SUITES); do \

--- a/analyzer/neby_prices/neby_prices.go
+++ b/analyzer/neby_prices/neby_prices.go
@@ -1,0 +1,155 @@
+// Package nebyprices implements the Neby prices analyzer.
+package nebyprices
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/oasisprotocol/nexus/analyzer"
+	"github.com/oasisprotocol/nexus/analyzer/httpmisc"
+	"github.com/oasisprotocol/nexus/analyzer/item"
+	"github.com/oasisprotocol/nexus/common"
+	"github.com/oasisprotocol/nexus/config"
+	"github.com/oasisprotocol/nexus/log"
+	"github.com/oasisprotocol/nexus/storage"
+)
+
+const (
+	analyzerPrefix = "neby_prices_"
+
+	defaultNebyEndpoint = "https://graph.api.neby.exchange/dex"
+)
+
+type processor struct {
+	runtime common.Runtime
+	target  storage.TargetStorage
+	logger  *log.Logger
+
+	client *http.Client
+
+	endpoint string
+}
+
+var _ item.ItemProcessor[struct{}] = (*processor)(nil)
+
+func NewAnalyzer(
+	runtime common.Runtime,
+	cfg *config.NebyPricesConfig,
+	target storage.TargetStorage,
+	logger *log.Logger,
+) (analyzer.Analyzer, error) {
+	logger = logger.With("analyzer", analyzerPrefix+runtime)
+
+	logger.Info("Starting analyzer")
+
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = defaultNebyEndpoint
+	}
+
+	if cfg.Interval == 0 {
+		cfg.Interval = 15 * time.Minute
+	}
+	p := &processor{
+		runtime:  runtime,
+		target:   target,
+		logger:   logger,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		endpoint: endpoint,
+	}
+
+	return item.NewAnalyzer(
+		analyzerPrefix+string(runtime),
+		cfg.ItemBasedAnalyzerConfig,
+		p,
+		target,
+		logger,
+	)
+}
+
+func (p *processor) GetItems(ctx context.Context, limit uint64) ([]struct{}, error) {
+	return []struct{}{{}}, nil
+}
+
+func (p *processor) ProcessItem(ctx context.Context, batch *storage.QueryBatch, item struct{}) error {
+	p.logger.Debug("fetching Neby token prices", "endpoint", p.endpoint)
+	result, err := p.fetchNebyTokenPrices(ctx, p.endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to fetch Neby token prices: %w", err)
+	}
+	p.logger.Debug("fetched Neby token prices", "count", len(result.Data.Tokens), "result", result)
+
+	// Store the prices in the database.
+	for _, token := range result.Data.Tokens {
+		ethAddress := ethCommon.HexToAddress(token.ID)
+		batch.Queue(
+			tokenNebyDerivedPriceUpsert,
+			p.runtime,
+			ethAddress[:],
+			token.DerivedETH,
+		)
+	}
+
+	return nil
+}
+
+type graphTokensResponse struct {
+	Data struct {
+		Tokens []struct {
+			ID         string `json:"id"`
+			DerivedETH string `json:"derivedETH"`
+			Name       string `json:"name"`
+		} `json:"tokens"`
+	} `json:"data"`
+}
+
+func (p *processor) fetchNebyTokenPrices(ctx context.Context, endpoint string) (*graphTokensResponse, error) {
+	query := `
+	{
+		tokens(first: 1000) {
+			id
+			derivedETH
+			name
+		}
+	}`
+	body, _ := json.Marshal(map[string]string{
+		"query": query,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	if err := httpmisc.ResponseOK(resp); err != nil {
+		return nil, fmt.Errorf("response error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result graphTokensResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (p *processor) QueueLength(ctx context.Context) (int, error) {
+	return 0, nil
+}

--- a/analyzer/neby_prices/queries.go
+++ b/analyzer/neby_prices/queries.go
@@ -1,0 +1,12 @@
+package nebyprices
+
+// nolint: gosec // G101: Potential hardcoded credentials.
+const tokenNebyDerivedPriceUpsert = `
+INSERT INTO chain.evm_tokens (runtime, token_address, neby_derived_price)
+	SELECT
+		$1::runtime, derive_oasis_addr($2), $3
+	WHERE
+		derive_oasis_addr($2) IS NOT NULL
+	ON CONFLICT (runtime, token_address) DO UPDATE
+	SET
+	neby_derived_price = excluded.neby_derived_price`

--- a/analyzer/pubclient/pub_client.go
+++ b/analyzer/pubclient/pub_client.go
@@ -1,6 +1,7 @@
 package pubclient
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -90,4 +91,13 @@ var client = &http.Client{
 
 func GetWithContext(ctx context.Context, url string) (*http.Response, error) {
 	return httpmisc.GetWithContextWithClient(ctx, client, url)
+}
+
+func PostWithContext(ctx context.Context, url string, bodyType string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return client.Do(req)
 }

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1669,6 +1669,15 @@ components:
       example: "1234567890123456789012"
       x-go-type: common.BigInt
       x-go-type-import: { name: common, path: "github.com/oasisprotocol/nexus/common" }
+    TextBigDecimal:
+      type: string
+      pattern: '^-?[0-9]+(\.[0-9]+)?$'
+      format: decimal  # Informative only; not used by Go codegen
+      example: "12345.678901234567890123"
+      x-go-type: common.BigDecimal
+      x-go-type-import:
+        name: common
+        path: github.com/oasisprotocol/nexus/common
     Address:
       type: string
       pattern: '^oasis1[a-z0-9]{40}$'
@@ -3646,6 +3655,15 @@ components:
         total_supply:
           allOf: [$ref: '#/components/schemas/TextBigInt']
           description: The total number of base units available.
+        neby_derived_price:
+          allOf: [$ref: '#/components/schemas/TextBigDecimal']
+          description: |
+            The estimated price of one base unit of this token, expressed in the native denomination of the runtime.
+
+            This value is sourced from the Neby GraphQL API and reflects the token's `derivedETH` price as computed by the subgraph indexing the Neby DEX.
+            It is available only for tokens listed and tradable on the Neby exchange.
+
+            May be zero if the subgraph could not determine a valid price route to the native token unit.
         num_transfers:
           type: integer
           format: int64

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oasisprotocol/nexus/analyzer/evmtokens"
 	"github.com/oasisprotocol/nexus/analyzer/evmverifier"
 	"github.com/oasisprotocol/nexus/analyzer/metadata_registry"
+	nebyprices "github.com/oasisprotocol/nexus/analyzer/neby_prices"
 	nodestats "github.com/oasisprotocol/nexus/analyzer/node_stats"
 	"github.com/oasisprotocol/nexus/analyzer/rofl"
 	roflinstance "github.com/oasisprotocol/nexus/analyzer/rofl/instance_transactions"
@@ -617,6 +618,11 @@ func NewService(ctx context.Context, cfg *config.AnalysisConfig, logger *log.Log
 	if cfg.Analyzers.PontusxDevAbi != nil {
 		analyzers, err = addAnalyzer(analyzers, err, syncTagPontusxDev, func() (A, error) {
 			return evmabibackfill.NewAnalyzer(common.RuntimePontusxDev, cfg.Analyzers.PontusxDevAbi.ItemBasedAnalyzerConfig, dbClient, logger)
+		})
+	}
+	if cfg.Analyzers.SapphireNebyPrices != nil {
+		analyzers, err = addAnalyzer(analyzers, err, syncTagSapphire, func() (A, error) {
+			return nebyprices.NewAnalyzer(common.RuntimeSapphire, cfg.Analyzers.SapphireNebyPrices, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,11 @@ func (cfg *AnalysisConfig) Validate() error {
 			return err
 		}
 	}
+	if cfg.Analyzers.SapphireNebyPrices != nil {
+		if err := cfg.Analyzers.SapphireNebyPrices.Validate(); err != nil {
+			return err
+		}
+	}
 	if cfg.Analyzers.MetadataRegistry != nil {
 		if err := cfg.Analyzers.MetadataRegistry.Validate(); err != nil {
 			return err
@@ -168,6 +173,7 @@ type AnalyzersList struct {
 	SapphireAbi                      *EvmAbiAnalyzerConfig          `koanf:"evm_abi_sapphire"`
 	PontusxTestAbi                   *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx_test"`
 	PontusxDevAbi                    *EvmAbiAnalyzerConfig          `koanf:"evm_abi_pontusx_dev"`
+	SapphireNebyPrices               *NebyPricesConfig              `koanf:"neby_prices_sapphire"`
 
 	MetadataRegistry        *MetadataRegistryConfig        `koanf:"metadata_registry"`
 	ValidatorStakingHistory *ValidatorStakingHistoryConfig `koanf:"validator_staking_history"`
@@ -553,6 +559,18 @@ type MetadataRegistryConfig struct {
 
 // Validate validates the configuration.
 func (cfg *MetadataRegistryConfig) Validate() error {
+	return nil
+}
+
+// NebyPricesConfig is the configuration for the Neby prices analyzer.
+type NebyPricesConfig struct {
+	ItemBasedAnalyzerConfig `koanf:",squash"`
+
+	Endpoint string `koanf:"endpoint"`
+}
+
+// Validate validates the configuration.
+func (cfg *NebyPricesConfig) Validate() error {
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
 	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
+github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/consensys/gnark-crypto v0.18.0 h1:vIye/FqI50VeAr0B3dx+YjeIvmc3LWz4yEfbWBpTUf0=
 github.com/consensys/gnark-crypto v0.18.0/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -2267,6 +2267,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, runtime common.Runtim
 			&t.TotalSupply,
 			&t.NumTransfers,
 			&tokenType,
+			&t.NebyDerivedPrice,
 			&t.NumHolders,
 			&refSwapPairAddr,
 			&refSwapPairEthAddr,

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -1218,6 +1218,7 @@ func EVMTokens(rawNames *[]string, args *[]interface{}) string {
 			tokens.total_supply,
 			tokens.num_transfers,
 			tokens.token_type AS type,
+			tokens.neby_derived_price,
 			COALESCE(holders.cnt, 0) AS num_holders,
 			ref_swap_pair_creations.pair_address AS ref_swap_pair_address,
 			eth_preimage(ref_swap_pair_creations.pair_address) AS ref_swap_pair_address_eth,
@@ -1264,6 +1265,8 @@ func EVMTokens(rawNames *[]string, args *[]interface{}) string {
 			tokens.token_type != 0 -- exclude unknown-type tokens; they're often just contracts that emitted Transfer events but don't expose the token ticker, name, balance etc.
 		ORDER BY
 			custom_sort_order,
+			-- Neby derived market cap.
+			tokens.neby_derived_price * tokens.total_supply DESC NULLS LAST,
 			CASE
 				-- If sort_by is not "market_cap" then we sort by num_holders (below).
 				WHEN $6::text IS NULL OR $6::text != 'market_cap' THEN NULL

--- a/storage/migrations/01_runtimes.up.sql
+++ b/storage/migrations/01_runtimes.up.sql
@@ -331,6 +331,8 @@ CREATE TABLE chain.evm_tokens
   -- causing a negative dead-reckoned total_supply.
   total_supply NUMERIC(1000,0),
 
+  -- neby_derived_price NUMERIC(38, 18), -- Added in 44_runtime_evm_tokens_neby.up.sql.
+
   num_transfers UINT63 NOT NULL DEFAULT 0,
 
   -- Block analyzer bumps this when it sees the mutable fields of the token

--- a/storage/migrations/44_runtime_evm_tokens_neby.up.sql
+++ b/storage/migrations/44_runtime_evm_tokens_neby.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE chain.evm_tokens ADD COLUMN neby_derived_price NUMERIC(38, 18);
+
+COMMIT;

--- a/tests/e2e_regression/eden_2025/e2e_config_2.yml
+++ b/tests/e2e_regression/eden_2025/e2e_config_2.yml
@@ -12,6 +12,7 @@ analysis:
   helpers:
     caching_proxies:
       - { target: "https://sourcify.dev/server", host_addr: "localhost:9191" }
+      - { target: "https://graph.api.neby.exchange/dex", host_addr: "localhost:9192" }
   analyzers:
     consensus_accounts_list:             { interval: 5s, stop_if_queue_empty_for: 1s }
     evm_tokens_sapphire:                 { stop_if_queue_empty_for: 1s }
@@ -20,6 +21,7 @@ analysis:
     evm_contract_code_sapphire:          { stop_if_queue_empty_for: 1s }
     evm_abi_sapphire:                    { stop_if_queue_empty_for: 30s } # Give evm_contract_verifier time to fetch ABIs first. The 20s has been enough in practice, but might need to be tuned in the future, especially if the caching proxy has an empty cache.
     evm_contract_verifier_sapphire:      { stop_if_queue_empty_for: 1s, sourcify_server_url: http://localhost:9191, batch_size: 3_000 }
+    neby_prices_sapphire:                { interval: 5s, stop_if_queue_empty_for: 1s, endpoint: http://localhost:9192 }
     rofl_sapphire:                       { stop_if_queue_empty_for: 1s }
     rofl_instance_transactions_sapphire: { stop_if_queue_empty_for: 1s }
     roflmarket_sapphire:                 { stop_if_queue_empty_for: 1s }
@@ -36,7 +38,7 @@ analysis:
     migrations: file://storage/migrations
 
 log:
-  level: info
+  level: debug
   format: json
 
 metrics:

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.body
@@ -6,6 +6,7 @@
       "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
       "is_verified": true,
       "name": "BitUSDs",
+      "neby_derived_price": "30.025448675228444259",
       "num_holders": 0,
       "num_transfers": 0,
       "ref_token": {

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_configured_addresses.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_configured_addresses.body
@@ -4,6 +4,7 @@
   "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
   "is_verified": true,
   "name": "BitUSDs",
+  "neby_derived_price": "30.025448675228444259",
   "num_holders": 0,
   "num_transfers": 0,
   "ref_token": {

--- a/tests/e2e_regression/eden_2025/expected/sapphire_tokens.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_tokens.body
@@ -1,6 +1,46 @@
 {
   "evm_tokens": [
     {
+      "contract_addr": "oasis1qq309j5u6ut8da3fh9ra5k8ky77sqhhr8cmdqzpw",
+      "decimals": 18,
+      "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
+      "is_verified": true,
+      "name": "BitUSDs",
+      "neby_derived_price": "30.025448675228444259",
+      "num_holders": 0,
+      "num_transfers": 0,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "BitUSDs",
+      "total_supply": "1653477128185483411842062",
+      "type": "ERC20",
+      "verification_level": "full"
+    },
+    {
+      "contract_addr": "oasis1qpdgv5nv2dhxp4q897cgag6kgnm9qs0dccwnckuu",
+      "decimals": 18,
+      "eth_contract_addr": "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
+      "is_verified": true,
+      "name": "Wrapped ROSE",
+      "neby_derived_price": "1.000000000000000000",
+      "num_holders": 2,
+      "num_transfers": 11,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "wROSE",
+      "total_supply": "34612415618290278876942747",
+      "type": "ERC20",
+      "verification_level": "full"
+    },
+    {
       "contract_addr": "oasis1qr43dvghx4a75vndjcsg2r9ct2xqftwrgcnt5tge",
       "decimals": 18,
       "eth_contract_addr": "0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520",
@@ -16,44 +56,6 @@
       },
       "symbol": "OCEAN",
       "total_supply": "1418576715298904178394593",
-      "type": "ERC20",
-      "verification_level": "full"
-    },
-    {
-      "contract_addr": "oasis1qpdgv5nv2dhxp4q897cgag6kgnm9qs0dccwnckuu",
-      "decimals": 18,
-      "eth_contract_addr": "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
-      "is_verified": true,
-      "name": "Wrapped ROSE",
-      "num_holders": 2,
-      "num_transfers": 11,
-      "ref_token": {
-        "decimals": 18,
-        "name": "Wrapped ROSE",
-        "symbol": "wROSE",
-        "type": "ERC20"
-      },
-      "symbol": "wROSE",
-      "total_supply": "34612415618290278876942747",
-      "type": "ERC20",
-      "verification_level": "full"
-    },
-    {
-      "contract_addr": "oasis1qq309j5u6ut8da3fh9ra5k8ky77sqhhr8cmdqzpw",
-      "decimals": 18,
-      "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
-      "is_verified": true,
-      "name": "BitUSDs",
-      "num_holders": 0,
-      "num_transfers": 0,
-      "ref_token": {
-        "decimals": 18,
-        "name": "Wrapped ROSE",
-        "symbol": "wROSE",
-        "type": "ERC20"
-      },
-      "symbol": "BitUSDs",
-      "total_supply": "1653477128185483411842062",
       "type": "ERC20",
       "verification_level": "full"
     },

--- a/tests/e2e_regression/eden_2025/expected/sapphire_tokens_sort_market_cap.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_tokens_sort_market_cap.body
@@ -1,11 +1,32 @@
 {
   "evm_tokens": [
     {
+      "contract_addr": "oasis1qq309j5u6ut8da3fh9ra5k8ky77sqhhr8cmdqzpw",
+      "decimals": 18,
+      "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
+      "is_verified": true,
+      "name": "BitUSDs",
+      "neby_derived_price": "30.025448675228444259",
+      "num_holders": 0,
+      "num_transfers": 0,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "BitUSDs",
+      "total_supply": "1653477128185483411842062",
+      "type": "ERC20",
+      "verification_level": "full"
+    },
+    {
       "contract_addr": "oasis1qpdgv5nv2dhxp4q897cgag6kgnm9qs0dccwnckuu",
       "decimals": 18,
       "eth_contract_addr": "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
       "is_verified": true,
       "name": "Wrapped ROSE",
+      "neby_derived_price": "1.000000000000000000",
       "num_holders": 2,
       "num_transfers": 11,
       "ref_token": {
@@ -35,25 +56,6 @@
       },
       "symbol": "OCEAN",
       "total_supply": "1418576715298904178394593",
-      "type": "ERC20",
-      "verification_level": "full"
-    },
-    {
-      "contract_addr": "oasis1qq309j5u6ut8da3fh9ra5k8ky77sqhhr8cmdqzpw",
-      "decimals": 18,
-      "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
-      "is_verified": true,
-      "name": "BitUSDs",
-      "num_holders": 0,
-      "num_transfers": 0,
-      "ref_token": {
-        "decimals": 18,
-        "name": "Wrapped ROSE",
-        "symbol": "wROSE",
-        "type": "ERC20"
-      },
-      "symbol": "BitUSDs",
-      "total_supply": "1653477128185483411842062",
       "type": "ERC20",
       "verification_level": "full"
     },


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/953

Add support for fetching EVM token prices from Neby subgraph

- Introduces `neby_derived_price` to the database and API, sourced directly from the Neby DEX GraphQL API.

- Unlike Uniswap v2, we do not parse on-chain events or follow swaps; instead, we rely on the subgraph’s `derivedETH` field as the canonical price. This significantly simplifies the implementation and is acceptable given that the price is primarily used for token sorting.

- The analyzer is currently hardcoded to Neby; the implementation can be generalized in the future to support additional sources or DEX subgraphs if needed.