### PR TITLE
storage/client: Remove consensus block cache

### DIFF
--- a/.changelog/1107.internal.md
+++ b/.changelog/1107.internal.md
@@ -1,0 +1,5 @@
+storage/client: Remove consensus block cache
+
+The API currently uses an in-memory cache for a single endpoint,
+while no caching is applied to other cases. This somewhat arbitrary
+choice stems from historical decisions without clear justification.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,7 +32,6 @@ linters:
             - github.com/oasisprotocol/metadata-registry-tools
             - github.com/akrylysov/pogreb
             - github.com/cockroachdb/apd
-            - github.com/dgraph-io/ristretto
             - github.com/ethereum/go-ethereum
             - github.com/go-chi/chi/v5
             - github.com/go-kit/log

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,6 @@ require (
 	github.com/akrylysov/pogreb v0.10.2
 	github.com/cockroachdb/apd v1.1.0
 	github.com/cometbft/cometbft v0.37.15
-	github.com/dgraph-io/ristretto v1.0.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnN
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dgraph-io/badger/v4 v4.5.1 h1:7DCIXrQjo1LKmM96YD+hLVJ2EEsyyoWxJfpdd56HLps=
 github.com/dgraph-io/badger/v4 v4.5.1/go.mod h1:qn3Be0j3TfV4kPbVoK0arXCD1/nr1ftth6sbL5jxdoA=
-github.com/dgraph-io/ristretto v1.0.0 h1:SYG07bONKMlFDUYu5pEu3DGAh8c2OFNzKm6G9J4Si84=
-github.com/dgraph-io/ristretto v1.0.0/go.mod h1:jTi2FiYEhQ1NsMmA7DeBykizjOuY88NhKBkepyu1jPc=
 github.com/dgraph-io/ristretto/v2 v2.1.0 h1:59LjpOJLNDULHh8MC4UaegN52lC4JnO2dITsie/Pa8I=
 github.com/dgraph-io/ristretto/v2 v2.1.0/go.mod h1:uejeqfYXpUomfse0+lO+13ATz4TypQYLJZzBSAemuB4=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=


### PR DESCRIPTION
Fixes #887

The API currently uses an in-memory cache for a specific endpoint(consensus block), while no caching is applied to other cases. This somewhat arbitrary choice stems from historical decisions without clear justification. In practice, the utilization of this cache is very low, so we remove the cache for now.